### PR TITLE
chore: 공통 응답 봉투·전역 예외 처리·JSON 표기 규칙 추가 #9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ repositories {
 ext {
     junitVersion = '5.10.2'
     springVersion = '5.3.37'
+    jacksonVersion = '2.9.4'
+    mockitoVersion = '5.12.0'
 }
 
 tasks.withType(JavaCompile).configureEach {
@@ -43,13 +45,18 @@ dependencies {
     implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4:1.16'
 
     // Jackson - JSON 처리
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.4'
+    implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonVersion}"
 
     // Test
     testImplementation "org.springframework:spring-test:${springVersion}"
     testImplementation 'javax.servlet:javax.servlet-api:4.0.1'
     testImplementation("org.junit.jupiter:junit-jupiter-api:${junitVersion}")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:${junitVersion}")
     testImplementation 'org.hamcrest:hamcrest:2.2'
+    testImplementation 'com.jayway.jsonpath:json-path:2.9.0'
+    testImplementation "org.mockito:mockito-core:${mockitoVersion}"
+    testImplementation "org.mockito:mockito-junit-jupiter:${mockitoVersion}"
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${junitVersion}")
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/src/main/java/org/firstfolio/common/json/ApiObjectMapperFactory.java
+++ b/src/main/java/org/firstfolio/common/json/ApiObjectMapperFactory.java
@@ -1,0 +1,45 @@
+package org.firstfolio.common.json;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import java.math.BigDecimal;
+
+/**
+ * API_DOCS.md의 요청·응답 표현에 맞춘 ObjectMapper를 만든다.
+ *
+ * <ul>
+ *   <li>필드명은 snake_case ({@code portfolio_id}, {@code cash_balance}).</li>
+ *   <li>금액·수량·단가 등 {@link BigDecimal}은 자릿수 손실을 막기 위해 문자열로 표현한다
+ *       ({@code "30000000.00"}). 비율처럼 숫자로 표현해야 하는 소수의 필드는
+ *       해당 DTO 필드에 {@code @JsonFormat(shape = NUMBER_FLOAT)}을 직접 붙인다
+ *       (예: {@code allocation[].ratio}).</li>
+ *   <li>시각은 UTC 기준 {@code 2026-07-29T03:00:00Z} 형태 ({@link UtcDateTimeModule}).</li>
+ *   <li>{@code next_cursor}, {@code closed_at}처럼 명세가 {@code null}을 명시하는 필드가 있어
+ *       null 필드를 생략하지 않는다.</li>
+ *   <li>정의되지 않은 요청 필드는 조용히 무시하지 않고 오류로 처리한다.</li>
+ * </ul>
+ */
+public final class ApiObjectMapperFactory {
+
+    private ApiObjectMapperFactory() {
+    }
+
+    public static ObjectMapper create() {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.registerModule(new UtcDateTimeModule());
+        objectMapper.registerModule(new DecimalAsStringModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        objectMapper.enable(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN);
+        objectMapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+        return objectMapper;
+    }
+}

--- a/src/main/java/org/firstfolio/common/json/DecimalAsStringModule.java
+++ b/src/main/java/org/firstfolio/common/json/DecimalAsStringModule.java
@@ -1,0 +1,67 @@
+package org.firstfolio.common.json;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.ContextualSerializer;
+import com.fasterxml.jackson.databind.ser.std.NumberSerializer;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+/**
+ * 금액·수량·단가를 JSON 문자열로 내보낸다 ({@code "30000000.00"}).
+ *
+ * <p>숫자로 내보내면 자릿수가 사라지고 지수 표기로 바뀌며
+ * ({@code 30000000.00} → {@code 3.0E7}), 클라이언트에서 double로 읽히면서
+ * 금액에 부동소수점 오차가 생긴다 (FUNC-036 예외/제한사항).</p>
+ *
+ * <p>비율처럼 숫자로 표현해야 하는 필드는 DTO에서 빠져나갈 수 있다:
+ * <pre>
+ * &#64;JsonFormat(shape = JsonFormat.Shape.NUMBER_FLOAT)
+ * private BigDecimal ratio;
+ * </pre>
+ */
+public final class DecimalAsStringModule extends SimpleModule {
+
+    public DecimalAsStringModule() {
+        addSerializer(BigDecimal.class, new DecimalAsStringSerializer());
+    }
+
+    private static final class DecimalAsStringSerializer
+            extends JsonSerializer<BigDecimal>
+            implements ContextualSerializer {
+
+        @Override
+        public void serialize(
+                BigDecimal value,
+                JsonGenerator generator,
+                SerializerProvider provider
+        ) throws IOException {
+            generator.writeString(value.toPlainString());
+        }
+
+        /**
+         * 필드에 {@code @JsonFormat(shape = NUMBER_*)}이 붙어 있으면 숫자로 내보낸다.
+         */
+        @Override
+        public JsonSerializer<?> createContextual(
+                SerializerProvider provider,
+                BeanProperty property
+        ) {
+            if (property == null) {
+                return this;
+            }
+
+            JsonFormat.Value format =
+                    property.findPropertyFormat(provider.getConfig(), BigDecimal.class);
+
+            return format.getShape().isNumeric()
+                    ? new NumberSerializer(BigDecimal.class)
+                    : this;
+        }
+    }
+}

--- a/src/main/java/org/firstfolio/common/json/UtcDateTimeModule.java
+++ b/src/main/java/org/firstfolio/common/json/UtcDateTimeModule.java
@@ -1,0 +1,85 @@
+package org.firstfolio.common.json;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+/**
+ * DB의 DATETIME 컬럼에는 UTC 값을 저장한다(PROJECT_SPEC 16장, 스키마 주석).
+ * 따라서 {@link LocalDateTime}은 항상 UTC 기준 시각으로 취급하고,
+ * API 표현은 {@code 2026-07-29T03:00:00Z} 형태로 통일한다.
+ */
+public final class UtcDateTimeModule extends SimpleModule {
+
+    private static final DateTimeFormatter UTC_FORMATTER =
+            DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss'Z'");
+
+    public UtcDateTimeModule() {
+        addSerializer(LocalDateTime.class, new UtcLocalDateTimeSerializer());
+        addDeserializer(LocalDateTime.class, new UtcLocalDateTimeDeserializer());
+    }
+
+    private static final class UtcLocalDateTimeSerializer
+            extends JsonSerializer<LocalDateTime> {
+
+        @Override
+        public void serialize(
+                LocalDateTime value,
+                JsonGenerator generator,
+                SerializerProvider provider
+        ) throws IOException {
+            generator.writeString(UTC_FORMATTER.format(value));
+        }
+    }
+
+    /**
+     * {@code Z} 또는 오프셋이 붙은 값은 UTC로 변환해 받고,
+     * 오프셋이 없는 값은 이미 UTC로 간주한다.
+     */
+    private static final class UtcLocalDateTimeDeserializer
+            extends JsonDeserializer<LocalDateTime> {
+
+        @Override
+        public LocalDateTime deserialize(
+                JsonParser parser,
+                DeserializationContext context
+        ) throws IOException {
+            String text = parser.getText();
+
+            if (text == null || text.isBlank()) {
+                return null;
+            }
+
+            String value = text.trim();
+
+            try {
+                // OffsetDateTime은 'Z'와 '+09:00' 형태를 모두 받는다.
+                return OffsetDateTime.parse(value)
+                        .withOffsetSameInstant(ZoneOffset.UTC)
+                        .toLocalDateTime();
+            } catch (DateTimeParseException ignored) {
+                // 오프셋이 없는 표현으로 재시도한다.
+            }
+
+            try {
+                return LocalDateTime.parse(value);
+            } catch (DateTimeParseException exception) {
+                throw new IOException(
+                        "날짜·시각 형식이 올바르지 않습니다: " + value,
+                        exception
+                );
+            }
+        }
+    }
+}

--- a/src/main/java/org/firstfolio/common/response/ApiResponse.java
+++ b/src/main/java/org/firstfolio/common/response/ApiResponse.java
@@ -1,0 +1,21 @@
+package org.firstfolio.common.response;
+
+/**
+ * API_DOCS.md의 모든 성공 응답은 {@code {"data": ...}} 한 겹으로 감싼다.
+ */
+public final class ApiResponse<T> {
+
+    private final T data;
+
+    private ApiResponse(T data) {
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> of(T data) {
+        return new ApiResponse<>(data);
+    }
+
+    public T getData() {
+        return data;
+    }
+}

--- a/src/main/java/org/firstfolio/common/response/ErrorResponse.java
+++ b/src/main/java/org/firstfolio/common/response/ErrorResponse.java
@@ -1,0 +1,54 @@
+package org.firstfolio.common.response;
+
+/**
+ * API_DOCS.md의 공통 오류 응답 형식.
+ *
+ * <pre>
+ * {"error": {"code": "...", "message": "...", "request_id": "req-..."}}
+ * </pre>
+ */
+public final class ErrorResponse {
+
+    private final Error error;
+
+    private ErrorResponse(Error error) {
+        this.error = error;
+    }
+
+    public static ErrorResponse of(
+            String code,
+            String message,
+            String requestId
+    ) {
+        return new ErrorResponse(new Error(code, message, requestId));
+    }
+
+    public Error getError() {
+        return error;
+    }
+
+    public static final class Error {
+
+        private final String code;
+        private final String message;
+        private final String requestId;
+
+        private Error(String code, String message, String requestId) {
+            this.code = code;
+            this.message = message;
+            this.requestId = requestId;
+        }
+
+        public String getCode() {
+            return code;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public String getRequestId() {
+            return requestId;
+        }
+    }
+}

--- a/src/main/java/org/firstfolio/common/web/RequestIdFilter.java
+++ b/src/main/java/org/firstfolio/common/web/RequestIdFilter.java
@@ -1,0 +1,70 @@
+package org.firstfolio.common.web;
+
+import org.apache.logging.log4j.ThreadContext;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * 요청마다 추적 식별자를 발급한다.
+ *
+ * <p>API_DOCS.md의 오류 응답은 {@code request_id}를 필수로 요구한다. 컨트롤러마다
+ * 만들지 않도록 여기서 한 번 발급해 요청 속성과 로그 컨텍스트에 넣어 두고,
+ * {@code CommonExceptionAdvice}가 꺼내 쓴다.</p>
+ *
+ * <p>정상 응답에는 {@code request_id}가 본문에 없으므로 응답 헤더
+ * {@code X-Request-Id}로도 같은 값을 내보낸다.</p>
+ */
+public class RequestIdFilter implements Filter {
+
+    public static final String REQUEST_ID_ATTRIBUTE = "org.firstfolio.requestId";
+    public static final String REQUEST_ID_HEADER = "X-Request-Id";
+    public static final String REQUEST_ID_LOG_KEY = "requestId";
+
+    @Override
+    public void doFilter(
+            ServletRequest request,
+            ServletResponse response,
+            FilterChain chain
+    ) throws IOException, ServletException {
+        String requestId = generate();
+
+        request.setAttribute(REQUEST_ID_ATTRIBUTE, requestId);
+        ThreadContext.put(REQUEST_ID_LOG_KEY, requestId);
+
+        if (response instanceof HttpServletResponse) {
+            ((HttpServletResponse) response).setHeader(REQUEST_ID_HEADER, requestId);
+        }
+
+        try {
+            chain.doFilter(request, response);
+        } finally {
+            ThreadContext.remove(REQUEST_ID_LOG_KEY);
+        }
+    }
+
+    /**
+     * 요청 속성에서 추적 식별자를 읽는다. 필터를 거치지 않은 경로에서도
+     * 응답을 만들 수 있도록 없으면 새로 만들어 준다.
+     */
+    public static String currentRequestId(HttpServletRequest request) {
+        if (request == null) {
+            return generate();
+        }
+
+        Object value = request.getAttribute(REQUEST_ID_ATTRIBUTE);
+
+        return value instanceof String ? (String) value : generate();
+    }
+
+    private static String generate() {
+        return "req-" + UUID.randomUUID().toString().replace("-", "");
+    }
+}

--- a/src/main/java/org/firstfolio/config/ServletConfig.java
+++ b/src/main/java/org/firstfolio/config/ServletConfig.java
@@ -1,11 +1,17 @@
 package org.firstfolio.config;
 
+import org.firstfolio.common.json.ApiObjectMapperFactory;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
 @EnableWebMvc
@@ -20,5 +26,20 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
                 }
         )
 )
-public class ServletConfig {
+public class ServletConfig implements WebMvcConfigurer {
+
+    /**
+     * 기본 컨버터 구성은 그대로 두고 JSON 컨버터의 ObjectMapper만 교체한다.
+     * API_DOCS.md의 표기 규칙(snake_case, 금액 문자열, UTC 시각)은
+     * {@link ApiObjectMapperFactory}에 모여 있다.
+     */
+    @Override
+    public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
+        for (HttpMessageConverter<?> converter : converters) {
+            if (converter instanceof MappingJackson2HttpMessageConverter) {
+                ((MappingJackson2HttpMessageConverter) converter)
+                        .setObjectMapper(ApiObjectMapperFactory.create());
+            }
+        }
+    }
 }

--- a/src/main/java/org/firstfolio/config/WebConfig.java
+++ b/src/main/java/org/firstfolio/config/WebConfig.java
@@ -1,5 +1,6 @@
 package org.firstfolio.config;
 
+import org.firstfolio.common.web.RequestIdFilter;
 import org.springframework.web.filter.CharacterEncodingFilter;
 import org.springframework.web.servlet.support.AbstractAnnotationConfigDispatcherServletInitializer;
 
@@ -29,6 +30,6 @@ public class WebConfig extends AbstractAnnotationConfigDispatcherServletInitiali
         characterEncodingFilter.setEncoding("UTF-8");
         characterEncodingFilter.setForceEncoding(true);
 
-        return new Filter[]{characterEncodingFilter};
+        return new Filter[]{characterEncodingFilter, new RequestIdFilter()};
     }
 }

--- a/src/main/java/org/firstfolio/exception/ApiException.java
+++ b/src/main/java/org/firstfolio/exception/ApiException.java
@@ -1,0 +1,27 @@
+package org.firstfolio.exception;
+
+/**
+ * API_DOCS.md의 오류 코드로 응답해야 하는 예외.
+ * 서비스 계층에서 {@code throw new ApiException(ErrorCode.TRADE_NOT_ALLOWED)} 형태로 사용한다.
+ */
+public class ApiException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public ApiException(ErrorCode errorCode) {
+        this(errorCode, errorCode.getDefaultMessage(), null);
+    }
+
+    public ApiException(ErrorCode errorCode, String message) {
+        this(errorCode, message, null);
+    }
+
+    public ApiException(ErrorCode errorCode, String message, Throwable cause) {
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/org/firstfolio/exception/CommonExceptionAdvice.java
+++ b/src/main/java/org/firstfolio/exception/CommonExceptionAdvice.java
@@ -7,6 +7,7 @@ import org.firstfolio.common.web.RequestIdFilter;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -45,6 +46,7 @@ public class CommonExceptionAdvice {
             HttpMessageNotReadableException.class,
             MissingServletRequestParameterException.class,
             MethodArgumentTypeMismatchException.class,
+            MethodArgumentNotValidException.class,
             IllegalArgumentException.class
     })
     public ResponseEntity<ErrorResponse> handleInvalidRequest(

--- a/src/main/java/org/firstfolio/exception/CommonExceptionAdvice.java
+++ b/src/main/java/org/firstfolio/exception/CommonExceptionAdvice.java
@@ -1,4 +1,120 @@
 package org.firstfolio.exception;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.firstfolio.common.response.ErrorResponse;
+import org.firstfolio.common.web.RequestIdFilter;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * 모든 오류 응답을 API_DOCS.md의 {@code {"error": {...}}} 형식으로 통일한다.
+ */
+@RestControllerAdvice
 public class CommonExceptionAdvice {
+
+    private static final Logger log = LogManager.getLogger(CommonExceptionAdvice.class);
+
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ErrorResponse> handleApiException(
+            ApiException exception,
+            HttpServletRequest request
+    ) {
+        ErrorCode errorCode = exception.getErrorCode();
+        String requestId = RequestIdFilter.currentRequestId(request);
+
+        log.warn(
+                "처리 거절 code={} path={} requestId={} message={}",
+                errorCode,
+                request.getRequestURI(),
+                requestId,
+                exception.getMessage()
+        );
+
+        return toResponse(errorCode, exception.getMessage(), requestId);
+    }
+
+    @ExceptionHandler({
+            HttpMessageNotReadableException.class,
+            MissingServletRequestParameterException.class,
+            MethodArgumentTypeMismatchException.class,
+            IllegalArgumentException.class
+    })
+    public ResponseEntity<ErrorResponse> handleInvalidRequest(
+            Exception exception,
+            HttpServletRequest request
+    ) {
+        String requestId = RequestIdFilter.currentRequestId(request);
+
+        log.warn(
+                "잘못된 요청 path={} requestId={} message={}",
+                request.getRequestURI(),
+                requestId,
+                exception.getMessage()
+        );
+
+        // 파싱 실패 메시지에는 내부 타입·패키지 정보가 섞이므로 그대로 노출하지 않는다.
+        return toResponse(
+                ErrorCode.INVALID_REQUEST,
+                ErrorCode.INVALID_REQUEST.getDefaultMessage(),
+                requestId
+        );
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleMethodNotSupported(
+            HttpRequestMethodNotSupportedException exception,
+            HttpServletRequest request
+    ) {
+        String requestId = RequestIdFilter.currentRequestId(request);
+
+        return toResponse(
+                ErrorCode.METHOD_NOT_ALLOWED,
+                ErrorCode.METHOD_NOT_ALLOWED.getDefaultMessage(),
+                requestId
+        );
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnexpected(
+            Exception exception,
+            HttpServletRequest request
+    ) {
+        String requestId = RequestIdFilter.currentRequestId(request);
+
+        log.error(
+                "처리하지 못한 예외 path={} requestId={}",
+                request.getRequestURI(),
+                requestId,
+                exception
+        );
+
+        // 내부 예외 메시지는 사용자에게 노출하지 않는다.
+        return toResponse(
+                ErrorCode.INTERNAL_ERROR,
+                ErrorCode.INTERNAL_ERROR.getDefaultMessage(),
+                requestId
+        );
+    }
+
+    private ResponseEntity<ErrorResponse> toResponse(
+            ErrorCode errorCode,
+            String message,
+            String requestId
+    ) {
+        String body = message == null || message.isBlank()
+                ? errorCode.getDefaultMessage()
+                : message;
+
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ErrorResponse.of(errorCode.name(), body, requestId));
+    }
 }

--- a/src/main/java/org/firstfolio/exception/ErrorCode.java
+++ b/src/main/java/org/firstfolio/exception/ErrorCode.java
@@ -1,0 +1,62 @@
+package org.firstfolio.exception;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * API_DOCS.md에 정의된 오류 코드와 HTTP 상태의 대응표.
+ *
+ * <p>담당 범위(FUNC-029~042, Portfolio / Product Simulation)의 코드만 담는다.
+ * 다른 도메인이 자기 코드를 추가할 때도 이 enum을 함께 사용한다.</p>
+ */
+public enum ErrorCode {
+
+    // 포트폴리오 (FUNC-033, 034, 036)
+    PORTFOLIO_ALREADY_CONFIGURED(HttpStatus.CONFLICT, "이미 최초 포트폴리오를 구성했습니다."),
+    INSUFFICIENT_SIMULATION_CASH(HttpStatus.UNPROCESSABLE_ENTITY, "사용 가능한 모의 현금이 부족합니다."),
+    ACTIVE_PORTFOLIO_NOT_FOUND(HttpStatus.NOT_FOUND, "활성 포트폴리오가 없습니다."),
+
+    // 거래 (FUNC-035)
+    IDEMPOTENCY_CONFLICT(HttpStatus.CONFLICT, "다른 요청 내용으로 사용한 중복 키입니다."),
+    TRADE_NOT_ALLOWED(HttpStatus.UNPROCESSABLE_ENTITY, "잔액·수량·시간 또는 정책 조건을 충족하지 않습니다."),
+
+    // 초기화 (FUNC-037)
+    RESET_CONFIRMATION_REQUIRED(HttpStatus.BAD_REQUEST, "확인 문구가 일치하지 않습니다."),
+    RESET_POLICY_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "초기화 횟수 또는 대기 시간 정책을 충족하지 않습니다."),
+
+    // 상품 조회 (FUNC-031, 032, 039)
+    INVALID_PRODUCT_FILTER(HttpStatus.BAD_REQUEST, "상품 필터가 올바르지 않습니다."),
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "공개 상품을 찾을 수 없습니다."),
+
+    // 관리자 상품 (FUNC-038)
+    ADMIN_REQUIRED(HttpStatus.FORBIDDEN, "관리자 권한이 필요합니다."),
+    INVALID_SOURCE_PRODUCT(HttpStatus.UNPROCESSABLE_ENTITY, "원천 데이터 또는 가명·시뮬레이션 조건이 올바르지 않습니다."),
+
+    // 내부 배치 (FUNC-040, 041, 042)
+    INTERNAL_CALL_REQUIRED(HttpStatus.FORBIDDEN, "허용된 내부 호출이 아닙니다."),
+    PRICE_POLICY_INVALID(HttpStatus.UNPROCESSABLE_ENTITY, "가격 생성 정책 또는 상품 조건이 올바르지 않습니다."),
+    EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "이벤트를 찾을 수 없습니다."),
+    EVENT_NOT_RETRYABLE(HttpStatus.CONFLICT, "재처리할 수 없는 상태입니다."),
+
+    // 공통 - API_DOCS에 개별 정의가 없는 경우의 기본 코드
+    // TODO: AUTHENTICATION_REQUIRED는 API_DOCS에 명시되지 않은 가정값이다. 팀 확정 후 조정한다.
+    AUTHENTICATION_REQUIRED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "요청 형식이 올바르지 않습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 HTTP 메서드입니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "요청을 처리하지 못했습니다.");
+
+    private final HttpStatus status;
+    private final String defaultMessage;
+
+    ErrorCode(HttpStatus status, String defaultMessage) {
+        this.status = status;
+        this.defaultMessage = defaultMessage;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    public String getDefaultMessage() {
+        return defaultMessage;
+    }
+}

--- a/src/test/java/org/firstfolio/common/json/ApiObjectMapperFactoryTest.java
+++ b/src/test/java/org/firstfolio/common/json/ApiObjectMapperFactoryTest.java
@@ -1,0 +1,156 @@
+package org.firstfolio.common.json;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ApiObjectMapperFactoryTest {
+
+    private final ObjectMapper objectMapper = ApiObjectMapperFactory.create();
+
+    @Test
+    @DisplayName("필드명을 snake_case로 직렬화한다")
+    void serializesFieldNamesInSnakeCase() throws Exception {
+        Sample sample = new Sample();
+        sample.setPortfolioTransactionId(8201L);
+
+        assertEquals(
+                "8201",
+                objectMapper.readTree(objectMapper.writeValueAsString(sample))
+                        .get("portfolio_transaction_id")
+                        .asText()
+        );
+    }
+
+    @Test
+    @DisplayName("금액은 자릿수를 유지한 문자열로 직렬화한다")
+    void serializesBigDecimalAsStringKeepingScale() throws Exception {
+        Sample sample = new Sample();
+        sample.setAmount(new BigDecimal("30000000.00"));
+
+        String json = objectMapper.writeValueAsString(sample);
+
+        // 숫자가 아니라 따옴표가 붙은 문자열이어야 한다.
+        assertEquals(
+                "\"30000000.00\"",
+                objectMapper.readTree(json).get("amount").toString()
+        );
+    }
+
+    @Test
+    @DisplayName("@JsonFormat(NUMBER_FLOAT)을 붙인 필드는 숫자로 직렬화한다")
+    void serializesAnnotatedDecimalAsNumber() throws Exception {
+        Sample sample = new Sample();
+        sample.setRatio(new BigDecimal("33.38"));
+
+        assertEquals(
+                "33.38",
+                objectMapper.readTree(objectMapper.writeValueAsString(sample))
+                        .get("ratio")
+                        .toString()
+        );
+    }
+
+    @Test
+    @DisplayName("시각은 UTC 기준 Z 표기로 직렬화한다")
+    void serializesDateTimeAsUtcWithZ() throws Exception {
+        Sample sample = new Sample();
+        sample.setProcessedAt(LocalDateTime.of(2026, 7, 29, 3, 0, 0));
+
+        assertEquals(
+                "2026-07-29T03:00:00Z",
+                objectMapper.readTree(objectMapper.writeValueAsString(sample))
+                        .get("processed_at")
+                        .asText()
+        );
+    }
+
+    @Test
+    @DisplayName("Z가 붙은 시각을 그대로 UTC로 역직렬화한다")
+    void deserializesZuluDateTime() throws Exception {
+        Sample sample = objectMapper.readValue(
+                "{\"processed_at\":\"2026-07-29T03:15:00Z\"}",
+                Sample.class
+        );
+
+        assertEquals(LocalDateTime.of(2026, 7, 29, 3, 15, 0), sample.getProcessedAt());
+    }
+
+    @Test
+    @DisplayName("오프셋이 붙은 시각은 UTC로 변환해 역직렬화한다")
+    void convertsOffsetDateTimeToUtc() throws Exception {
+        Sample sample = objectMapper.readValue(
+                "{\"processed_at\":\"2026-07-29T12:15:00+09:00\"}",
+                Sample.class
+        );
+
+        assertEquals(LocalDateTime.of(2026, 7, 29, 3, 15, 0), sample.getProcessedAt());
+    }
+
+    @Test
+    @DisplayName("null 필드를 생략하지 않는다 (next_cursor, closed_at 등)")
+    void keepsNullFields() throws Exception {
+        String json = objectMapper.writeValueAsString(new Sample());
+
+        assertNull(objectMapper.readTree(json).get("amount").textValue());
+    }
+
+    @Test
+    @DisplayName("정의되지 않은 요청 필드는 거부한다")
+    void rejectsUnknownFields() {
+        assertThrows(
+                Exception.class,
+                () -> objectMapper.readValue("{\"unknown_field\":1}", Sample.class)
+        );
+    }
+
+    static class Sample {
+
+        private Long portfolioTransactionId;
+        private BigDecimal amount;
+        private LocalDateTime processedAt;
+
+        @JsonFormat(shape = JsonFormat.Shape.NUMBER_FLOAT)
+        private BigDecimal ratio;
+
+        public BigDecimal getRatio() {
+            return ratio;
+        }
+
+        public void setRatio(BigDecimal ratio) {
+            this.ratio = ratio;
+        }
+
+        public Long getPortfolioTransactionId() {
+            return portfolioTransactionId;
+        }
+
+        public void setPortfolioTransactionId(Long portfolioTransactionId) {
+            this.portfolioTransactionId = portfolioTransactionId;
+        }
+
+        public BigDecimal getAmount() {
+            return amount;
+        }
+
+        public void setAmount(BigDecimal amount) {
+            this.amount = amount;
+        }
+
+        public LocalDateTime getProcessedAt() {
+            return processedAt;
+        }
+
+        public void setProcessedAt(LocalDateTime processedAt) {
+            this.processedAt = processedAt;
+        }
+    }
+}

--- a/src/test/java/org/firstfolio/common/web/RequestIdFilterTest.java
+++ b/src/test/java/org/firstfolio/common/web/RequestIdFilterTest.java
@@ -1,0 +1,59 @@
+package org.firstfolio.common.web;
+
+import org.apache.logging.log4j.ThreadContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RequestIdFilterTest {
+
+    private final RequestIdFilter filter = new RequestIdFilter();
+
+    @Test
+    @DisplayName("요청마다 req- 접두사를 가진 식별자를 발급하고 응답 헤더에도 넣는다")
+    void issuesRequestIdAndEchoesItInResponseHeader() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        String requestId = (String) request.getAttribute(RequestIdFilter.REQUEST_ID_ATTRIBUTE);
+
+        assertTrue(requestId.startsWith("req-"), "req- 접두사가 있어야 합니다.");
+        assertEquals(requestId, response.getHeader(RequestIdFilter.REQUEST_ID_HEADER));
+    }
+
+    @Test
+    @DisplayName("요청마다 서로 다른 식별자를 발급한다")
+    void issuesDistinctRequestIds() throws Exception {
+        MockHttpServletRequest first = new MockHttpServletRequest();
+        MockHttpServletRequest second = new MockHttpServletRequest();
+
+        filter.doFilter(first, new MockHttpServletResponse(), new MockFilterChain());
+        filter.doFilter(second, new MockHttpServletResponse(), new MockFilterChain());
+
+        assertNotEquals(
+                first.getAttribute(RequestIdFilter.REQUEST_ID_ATTRIBUTE),
+                second.getAttribute(RequestIdFilter.REQUEST_ID_ATTRIBUTE)
+        );
+    }
+
+    @Test
+    @DisplayName("요청이 끝나면 로그 컨텍스트를 비운다")
+    void clearsLogContextAfterRequest() throws Exception {
+        filter.doFilter(
+                new MockHttpServletRequest(),
+                new MockHttpServletResponse(),
+                new MockFilterChain()
+        );
+
+        assertNull(ThreadContext.get(RequestIdFilter.REQUEST_ID_LOG_KEY));
+    }
+}

--- a/src/test/java/org/firstfolio/exception/CommonExceptionAdviceTest.java
+++ b/src/test/java/org/firstfolio/exception/CommonExceptionAdviceTest.java
@@ -1,0 +1,107 @@
+package org.firstfolio.exception;
+
+import org.firstfolio.common.json.ApiObjectMapperFactory;
+import org.firstfolio.common.response.ApiResponse;
+import org.firstfolio.common.web.RequestIdFilter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class CommonExceptionAdviceTest {
+
+    private final MockMvc mockMvc = buildMockMvc();
+
+    private static MockMvc buildMockMvc() {
+        MappingJackson2HttpMessageConverter converter =
+                new MappingJackson2HttpMessageConverter(ApiObjectMapperFactory.create());
+
+        return MockMvcBuilders.standaloneSetup(new FailingController())
+                .setControllerAdvice(new CommonExceptionAdvice())
+                .setMessageConverters(converter)
+                .addFilters(new RequestIdFilter())
+                .build();
+    }
+
+    @Test
+    @DisplayName("ApiException은 오류 코드에 대응하는 상태와 error 봉투로 응답한다")
+    void mapsApiExceptionToDocumentedErrorEnvelope() throws Exception {
+        mockMvc.perform(get("/test/trade-not-allowed"))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.error.code").value("TRADE_NOT_ALLOWED"))
+                .andExpect(jsonPath("$.error.message").value("보유수량을 초과했습니다."))
+                .andExpect(jsonPath("$.error.request_id").value(startsWith("req-")));
+    }
+
+    @Test
+    @DisplayName("오류 코드마다 문서에 적힌 HTTP 상태를 그대로 쓴다")
+    void usesDocumentedHttpStatusPerErrorCode() throws Exception {
+        mockMvc.perform(get("/test/not-found"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("ACTIVE_PORTFOLIO_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("예상하지 못한 예외는 내부 메시지를 감추고 500으로 응답한다")
+    void hidesInternalDetailsOnUnexpectedException() throws Exception {
+        mockMvc.perform(get("/test/boom"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.error.code").value("INTERNAL_ERROR"))
+                .andExpect(jsonPath("$.error.message").value(not("DB 비밀번호가 틀렸습니다")))
+                .andExpect(jsonPath("$.error.request_id").value(startsWith("req-")));
+    }
+
+    @Test
+    @DisplayName("성공 응답은 data 봉투로 감싼다")
+    void wrapsSuccessInDataEnvelope() throws Exception {
+        mockMvc.perform(get("/test/ok"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.portfolio_id").value(8001));
+    }
+
+    @RestController
+    static class FailingController {
+
+        @GetMapping("/test/trade-not-allowed")
+        public void tradeNotAllowed() {
+            throw new ApiException(ErrorCode.TRADE_NOT_ALLOWED, "보유수량을 초과했습니다.");
+        }
+
+        @GetMapping("/test/not-found")
+        public void notFound() {
+            throw new ApiException(ErrorCode.ACTIVE_PORTFOLIO_NOT_FOUND);
+        }
+
+        @GetMapping("/test/boom")
+        public void boom() {
+            throw new IllegalStateException("DB 비밀번호가 틀렸습니다");
+        }
+
+        @GetMapping("/test/ok")
+        public ApiResponse<Payload> ok() {
+            return ApiResponse.of(new Payload(8001L));
+        }
+    }
+
+    static class Payload {
+
+        private final Long portfolioId;
+
+        Payload(Long portfolioId) {
+            this.portfolioId = portfolioId;
+        }
+
+        public Long getPortfolioId() {
+            return portfolioId;
+        }
+    }
+}


### PR DESCRIPTION
## 배경

Portfolio / Product Simulation 도메인(FUNC-029~042) 작업을 시작하려면 `API_DOCS.md`의 응답 형식을 만들어 주는 공통 코드가 필요한데 아직 없어서 먼저 만들었습니다.
전 도메인에 적용되는 규칙이라 도메인 작업과 분리해 별도 PR로 올립니다.

## 무엇이 생겼나

| 클래스 | 역할 |
|---|---|
| `common.response.ApiResponse<T>` | 성공 응답을 `{"data": ...}`로 감싼다 |
| `common.response.ErrorResponse` | 오류 응답 `{"error": {"code","message","request_id"}}` |
| `exception.ErrorCode` | 오류 코드 ↔ HTTP 상태 대응표 (enum) |
| `exception.ApiException` | 서비스에서 던지는 예외 |
| `exception.CommonExceptionAdvice` | 전역 `@RestControllerAdvice`. 빈 클래스였던 것을 채웠습니다 |
| `common.json.ApiObjectMapperFactory` | JSON 표기 규칙을 모아둔 곳 |
| `common.json.DecimalAsStringModule` | 금액을 자릿수 유지한 문자열로 직렬화 |
| `common.json.UtcDateTimeModule` | 시각을 UTC `...Z` 표기로 직렬화 |
| `common.web.RequestIdFilter` | 요청별 `request_id` 발급 |

## 전역으로 걸린 규칙

1. **필드명 snake_case.** `API_DOCS.md` 전체가 그렇게 되어 있어 따랐습니다(`portfolio_id`, `attempt_id`). Java 필드는 camelCase로 두면 자동 변환됩니다.
2. **`BigDecimal`은 JSON 문자열.** `"30000000.00"`처럼 자릿수를 유지합니다. 숫자로 내보내야 하는 필드는 DTO에 `@JsonFormat(shape = NUMBER_FLOAT)`를 붙이세요 (예: `allocation[].ratio`).
3. **시각은 UTC.** DB DATETIME에 UTC를 넣는 전제(`PROJECT_SPEC.md` 16장)라 `LocalDateTime`을 `2026-07-29T03:00:00Z`로 씁니다. 요청에 `+09:00`이 오면 UTC로 변환해 받습니다.
4. **null 필드를 생략하지 않습니다.** `next_cursor: null`처럼 명세가 null을 명시하는 곳이 있어서입니다.
5. **정의되지 않은 요청 필드는 400.** 오타를 조용히 넘기지 않습니다.

## 쓰는 법

```java
// 성공
return ApiResponse.of(new PortfolioResponse(...));

// 실패 — 상태 코드와 메시지는 ErrorCode가 정한다
throw new ApiException(ErrorCode.INSUFFICIENT_SIMULATION_CASH);
```

각 도메인의 오류 코드는 `ErrorCode`에 추가하면 됩니다.

## 의존성 변경(라이브러리 추가)

- `jackson-datatype-jsr310:2.9.4` — java.time 직렬화 (databind와 같은 버전)
- `json-path:2.9.0` (test) — MockMvc의 `jsonPath()` 매처가 요구합니다. 없어서 컨트롤러 테스트가 `NoClassDefFoundError`로 실패했습니다.
- `mockito-core`, `mockito-junit-jupiter`, `junit-jupiter-params` (test)

## 테스트

`./gradlew clean test` 통과 (16개). 위 규칙 5가지와 예외 처리 동작을 테스트로 고정했습니다.

| 테스트 클래스 | 개수 |
|---|---|
| `ApiObjectMapperFactoryTest` | 8 |
| `CommonExceptionAdviceTest` | 4 |
| `RequestIdFilterTest` | 3 |
| `HealthControllerTest` | 1 |