### PR TITLE
chore: 관리자·내부 호출 권한 검증 추가 (인증은 임시 스텁) #19

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,7 @@ DB_DRIVER=net.sf.log4jdbc.sql.jdbcapi.DriverSpy
 DB_URL=jdbc:log4jdbc:mysql://localhost:3306/firstfolio_db?serverTimezone=UTC&characterEncoding=UTF-8
 DB_USERNAME=사용자이름
 DB_PASSWORD=비밀번호
+
+# /internal/** 내부 배치 호출용 공유 토큰. 비어 있으면 내부 호출이 전부 거부된다.
+# 로컬에서는 아무 값이나 넣고 요청 헤더 X-Internal-Token 에 같은 값을 보내면 된다.
+INTERNAL_CALL_TOKEN=local-internal-token

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ repositories {
 ext {
     junitVersion = '5.10.2'
     springVersion = '5.3.37'
+    jacksonVersion = '2.9.4'
+    mockitoVersion = '5.12.0'
 }
 
 tasks.withType(JavaCompile).configureEach {
@@ -43,13 +45,18 @@ dependencies {
     implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4:1.16'
 
     // Jackson - JSON 처리
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.4'
+    implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonVersion}"
 
     // Test
     testImplementation "org.springframework:spring-test:${springVersion}"
     testImplementation 'javax.servlet:javax.servlet-api:4.0.1'
     testImplementation("org.junit.jupiter:junit-jupiter-api:${junitVersion}")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:${junitVersion}")
     testImplementation 'org.hamcrest:hamcrest:2.2'
+    testImplementation 'com.jayway.jsonpath:json-path:2.9.0'
+    testImplementation "org.mockito:mockito-core:${mockitoVersion}"
+    testImplementation "org.mockito:mockito-junit-jupiter:${mockitoVersion}"
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${junitVersion}")
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/src/main/java/org/firstfolio/common/json/ApiObjectMapperFactory.java
+++ b/src/main/java/org/firstfolio/common/json/ApiObjectMapperFactory.java
@@ -1,0 +1,45 @@
+package org.firstfolio.common.json;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import java.math.BigDecimal;
+
+/**
+ * API_DOCS.md의 요청·응답 표현에 맞춘 ObjectMapper를 만든다.
+ *
+ * <ul>
+ *   <li>필드명은 snake_case ({@code portfolio_id}, {@code cash_balance}).</li>
+ *   <li>금액·수량·단가 등 {@link BigDecimal}은 자릿수 손실을 막기 위해 문자열로 표현한다
+ *       ({@code "30000000.00"}). 비율처럼 숫자로 표현해야 하는 소수의 필드는
+ *       해당 DTO 필드에 {@code @JsonFormat(shape = NUMBER_FLOAT)}을 직접 붙인다
+ *       (예: {@code allocation[].ratio}).</li>
+ *   <li>시각은 UTC 기준 {@code 2026-07-29T03:00:00Z} 형태 ({@link UtcDateTimeModule}).</li>
+ *   <li>{@code next_cursor}, {@code closed_at}처럼 명세가 {@code null}을 명시하는 필드가 있어
+ *       null 필드를 생략하지 않는다.</li>
+ *   <li>정의되지 않은 요청 필드는 조용히 무시하지 않고 오류로 처리한다.</li>
+ * </ul>
+ */
+public final class ApiObjectMapperFactory {
+
+    private ApiObjectMapperFactory() {
+    }
+
+    public static ObjectMapper create() {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.registerModule(new UtcDateTimeModule());
+        objectMapper.registerModule(new DecimalAsStringModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        objectMapper.enable(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN);
+        objectMapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+        return objectMapper;
+    }
+}

--- a/src/main/java/org/firstfolio/common/json/DecimalAsStringModule.java
+++ b/src/main/java/org/firstfolio/common/json/DecimalAsStringModule.java
@@ -1,0 +1,67 @@
+package org.firstfolio.common.json;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.ContextualSerializer;
+import com.fasterxml.jackson.databind.ser.std.NumberSerializer;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+/**
+ * 금액·수량·단가를 JSON 문자열로 내보낸다 ({@code "30000000.00"}).
+ *
+ * <p>숫자로 내보내면 자릿수가 사라지고 지수 표기로 바뀌며
+ * ({@code 30000000.00} → {@code 3.0E7}), 클라이언트에서 double로 읽히면서
+ * 금액에 부동소수점 오차가 생긴다 (FUNC-036 예외/제한사항).</p>
+ *
+ * <p>비율처럼 숫자로 표현해야 하는 필드는 DTO에서 빠져나갈 수 있다:
+ * <pre>
+ * &#64;JsonFormat(shape = JsonFormat.Shape.NUMBER_FLOAT)
+ * private BigDecimal ratio;
+ * </pre>
+ */
+public final class DecimalAsStringModule extends SimpleModule {
+
+    public DecimalAsStringModule() {
+        addSerializer(BigDecimal.class, new DecimalAsStringSerializer());
+    }
+
+    private static final class DecimalAsStringSerializer
+            extends JsonSerializer<BigDecimal>
+            implements ContextualSerializer {
+
+        @Override
+        public void serialize(
+                BigDecimal value,
+                JsonGenerator generator,
+                SerializerProvider provider
+        ) throws IOException {
+            generator.writeString(value.toPlainString());
+        }
+
+        /**
+         * 필드에 {@code @JsonFormat(shape = NUMBER_*)}이 붙어 있으면 숫자로 내보낸다.
+         */
+        @Override
+        public JsonSerializer<?> createContextual(
+                SerializerProvider provider,
+                BeanProperty property
+        ) {
+            if (property == null) {
+                return this;
+            }
+
+            JsonFormat.Value format =
+                    property.findPropertyFormat(provider.getConfig(), BigDecimal.class);
+
+            return format.getShape().isNumeric()
+                    ? new NumberSerializer(BigDecimal.class)
+                    : this;
+        }
+    }
+}

--- a/src/main/java/org/firstfolio/common/json/UtcDateTimeModule.java
+++ b/src/main/java/org/firstfolio/common/json/UtcDateTimeModule.java
@@ -1,0 +1,85 @@
+package org.firstfolio.common.json;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+/**
+ * DB의 DATETIME 컬럼에는 UTC 값을 저장한다(PROJECT_SPEC 16장, 스키마 주석).
+ * 따라서 {@link LocalDateTime}은 항상 UTC 기준 시각으로 취급하고,
+ * API 표현은 {@code 2026-07-29T03:00:00Z} 형태로 통일한다.
+ */
+public final class UtcDateTimeModule extends SimpleModule {
+
+    private static final DateTimeFormatter UTC_FORMATTER =
+            DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss'Z'");
+
+    public UtcDateTimeModule() {
+        addSerializer(LocalDateTime.class, new UtcLocalDateTimeSerializer());
+        addDeserializer(LocalDateTime.class, new UtcLocalDateTimeDeserializer());
+    }
+
+    private static final class UtcLocalDateTimeSerializer
+            extends JsonSerializer<LocalDateTime> {
+
+        @Override
+        public void serialize(
+                LocalDateTime value,
+                JsonGenerator generator,
+                SerializerProvider provider
+        ) throws IOException {
+            generator.writeString(UTC_FORMATTER.format(value));
+        }
+    }
+
+    /**
+     * {@code Z} 또는 오프셋이 붙은 값은 UTC로 변환해 받고,
+     * 오프셋이 없는 값은 이미 UTC로 간주한다.
+     */
+    private static final class UtcLocalDateTimeDeserializer
+            extends JsonDeserializer<LocalDateTime> {
+
+        @Override
+        public LocalDateTime deserialize(
+                JsonParser parser,
+                DeserializationContext context
+        ) throws IOException {
+            String text = parser.getText();
+
+            if (text == null || text.isBlank()) {
+                return null;
+            }
+
+            String value = text.trim();
+
+            try {
+                // OffsetDateTime은 'Z'와 '+09:00' 형태를 모두 받는다.
+                return OffsetDateTime.parse(value)
+                        .withOffsetSameInstant(ZoneOffset.UTC)
+                        .toLocalDateTime();
+            } catch (DateTimeParseException ignored) {
+                // 오프셋이 없는 표현으로 재시도한다.
+            }
+
+            try {
+                return LocalDateTime.parse(value);
+            } catch (DateTimeParseException exception) {
+                throw new IOException(
+                        "날짜·시각 형식이 올바르지 않습니다: " + value,
+                        exception
+                );
+            }
+        }
+    }
+}

--- a/src/main/java/org/firstfolio/common/response/ApiResponse.java
+++ b/src/main/java/org/firstfolio/common/response/ApiResponse.java
@@ -1,0 +1,21 @@
+package org.firstfolio.common.response;
+
+/**
+ * API_DOCS.md의 모든 성공 응답은 {@code {"data": ...}} 한 겹으로 감싼다.
+ */
+public final class ApiResponse<T> {
+
+    private final T data;
+
+    private ApiResponse(T data) {
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> of(T data) {
+        return new ApiResponse<>(data);
+    }
+
+    public T getData() {
+        return data;
+    }
+}

--- a/src/main/java/org/firstfolio/common/response/ErrorResponse.java
+++ b/src/main/java/org/firstfolio/common/response/ErrorResponse.java
@@ -1,0 +1,54 @@
+package org.firstfolio.common.response;
+
+/**
+ * API_DOCS.md의 공통 오류 응답 형식.
+ *
+ * <pre>
+ * {"error": {"code": "...", "message": "...", "request_id": "req-..."}}
+ * </pre>
+ */
+public final class ErrorResponse {
+
+    private final Error error;
+
+    private ErrorResponse(Error error) {
+        this.error = error;
+    }
+
+    public static ErrorResponse of(
+            String code,
+            String message,
+            String requestId
+    ) {
+        return new ErrorResponse(new Error(code, message, requestId));
+    }
+
+    public Error getError() {
+        return error;
+    }
+
+    public static final class Error {
+
+        private final String code;
+        private final String message;
+        private final String requestId;
+
+        private Error(String code, String message, String requestId) {
+            this.code = code;
+            this.message = message;
+            this.requestId = requestId;
+        }
+
+        public String getCode() {
+            return code;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public String getRequestId() {
+            return requestId;
+        }
+    }
+}

--- a/src/main/java/org/firstfolio/common/security/AdminAuthorizationInterceptor.java
+++ b/src/main/java/org/firstfolio/common/security/AdminAuthorizationInterceptor.java
@@ -1,0 +1,32 @@
+package org.firstfolio.common.security;
+
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * {@code /admin/**} 요청에 ADMIN 권한을 요구한다.
+ *
+ * <p>화면에서 감췄는지와 무관하게 서버에서 검증한다 (PROJECT_SPEC 16장).</p>
+ */
+public class AdminAuthorizationInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Object handler
+    ) {
+        CurrentUser currentUser = StubUserHeaders.read(request)
+                .orElseThrow(() -> new ApiException(ErrorCode.AUTHENTICATION_REQUIRED));
+
+        if (!currentUser.isAdmin()) {
+            throw new ApiException(ErrorCode.ADMIN_REQUIRED);
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/org/firstfolio/common/security/CurrentUser.java
+++ b/src/main/java/org/firstfolio/common/security/CurrentUser.java
@@ -1,0 +1,27 @@
+package org.firstfolio.common.security;
+
+/**
+ * 요청을 보낸 사용자. 인증 방식이 무엇으로 확정되든 이 형태는 그대로 쓸 수 있게 둔다.
+ */
+public final class CurrentUser {
+
+    private final Long userId;
+    private final UserRole role;
+
+    public CurrentUser(Long userId, UserRole role) {
+        this.userId = userId;
+        this.role = role;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public UserRole getRole() {
+        return role;
+    }
+
+    public boolean isAdmin() {
+        return role == UserRole.ADMIN;
+    }
+}

--- a/src/main/java/org/firstfolio/common/security/CurrentUserProvider.java
+++ b/src/main/java/org/firstfolio/common/security/CurrentUserProvider.java
@@ -1,0 +1,23 @@
+package org.firstfolio.common.security;
+
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+
+import java.util.Optional;
+
+/**
+ * 현재 요청의 사용자를 알려준다.
+ *
+ * <p><b>Identity 도메인이 나오면 구현체만 교체하면 되도록 인터페이스로 둔다.</b>
+ * 서비스 계층은 이 인터페이스에만 의존하고, 헤더·토큰·세션 같은 인증 수단을 알지 못한다.</p>
+ */
+public interface CurrentUserProvider {
+
+    Optional<CurrentUser> find();
+
+    default CurrentUser require() {
+        return find().orElseThrow(
+                () -> new ApiException(ErrorCode.AUTHENTICATION_REQUIRED)
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/common/security/HeaderCurrentUserProvider.java
+++ b/src/main/java/org/firstfolio/common/security/HeaderCurrentUserProvider.java
@@ -1,0 +1,29 @@
+package org.firstfolio.common.security;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.Optional;
+
+/**
+ * {@link StubUserHeaders} 기반 임시 구현.
+ *
+ * <p><b>TODO: Identity 도메인 구현 후 실제 인증 구현체로 교체한다.</b>
+ * 교체 시 이 클래스만 지우면 되고, 이 인터페이스를 쓰는 서비스는 손대지 않는다.</p>
+ */
+@Component
+public class HeaderCurrentUserProvider implements CurrentUserProvider {
+
+    @Override
+    public Optional<CurrentUser> find() {
+        RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
+
+        if (!(attributes instanceof ServletRequestAttributes)) {
+            return Optional.empty();
+        }
+
+        return StubUserHeaders.read(((ServletRequestAttributes) attributes).getRequest());
+    }
+}

--- a/src/main/java/org/firstfolio/common/security/InternalCallInterceptor.java
+++ b/src/main/java/org/firstfolio/common/security/InternalCallInterceptor.java
@@ -1,0 +1,63 @@
+package org.firstfolio.common.security;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+/**
+ * {@code /internal/**} 요청이 허용된 내부 호출인지 확인한다.
+ *
+ * <p>내부 배치·스케줄러만 부르는 경로라 사용자 인증과 별개로 공유 토큰으로 막는다.
+ * 토큰이 설정돼 있지 않으면 <b>전부 거부한다</b> — 설정을 빠뜨렸을 때 조용히 열려 있는 것보다
+ * 막히는 편이 안전하다.</p>
+ */
+public class InternalCallInterceptor implements HandlerInterceptor {
+
+    public static final String INTERNAL_TOKEN_HEADER = "X-Internal-Token";
+
+    private static final Logger log = LogManager.getLogger(InternalCallInterceptor.class);
+
+    private final String expectedToken;
+
+    public InternalCallInterceptor(String expectedToken) {
+        this.expectedToken = expectedToken == null ? "" : expectedToken.trim();
+    }
+
+    @Override
+    public boolean preHandle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Object handler
+    ) {
+        if (expectedToken.isEmpty()) {
+            log.error(
+                    "내부 호출 토큰이 설정되지 않아 요청을 거부했습니다. path={} 환경변수 INTERNAL_CALL_TOKEN 확인 필요",
+                    request.getRequestURI()
+            );
+            throw new ApiException(ErrorCode.INTERNAL_CALL_REQUIRED);
+        }
+
+        String provided = request.getHeader(INTERNAL_TOKEN_HEADER);
+
+        if (provided == null || !matches(provided.trim())) {
+            throw new ApiException(ErrorCode.INTERNAL_CALL_REQUIRED);
+        }
+
+        return true;
+    }
+
+    /** 비교 시간으로 토큰을 추측당하지 않도록 상수 시간 비교를 쓴다. */
+    private boolean matches(String provided) {
+        return MessageDigest.isEqual(
+                provided.getBytes(StandardCharsets.UTF_8),
+                expectedToken.getBytes(StandardCharsets.UTF_8)
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/common/security/StubUserHeaders.java
+++ b/src/main/java/org/firstfolio/common/security/StubUserHeaders.java
@@ -1,0 +1,49 @@
+package org.firstfolio.common.security;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Optional;
+
+/**
+ * 임시 인증 스텁. 요청 헤더를 그대로 사용자 정보로 받아들인다.
+ *
+ * <p><b>TODO: Identity 도메인(인증·인가) 구현 후 제거한다.</b> 헤더만 바꾸면 누구든
+ * 관리자가 될 수 있으므로 <b>운영 환경에 이 상태로 배포하면 안 된다.</b>
+ * Portfolio 도메인 작업을 인증 구현과 병행하기 위한 임시 수단이다.</p>
+ */
+public final class StubUserHeaders {
+
+    public static final String USER_ID_HEADER = "X-User-Id";
+    public static final String USER_ROLE_HEADER = "X-User-Role";
+
+    private StubUserHeaders() {
+    }
+
+    public static Optional<CurrentUser> read(HttpServletRequest request) {
+        if (request == null) {
+            return Optional.empty();
+        }
+
+        String rawUserId = request.getHeader(USER_ID_HEADER);
+
+        if (rawUserId == null || rawUserId.isBlank()) {
+            return Optional.empty();
+        }
+
+        long userId;
+
+        try {
+            userId = Long.parseLong(rawUserId.trim());
+        } catch (NumberFormatException exception) {
+            return Optional.empty();
+        }
+
+        if (userId <= 0) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new CurrentUser(
+                userId,
+                UserRole.from(request.getHeader(USER_ROLE_HEADER))
+        ));
+    }
+}

--- a/src/main/java/org/firstfolio/common/security/UserRole.java
+++ b/src/main/java/org/firstfolio/common/security/UserRole.java
@@ -1,0 +1,22 @@
+package org.firstfolio.common.security;
+
+/**
+ * {@code users.role_code}와 값이 같아야 한다.
+ */
+public enum UserRole {
+
+    USER,
+    ADMIN;
+
+    public static UserRole from(String value) {
+        if (value == null || value.isBlank()) {
+            return USER;
+        }
+
+        try {
+            return valueOf(value.trim().toUpperCase());
+        } catch (IllegalArgumentException exception) {
+            return USER;
+        }
+    }
+}

--- a/src/main/java/org/firstfolio/common/web/RequestIdFilter.java
+++ b/src/main/java/org/firstfolio/common/web/RequestIdFilter.java
@@ -1,0 +1,70 @@
+package org.firstfolio.common.web;
+
+import org.apache.logging.log4j.ThreadContext;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * 요청마다 추적 식별자를 발급한다.
+ *
+ * <p>API_DOCS.md의 오류 응답은 {@code request_id}를 필수로 요구한다. 컨트롤러마다
+ * 만들지 않도록 여기서 한 번 발급해 요청 속성과 로그 컨텍스트에 넣어 두고,
+ * {@code CommonExceptionAdvice}가 꺼내 쓴다.</p>
+ *
+ * <p>정상 응답에는 {@code request_id}가 본문에 없으므로 응답 헤더
+ * {@code X-Request-Id}로도 같은 값을 내보낸다.</p>
+ */
+public class RequestIdFilter implements Filter {
+
+    public static final String REQUEST_ID_ATTRIBUTE = "org.firstfolio.requestId";
+    public static final String REQUEST_ID_HEADER = "X-Request-Id";
+    public static final String REQUEST_ID_LOG_KEY = "requestId";
+
+    @Override
+    public void doFilter(
+            ServletRequest request,
+            ServletResponse response,
+            FilterChain chain
+    ) throws IOException, ServletException {
+        String requestId = generate();
+
+        request.setAttribute(REQUEST_ID_ATTRIBUTE, requestId);
+        ThreadContext.put(REQUEST_ID_LOG_KEY, requestId);
+
+        if (response instanceof HttpServletResponse) {
+            ((HttpServletResponse) response).setHeader(REQUEST_ID_HEADER, requestId);
+        }
+
+        try {
+            chain.doFilter(request, response);
+        } finally {
+            ThreadContext.remove(REQUEST_ID_LOG_KEY);
+        }
+    }
+
+    /**
+     * 요청 속성에서 추적 식별자를 읽는다. 필터를 거치지 않은 경로에서도
+     * 응답을 만들 수 있도록 없으면 새로 만들어 준다.
+     */
+    public static String currentRequestId(HttpServletRequest request) {
+        if (request == null) {
+            return generate();
+        }
+
+        Object value = request.getAttribute(REQUEST_ID_ATTRIBUTE);
+
+        return value instanceof String ? (String) value : generate();
+    }
+
+    private static String generate() {
+        return "req-" + UUID.randomUUID().toString().replace("-", "");
+    }
+}

--- a/src/main/java/org/firstfolio/config/ServletConfig.java
+++ b/src/main/java/org/firstfolio/config/ServletConfig.java
@@ -62,13 +62,18 @@ public class ServletConfig implements WebMvcConfigurer {
     /**
      * 권한 검증은 컨트롤러마다 반복하지 않고 경로 단위로 건다.
      * 새 관리자·내부 엔드포인트가 늘어도 검증을 빠뜨릴 수 없게 하기 위함이다.
+     *
+     * <p>모든 API는 {@code /api} 접두사를 쓴다 (FE의 {@code VITE_API_BASE_URL=/api},
+     * 프록시가 접두사를 떼지 않음). {@code API_DOCS.md}는 이 접두사를 생략해 표기하고 있다.
+     * 접두사 없는 패턴도 함께 걸어 두는데, 권한 검증은 과하게 걸리는 것보다
+     * 빠지는 쪽이 훨씬 위험하기 때문이다.</p>
      */
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new AdminAuthorizationInterceptor())
-                .addPathPatterns("/admin/**");
+                .addPathPatterns("/api/admin/**", "/admin/**");
 
         registry.addInterceptor(new InternalCallInterceptor(internalCallToken))
-                .addPathPatterns("/internal/**");
+                .addPathPatterns("/api/internal/**", "/internal/**");
     }
 }

--- a/src/main/java/org/firstfolio/config/ServletConfig.java
+++ b/src/main/java/org/firstfolio/config/ServletConfig.java
@@ -1,11 +1,17 @@
 package org.firstfolio.config;
 
+import org.firstfolio.common.json.ApiObjectMapperFactory;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
 @EnableWebMvc
@@ -20,5 +26,20 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
                 }
         )
 )
-public class ServletConfig {
+public class ServletConfig implements WebMvcConfigurer {
+
+    /**
+     * 기본 컨버터 구성은 그대로 두고 JSON 컨버터의 ObjectMapper만 교체한다.
+     * API_DOCS.md의 표기 규칙(snake_case, 금액 문자열, UTC 시각)은
+     * {@link ApiObjectMapperFactory}에 모여 있다.
+     */
+    @Override
+    public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
+        for (HttpMessageConverter<?> converter : converters) {
+            if (converter instanceof MappingJackson2HttpMessageConverter) {
+                ((MappingJackson2HttpMessageConverter) converter)
+                        .setObjectMapper(ApiObjectMapperFactory.create());
+            }
+        }
+    }
 }

--- a/src/main/java/org/firstfolio/config/ServletConfig.java
+++ b/src/main/java/org/firstfolio/config/ServletConfig.java
@@ -1,20 +1,28 @@
 package org.firstfolio.config;
 
 import org.firstfolio.common.json.ApiObjectMapperFactory;
+import org.firstfolio.common.security.AdminAuthorizationInterceptor;
+import org.firstfolio.common.security.InternalCallInterceptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
 
 @Configuration
 @EnableWebMvc
+@PropertySource("classpath:/application.properties")
 @ComponentScan(
         basePackages = "org.firstfolio",
         useDefaultFilters = false,
@@ -27,6 +35,14 @@ import java.util.List;
         )
 )
 public class ServletConfig implements WebMvcConfigurer {
+
+    @Value("${internal.call-token:}")
+    private String internalCallToken;
+
+    @Bean
+    public static PropertySourcesPlaceholderConfigurer servletPropertySourcesPlaceholderConfigurer() {
+        return new PropertySourcesPlaceholderConfigurer();
+    }
 
     /**
      * 기본 컨버터 구성은 그대로 두고 JSON 컨버터의 ObjectMapper만 교체한다.
@@ -41,5 +57,18 @@ public class ServletConfig implements WebMvcConfigurer {
                         .setObjectMapper(ApiObjectMapperFactory.create());
             }
         }
+    }
+
+    /**
+     * 권한 검증은 컨트롤러마다 반복하지 않고 경로 단위로 건다.
+     * 새 관리자·내부 엔드포인트가 늘어도 검증을 빠뜨릴 수 없게 하기 위함이다.
+     */
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new AdminAuthorizationInterceptor())
+                .addPathPatterns("/admin/**");
+
+        registry.addInterceptor(new InternalCallInterceptor(internalCallToken))
+                .addPathPatterns("/internal/**");
     }
 }

--- a/src/main/java/org/firstfolio/config/WebConfig.java
+++ b/src/main/java/org/firstfolio/config/WebConfig.java
@@ -1,5 +1,6 @@
 package org.firstfolio.config;
 
+import org.firstfolio.common.web.RequestIdFilter;
 import org.springframework.web.filter.CharacterEncodingFilter;
 import org.springframework.web.servlet.support.AbstractAnnotationConfigDispatcherServletInitializer;
 
@@ -29,6 +30,6 @@ public class WebConfig extends AbstractAnnotationConfigDispatcherServletInitiali
         characterEncodingFilter.setEncoding("UTF-8");
         characterEncodingFilter.setForceEncoding(true);
 
-        return new Filter[]{characterEncodingFilter};
+        return new Filter[]{characterEncodingFilter, new RequestIdFilter()};
     }
 }

--- a/src/main/java/org/firstfolio/exception/ApiException.java
+++ b/src/main/java/org/firstfolio/exception/ApiException.java
@@ -1,0 +1,27 @@
+package org.firstfolio.exception;
+
+/**
+ * API_DOCS.md의 오류 코드로 응답해야 하는 예외.
+ * 서비스 계층에서 {@code throw new ApiException(ErrorCode.TRADE_NOT_ALLOWED)} 형태로 사용한다.
+ */
+public class ApiException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public ApiException(ErrorCode errorCode) {
+        this(errorCode, errorCode.getDefaultMessage(), null);
+    }
+
+    public ApiException(ErrorCode errorCode, String message) {
+        this(errorCode, message, null);
+    }
+
+    public ApiException(ErrorCode errorCode, String message, Throwable cause) {
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/org/firstfolio/exception/CommonExceptionAdvice.java
+++ b/src/main/java/org/firstfolio/exception/CommonExceptionAdvice.java
@@ -7,6 +7,7 @@ import org.firstfolio.common.web.RequestIdFilter;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -45,6 +46,7 @@ public class CommonExceptionAdvice {
             HttpMessageNotReadableException.class,
             MissingServletRequestParameterException.class,
             MethodArgumentTypeMismatchException.class,
+            MethodArgumentNotValidException.class,
             IllegalArgumentException.class
     })
     public ResponseEntity<ErrorResponse> handleInvalidRequest(

--- a/src/main/java/org/firstfolio/exception/CommonExceptionAdvice.java
+++ b/src/main/java/org/firstfolio/exception/CommonExceptionAdvice.java
@@ -1,4 +1,120 @@
 package org.firstfolio.exception;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.firstfolio.common.response.ErrorResponse;
+import org.firstfolio.common.web.RequestIdFilter;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * 모든 오류 응답을 API_DOCS.md의 {@code {"error": {...}}} 형식으로 통일한다.
+ */
+@RestControllerAdvice
 public class CommonExceptionAdvice {
+
+    private static final Logger log = LogManager.getLogger(CommonExceptionAdvice.class);
+
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ErrorResponse> handleApiException(
+            ApiException exception,
+            HttpServletRequest request
+    ) {
+        ErrorCode errorCode = exception.getErrorCode();
+        String requestId = RequestIdFilter.currentRequestId(request);
+
+        log.warn(
+                "처리 거절 code={} path={} requestId={} message={}",
+                errorCode,
+                request.getRequestURI(),
+                requestId,
+                exception.getMessage()
+        );
+
+        return toResponse(errorCode, exception.getMessage(), requestId);
+    }
+
+    @ExceptionHandler({
+            HttpMessageNotReadableException.class,
+            MissingServletRequestParameterException.class,
+            MethodArgumentTypeMismatchException.class,
+            IllegalArgumentException.class
+    })
+    public ResponseEntity<ErrorResponse> handleInvalidRequest(
+            Exception exception,
+            HttpServletRequest request
+    ) {
+        String requestId = RequestIdFilter.currentRequestId(request);
+
+        log.warn(
+                "잘못된 요청 path={} requestId={} message={}",
+                request.getRequestURI(),
+                requestId,
+                exception.getMessage()
+        );
+
+        // 파싱 실패 메시지에는 내부 타입·패키지 정보가 섞이므로 그대로 노출하지 않는다.
+        return toResponse(
+                ErrorCode.INVALID_REQUEST,
+                ErrorCode.INVALID_REQUEST.getDefaultMessage(),
+                requestId
+        );
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleMethodNotSupported(
+            HttpRequestMethodNotSupportedException exception,
+            HttpServletRequest request
+    ) {
+        String requestId = RequestIdFilter.currentRequestId(request);
+
+        return toResponse(
+                ErrorCode.METHOD_NOT_ALLOWED,
+                ErrorCode.METHOD_NOT_ALLOWED.getDefaultMessage(),
+                requestId
+        );
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnexpected(
+            Exception exception,
+            HttpServletRequest request
+    ) {
+        String requestId = RequestIdFilter.currentRequestId(request);
+
+        log.error(
+                "처리하지 못한 예외 path={} requestId={}",
+                request.getRequestURI(),
+                requestId,
+                exception
+        );
+
+        // 내부 예외 메시지는 사용자에게 노출하지 않는다.
+        return toResponse(
+                ErrorCode.INTERNAL_ERROR,
+                ErrorCode.INTERNAL_ERROR.getDefaultMessage(),
+                requestId
+        );
+    }
+
+    private ResponseEntity<ErrorResponse> toResponse(
+            ErrorCode errorCode,
+            String message,
+            String requestId
+    ) {
+        String body = message == null || message.isBlank()
+                ? errorCode.getDefaultMessage()
+                : message;
+
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ErrorResponse.of(errorCode.name(), body, requestId));
+    }
 }

--- a/src/main/java/org/firstfolio/exception/ErrorCode.java
+++ b/src/main/java/org/firstfolio/exception/ErrorCode.java
@@ -1,0 +1,62 @@
+package org.firstfolio.exception;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * API_DOCS.md에 정의된 오류 코드와 HTTP 상태의 대응표.
+ *
+ * <p>담당 범위(FUNC-029~042, Portfolio / Product Simulation)의 코드만 담는다.
+ * 다른 도메인이 자기 코드를 추가할 때도 이 enum을 함께 사용한다.</p>
+ */
+public enum ErrorCode {
+
+    // 포트폴리오 (FUNC-033, 034, 036)
+    PORTFOLIO_ALREADY_CONFIGURED(HttpStatus.CONFLICT, "이미 최초 포트폴리오를 구성했습니다."),
+    INSUFFICIENT_SIMULATION_CASH(HttpStatus.UNPROCESSABLE_ENTITY, "사용 가능한 모의 현금이 부족합니다."),
+    ACTIVE_PORTFOLIO_NOT_FOUND(HttpStatus.NOT_FOUND, "활성 포트폴리오가 없습니다."),
+
+    // 거래 (FUNC-035)
+    IDEMPOTENCY_CONFLICT(HttpStatus.CONFLICT, "다른 요청 내용으로 사용한 중복 키입니다."),
+    TRADE_NOT_ALLOWED(HttpStatus.UNPROCESSABLE_ENTITY, "잔액·수량·시간 또는 정책 조건을 충족하지 않습니다."),
+
+    // 초기화 (FUNC-037)
+    RESET_CONFIRMATION_REQUIRED(HttpStatus.BAD_REQUEST, "확인 문구가 일치하지 않습니다."),
+    RESET_POLICY_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "초기화 횟수 또는 대기 시간 정책을 충족하지 않습니다."),
+
+    // 상품 조회 (FUNC-031, 032, 039)
+    INVALID_PRODUCT_FILTER(HttpStatus.BAD_REQUEST, "상품 필터가 올바르지 않습니다."),
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "공개 상품을 찾을 수 없습니다."),
+
+    // 관리자 상품 (FUNC-038)
+    ADMIN_REQUIRED(HttpStatus.FORBIDDEN, "관리자 권한이 필요합니다."),
+    INVALID_SOURCE_PRODUCT(HttpStatus.UNPROCESSABLE_ENTITY, "원천 데이터 또는 가명·시뮬레이션 조건이 올바르지 않습니다."),
+
+    // 내부 배치 (FUNC-040, 041, 042)
+    INTERNAL_CALL_REQUIRED(HttpStatus.FORBIDDEN, "허용된 내부 호출이 아닙니다."),
+    PRICE_POLICY_INVALID(HttpStatus.UNPROCESSABLE_ENTITY, "가격 생성 정책 또는 상품 조건이 올바르지 않습니다."),
+    EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "이벤트를 찾을 수 없습니다."),
+    EVENT_NOT_RETRYABLE(HttpStatus.CONFLICT, "재처리할 수 없는 상태입니다."),
+
+    // 공통 - API_DOCS에 개별 정의가 없는 경우의 기본 코드
+    // TODO: AUTHENTICATION_REQUIRED는 API_DOCS에 명시되지 않은 가정값이다. 팀 확정 후 조정한다.
+    AUTHENTICATION_REQUIRED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "요청 형식이 올바르지 않습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 HTTP 메서드입니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "요청을 처리하지 못했습니다.");
+
+    private final HttpStatus status;
+    private final String defaultMessage;
+
+    ErrorCode(HttpStatus status, String defaultMessage) {
+        this.status = status;
+        this.defaultMessage = defaultMessage;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    public String getDefaultMessage() {
+        return defaultMessage;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,3 +2,5 @@ jdbc.driver=${DB_DRIVER:net.sf.log4jdbc.sql.jdbcapi.DriverSpy}
 jdbc.url=${DB_URL:jdbc:log4jdbc:mysql://localhost:3306/firstfolio_db?serverTimezone=UTC&characterEncoding=UTF-8}
 jdbc.username=${DB_USERNAME:firstfolio}
 jdbc.password=${DB_PASSWORD:}
+
+internal.call-token=${INTERNAL_CALL_TOKEN:}

--- a/src/test/java/org/firstfolio/common/json/ApiObjectMapperFactoryTest.java
+++ b/src/test/java/org/firstfolio/common/json/ApiObjectMapperFactoryTest.java
@@ -1,0 +1,156 @@
+package org.firstfolio.common.json;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ApiObjectMapperFactoryTest {
+
+    private final ObjectMapper objectMapper = ApiObjectMapperFactory.create();
+
+    @Test
+    @DisplayName("필드명을 snake_case로 직렬화한다")
+    void serializesFieldNamesInSnakeCase() throws Exception {
+        Sample sample = new Sample();
+        sample.setPortfolioTransactionId(8201L);
+
+        assertEquals(
+                "8201",
+                objectMapper.readTree(objectMapper.writeValueAsString(sample))
+                        .get("portfolio_transaction_id")
+                        .asText()
+        );
+    }
+
+    @Test
+    @DisplayName("금액은 자릿수를 유지한 문자열로 직렬화한다")
+    void serializesBigDecimalAsStringKeepingScale() throws Exception {
+        Sample sample = new Sample();
+        sample.setAmount(new BigDecimal("30000000.00"));
+
+        String json = objectMapper.writeValueAsString(sample);
+
+        // 숫자가 아니라 따옴표가 붙은 문자열이어야 한다.
+        assertEquals(
+                "\"30000000.00\"",
+                objectMapper.readTree(json).get("amount").toString()
+        );
+    }
+
+    @Test
+    @DisplayName("@JsonFormat(NUMBER_FLOAT)을 붙인 필드는 숫자로 직렬화한다")
+    void serializesAnnotatedDecimalAsNumber() throws Exception {
+        Sample sample = new Sample();
+        sample.setRatio(new BigDecimal("33.38"));
+
+        assertEquals(
+                "33.38",
+                objectMapper.readTree(objectMapper.writeValueAsString(sample))
+                        .get("ratio")
+                        .toString()
+        );
+    }
+
+    @Test
+    @DisplayName("시각은 UTC 기준 Z 표기로 직렬화한다")
+    void serializesDateTimeAsUtcWithZ() throws Exception {
+        Sample sample = new Sample();
+        sample.setProcessedAt(LocalDateTime.of(2026, 7, 29, 3, 0, 0));
+
+        assertEquals(
+                "2026-07-29T03:00:00Z",
+                objectMapper.readTree(objectMapper.writeValueAsString(sample))
+                        .get("processed_at")
+                        .asText()
+        );
+    }
+
+    @Test
+    @DisplayName("Z가 붙은 시각을 그대로 UTC로 역직렬화한다")
+    void deserializesZuluDateTime() throws Exception {
+        Sample sample = objectMapper.readValue(
+                "{\"processed_at\":\"2026-07-29T03:15:00Z\"}",
+                Sample.class
+        );
+
+        assertEquals(LocalDateTime.of(2026, 7, 29, 3, 15, 0), sample.getProcessedAt());
+    }
+
+    @Test
+    @DisplayName("오프셋이 붙은 시각은 UTC로 변환해 역직렬화한다")
+    void convertsOffsetDateTimeToUtc() throws Exception {
+        Sample sample = objectMapper.readValue(
+                "{\"processed_at\":\"2026-07-29T12:15:00+09:00\"}",
+                Sample.class
+        );
+
+        assertEquals(LocalDateTime.of(2026, 7, 29, 3, 15, 0), sample.getProcessedAt());
+    }
+
+    @Test
+    @DisplayName("null 필드를 생략하지 않는다 (next_cursor, closed_at 등)")
+    void keepsNullFields() throws Exception {
+        String json = objectMapper.writeValueAsString(new Sample());
+
+        assertNull(objectMapper.readTree(json).get("amount").textValue());
+    }
+
+    @Test
+    @DisplayName("정의되지 않은 요청 필드는 거부한다")
+    void rejectsUnknownFields() {
+        assertThrows(
+                Exception.class,
+                () -> objectMapper.readValue("{\"unknown_field\":1}", Sample.class)
+        );
+    }
+
+    static class Sample {
+
+        private Long portfolioTransactionId;
+        private BigDecimal amount;
+        private LocalDateTime processedAt;
+
+        @JsonFormat(shape = JsonFormat.Shape.NUMBER_FLOAT)
+        private BigDecimal ratio;
+
+        public BigDecimal getRatio() {
+            return ratio;
+        }
+
+        public void setRatio(BigDecimal ratio) {
+            this.ratio = ratio;
+        }
+
+        public Long getPortfolioTransactionId() {
+            return portfolioTransactionId;
+        }
+
+        public void setPortfolioTransactionId(Long portfolioTransactionId) {
+            this.portfolioTransactionId = portfolioTransactionId;
+        }
+
+        public BigDecimal getAmount() {
+            return amount;
+        }
+
+        public void setAmount(BigDecimal amount) {
+            this.amount = amount;
+        }
+
+        public LocalDateTime getProcessedAt() {
+            return processedAt;
+        }
+
+        public void setProcessedAt(LocalDateTime processedAt) {
+            this.processedAt = processedAt;
+        }
+    }
+}

--- a/src/test/java/org/firstfolio/common/security/AuthorizationInterceptorTest.java
+++ b/src/test/java/org/firstfolio/common/security/AuthorizationInterceptorTest.java
@@ -1,0 +1,126 @@
+package org.firstfolio.common.security;
+
+import org.firstfolio.common.json.ApiObjectMapperFactory;
+import org.firstfolio.common.web.RequestIdFilter;
+import org.firstfolio.exception.CommonExceptionAdvice;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class AuthorizationInterceptorTest {
+
+    private static final String INTERNAL_TOKEN = "test-internal-token";
+
+    private final MockMvc mockMvc = MockMvcBuilders
+            .standaloneSetup(new GuardedController())
+            .setControllerAdvice(new CommonExceptionAdvice())
+            .setMessageConverters(
+                    new MappingJackson2HttpMessageConverter(ApiObjectMapperFactory.create())
+            )
+            .addFilters(new RequestIdFilter())
+            .addMappedInterceptors(
+                    new String[]{"/admin/**"},
+                    new AdminAuthorizationInterceptor()
+            )
+            .addMappedInterceptors(
+                    new String[]{"/internal/**"},
+                    new InternalCallInterceptor(INTERNAL_TOKEN)
+            )
+            .build();
+
+    @Test
+    @DisplayName("관리자 경로는 인증이 없으면 401로 막는다")
+    void rejectsAdminPathWithoutUser() throws Exception {
+        mockMvc.perform(get("/admin/things"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("AUTHENTICATION_REQUIRED"));
+    }
+
+    @Test
+    @DisplayName("일반 사용자는 관리자 경로에서 ADMIN_REQUIRED로 막힌다")
+    void rejectsAdminPathForNormalUser() throws Exception {
+        mockMvc.perform(get("/admin/things")
+                        .header(StubUserHeaders.USER_ID_HEADER, "1")
+                        .header(StubUserHeaders.USER_ROLE_HEADER, "USER"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("ADMIN_REQUIRED"));
+    }
+
+    @Test
+    @DisplayName("ADMIN 역할이면 관리자 경로를 통과한다")
+    void allowsAdmin() throws Exception {
+        mockMvc.perform(get("/admin/things")
+                        .header(StubUserHeaders.USER_ID_HEADER, "1")
+                        .header(StubUserHeaders.USER_ROLE_HEADER, "ADMIN"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("내부 경로는 토큰이 없으면 막는다")
+    void rejectsInternalPathWithoutToken() throws Exception {
+        mockMvc.perform(get("/internal/things"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("INTERNAL_CALL_REQUIRED"));
+    }
+
+    @Test
+    @DisplayName("내부 경로는 토큰이 틀리면 막는다")
+    void rejectsInternalPathWithWrongToken() throws Exception {
+        mockMvc.perform(get("/internal/things")
+                        .header(InternalCallInterceptor.INTERNAL_TOKEN_HEADER, "wrong"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("INTERNAL_CALL_REQUIRED"));
+    }
+
+    @Test
+    @DisplayName("토큰이 맞으면 내부 경로를 통과한다")
+    void allowsInternalCallWithToken() throws Exception {
+        mockMvc.perform(get("/internal/things")
+                        .header(InternalCallInterceptor.INTERNAL_TOKEN_HEADER, INTERNAL_TOKEN))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("토큰이 설정돼 있지 않으면 내부 호출을 전부 거부한다")
+    void deniesInternalCallWhenTokenNotConfigured() throws Exception {
+        MockMvc unconfigured = MockMvcBuilders
+                .standaloneSetup(new GuardedController())
+                .setControllerAdvice(new CommonExceptionAdvice())
+                .setMessageConverters(
+                        new MappingJackson2HttpMessageConverter(ApiObjectMapperFactory.create())
+                )
+                .addFilters(new RequestIdFilter())
+                .addMappedInterceptors(
+                        new String[]{"/internal/**"},
+                        new InternalCallInterceptor("")
+                )
+                .build();
+
+        unconfigured.perform(get("/internal/things")
+                        .header(InternalCallInterceptor.INTERNAL_TOKEN_HEADER, "anything"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("INTERNAL_CALL_REQUIRED"));
+    }
+
+    @RestController
+    static class GuardedController {
+
+        @GetMapping("/admin/things")
+        public String adminThing() {
+            return "ok";
+        }
+
+        @GetMapping("/internal/things")
+        public String internalThing() {
+            return "ok";
+        }
+    }
+}

--- a/src/test/java/org/firstfolio/common/web/RequestIdFilterTest.java
+++ b/src/test/java/org/firstfolio/common/web/RequestIdFilterTest.java
@@ -1,0 +1,59 @@
+package org.firstfolio.common.web;
+
+import org.apache.logging.log4j.ThreadContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RequestIdFilterTest {
+
+    private final RequestIdFilter filter = new RequestIdFilter();
+
+    @Test
+    @DisplayName("요청마다 req- 접두사를 가진 식별자를 발급하고 응답 헤더에도 넣는다")
+    void issuesRequestIdAndEchoesItInResponseHeader() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        String requestId = (String) request.getAttribute(RequestIdFilter.REQUEST_ID_ATTRIBUTE);
+
+        assertTrue(requestId.startsWith("req-"), "req- 접두사가 있어야 합니다.");
+        assertEquals(requestId, response.getHeader(RequestIdFilter.REQUEST_ID_HEADER));
+    }
+
+    @Test
+    @DisplayName("요청마다 서로 다른 식별자를 발급한다")
+    void issuesDistinctRequestIds() throws Exception {
+        MockHttpServletRequest first = new MockHttpServletRequest();
+        MockHttpServletRequest second = new MockHttpServletRequest();
+
+        filter.doFilter(first, new MockHttpServletResponse(), new MockFilterChain());
+        filter.doFilter(second, new MockHttpServletResponse(), new MockFilterChain());
+
+        assertNotEquals(
+                first.getAttribute(RequestIdFilter.REQUEST_ID_ATTRIBUTE),
+                second.getAttribute(RequestIdFilter.REQUEST_ID_ATTRIBUTE)
+        );
+    }
+
+    @Test
+    @DisplayName("요청이 끝나면 로그 컨텍스트를 비운다")
+    void clearsLogContextAfterRequest() throws Exception {
+        filter.doFilter(
+                new MockHttpServletRequest(),
+                new MockHttpServletResponse(),
+                new MockFilterChain()
+        );
+
+        assertNull(ThreadContext.get(RequestIdFilter.REQUEST_ID_LOG_KEY));
+    }
+}

--- a/src/test/java/org/firstfolio/config/ServletConfigInterceptorPathTest.java
+++ b/src/test/java/org/firstfolio/config/ServletConfigInterceptorPathTest.java
@@ -1,0 +1,107 @@
+package org.firstfolio.config;
+
+import org.firstfolio.common.security.AdminAuthorizationInterceptor;
+import org.firstfolio.common.security.InternalCallInterceptor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.handler.MappedInterceptor;
+import org.springframework.web.util.ServletRequestPathUtils;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link ServletConfig}에 실제로 등록된 경로 패턴을 검증한다.
+ *
+ * <p>기존 인터셉터 테스트는 테스트 코드가 직접 만든 매핑을 검증해서, 설정의 패턴이 틀려도
+ * 통과했다. 실제로 {@code /admin/**}만 걸려 있어 {@code /api} 접두사가 붙은 요청이 전부
+ * 검증을 통과해버리는 결함을 잡지 못했다. 그래서 설정 객체에서 패턴을 직접 읽어 확인한다.</p>
+ */
+class ServletConfigInterceptorPathTest {
+
+    @ParameterizedTest(name = "관리자 인터셉터가 {0} 를 가로챈다")
+    @DisplayName("관리자 경로는 /api 접두사가 붙어도 가로챈다")
+    @ValueSource(strings = {
+            "/api/admin/financial-products",
+            "/api/admin/financial-products/25",
+            "/api/admin/financial-products/imports",
+            "/admin/financial-products"
+    })
+    void adminInterceptorCoversAdminPaths(String path) {
+        assertTrue(
+                interceptorFor(AdminAuthorizationInterceptor.class).matches(request(path)),
+                path + " 가 권한 검증 없이 통과합니다."
+        );
+    }
+
+    @ParameterizedTest(name = "내부 호출 인터셉터가 {0} 를 가로챈다")
+    @DisplayName("내부 배치 경로는 /api 접두사가 붙어도 가로챈다")
+    @ValueSource(strings = {
+            "/api/internal/product-prices/refresh",
+            "/api/internal/portfolio-events/process",
+            "/internal/product-prices/refresh"
+    })
+    void internalInterceptorCoversInternalPaths(String path) {
+        assertTrue(
+                interceptorFor(InternalCallInterceptor.class).matches(request(path)),
+                path + " 가 내부 호출 검증 없이 통과합니다."
+        );
+    }
+
+    @ParameterizedTest(name = "{0} 는 권한 검증 대상이 아니다")
+    @DisplayName("일반 사용자 경로에는 관리자·내부 검증을 걸지 않는다")
+    @ValueSource(strings = {
+            "/api/health",
+            "/api/financial-products",
+            "/api/portfolios/current"
+    })
+    void doesNotGuardPublicPaths(String path) {
+        assertFalse(interceptorFor(AdminAuthorizationInterceptor.class).matches(request(path)));
+        assertFalse(interceptorFor(InternalCallInterceptor.class).matches(request(path)));
+    }
+
+    private static HttpServletRequest request(String path) {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", path);
+
+        // MappedInterceptor는 파싱된 경로를 요청 속성에서 읽는다.
+        // 실제로는 DispatcherServlet이 넣어 주지만 목 요청에는 없다.
+        ServletRequestPathUtils.parseAndCache(request);
+
+        return request;
+    }
+
+    private static MappedInterceptor interceptorFor(Class<?> interceptorType) {
+        InspectableRegistry registry = new InspectableRegistry();
+
+        new ServletConfig().addInterceptors(registry);
+
+        for (Object registered : registry.registered()) {
+            if (registered instanceof MappedInterceptor) {
+                MappedInterceptor mapped = (MappedInterceptor) registered;
+
+                if (interceptorType.isInstance(mapped.getInterceptor())) {
+                    return mapped;
+                }
+            }
+        }
+
+        assertNotNull(null, interceptorType.getSimpleName() + " 가 등록되지 않았습니다.");
+
+        return null;
+    }
+
+    /** {@code getInterceptors()}가 protected라 하위 클래스로 열어 준다. */
+    private static final class InspectableRegistry extends InterceptorRegistry {
+
+        List<Object> registered() {
+            return getInterceptors();
+        }
+    }
+}

--- a/src/test/java/org/firstfolio/exception/CommonExceptionAdviceTest.java
+++ b/src/test/java/org/firstfolio/exception/CommonExceptionAdviceTest.java
@@ -1,0 +1,107 @@
+package org.firstfolio.exception;
+
+import org.firstfolio.common.json.ApiObjectMapperFactory;
+import org.firstfolio.common.response.ApiResponse;
+import org.firstfolio.common.web.RequestIdFilter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class CommonExceptionAdviceTest {
+
+    private final MockMvc mockMvc = buildMockMvc();
+
+    private static MockMvc buildMockMvc() {
+        MappingJackson2HttpMessageConverter converter =
+                new MappingJackson2HttpMessageConverter(ApiObjectMapperFactory.create());
+
+        return MockMvcBuilders.standaloneSetup(new FailingController())
+                .setControllerAdvice(new CommonExceptionAdvice())
+                .setMessageConverters(converter)
+                .addFilters(new RequestIdFilter())
+                .build();
+    }
+
+    @Test
+    @DisplayName("ApiException은 오류 코드에 대응하는 상태와 error 봉투로 응답한다")
+    void mapsApiExceptionToDocumentedErrorEnvelope() throws Exception {
+        mockMvc.perform(get("/test/trade-not-allowed"))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.error.code").value("TRADE_NOT_ALLOWED"))
+                .andExpect(jsonPath("$.error.message").value("보유수량을 초과했습니다."))
+                .andExpect(jsonPath("$.error.request_id").value(startsWith("req-")));
+    }
+
+    @Test
+    @DisplayName("오류 코드마다 문서에 적힌 HTTP 상태를 그대로 쓴다")
+    void usesDocumentedHttpStatusPerErrorCode() throws Exception {
+        mockMvc.perform(get("/test/not-found"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("ACTIVE_PORTFOLIO_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("예상하지 못한 예외는 내부 메시지를 감추고 500으로 응답한다")
+    void hidesInternalDetailsOnUnexpectedException() throws Exception {
+        mockMvc.perform(get("/test/boom"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.error.code").value("INTERNAL_ERROR"))
+                .andExpect(jsonPath("$.error.message").value(not("DB 비밀번호가 틀렸습니다")))
+                .andExpect(jsonPath("$.error.request_id").value(startsWith("req-")));
+    }
+
+    @Test
+    @DisplayName("성공 응답은 data 봉투로 감싼다")
+    void wrapsSuccessInDataEnvelope() throws Exception {
+        mockMvc.perform(get("/test/ok"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.portfolio_id").value(8001));
+    }
+
+    @RestController
+    static class FailingController {
+
+        @GetMapping("/test/trade-not-allowed")
+        public void tradeNotAllowed() {
+            throw new ApiException(ErrorCode.TRADE_NOT_ALLOWED, "보유수량을 초과했습니다.");
+        }
+
+        @GetMapping("/test/not-found")
+        public void notFound() {
+            throw new ApiException(ErrorCode.ACTIVE_PORTFOLIO_NOT_FOUND);
+        }
+
+        @GetMapping("/test/boom")
+        public void boom() {
+            throw new IllegalStateException("DB 비밀번호가 틀렸습니다");
+        }
+
+        @GetMapping("/test/ok")
+        public ApiResponse<Payload> ok() {
+            return ApiResponse.of(new Payload(8001L));
+        }
+    }
+
+    static class Payload {
+
+        private final Long portfolioId;
+
+        Payload(Long portfolioId) {
+            this.portfolioId = portfolioId;
+        }
+
+        public Long getPortfolioId() {
+            return portfolioId;
+        }
+    }
+}


### PR DESCRIPTION
## 배경

`API_DOCS.md`는 관리자 API에 `ADMIN_REQUIRED`(403), 내부 배치 API에 `INTERNAL_CALL_REQUIRED`(403)를 요구하는데 저장소에 인증·인가가 없어 이 응답을 만들 수 없었습니다.

Portfolio 도메인(FUNC-029~042)의 관리자·내부 엔드포인트에 지금 필요하지만 전 도메인이 함께 쓰는 코드라, `#9`(공통 응답 봉투)와 같은 이유로 별도 PR로 올립니다.

인증 작업이 끝날 때까지 Portfolio 구현이 멈추지 않도록 교체 가능한 인터페이스와 최소 구현만 두었습니다.

## ⚠️ 이 상태로 운영 배포하면 안 됩니다

`X-User-Id`, `X-User-Role` 헤더만 바꾸면 누구든 관리자가 됩니다. 임시 스텁입니다.
`StubUserHeaders`와 `HeaderCurrentUserProvider`에 `TODO`와 경고 주석을 달아두었습니다.

## 교체 방법 (인증 담당자용)

인증이 완성되면 아래 두 파일만 지우고 `CurrentUserProvider` 구현체를 새로 넣으면 됩니다. 이 인터페이스를 쓰는 서비스 코드는 손대지 않아도 됩니다.

- `common/security/HeaderCurrentUserProvider.java` (삭제)
- `common/security/StubUserHeaders.java` (삭제)

`AdminAuthorizationInterceptor`도 `StubUserHeaders` 대신 `CurrentUserProvider`를 쓰도록 바꾸면 됩니다.

## 구조

권한 검증은 컨트롤러마다 반복하지 않고 **경로 단위 인터셉터**로 걸었습니다(`/admin/**`, `/internal/**`). 관리자·내부 엔드포인트를 새로 추가해도 검증을 빠뜨릴 수 없습니다.

| 클래스 | 역할 |
|---|---|
| `CurrentUser` / `UserRole` | 요청자 정보 |
| `CurrentUserProvider` | **교체 지점 인터페이스.** 서비스 계층은 이것에만 의존 |
| `HeaderCurrentUserProvider` | 임시 구현 |
| `StubUserHeaders` | 임시 헤더 파서 |
| `AdminAuthorizationInterceptor` | `/admin/**` — ADMIN 요구 |
| `InternalCallInterceptor` | `/internal/**` — 공유 토큰 요구 |

## 설정

`INTERNAL_CALL_TOKEN` — `/internal/**` 호출용 공유 토큰. **비어 있으면 내부 호출을 전부 거부합니다.** 설정을 빠뜨렸을 때 조용히 열려 있는 것보다 막히는 편이 안전하다고 판단했습니다.
로컬에서는 `.env.local`에 아무 값이나 넣고 요청 헤더 `X-Internal-Token`에 같은 값을 보내면 됩니다.

## 알아두실 것

- `ErrorCode.AUTHENTICATION_REQUIRED`(401)는 `API_DOCS.md`에 없는 **가정값**입니다. 관리자 경로에서 헤더가 아예 없으면 401, 있는데 권한이 모자라면 403으로 나눴습니다.
- 내부 토큰 비교는 상수 시간 비교(`MessageDigest.isEqual`)를 씁니다. 문자열 `equals`는 앞자리부터 비교하다 틀리면 즉시 반환해서, 응답 시간 차이로 토큰을 추측할 여지가 있습니다.

## 테스트

- `./gradlew clean test` 통과 (23개, 이 PR에서 7개 추가).
- 인증 없음 → 401, 일반 사용자 → 403, ADMIN → 통과, 내부 토큰 없음/틀림/미설정 → 403을 고정했습니다.

## 수정 이력

- 인터셉터 경로 패턴이 `/admin/**`, `/internal/**`이었으나 이 프로젝트의 모든 API에는 `/api` 접두사가 붙어(FE `.env.example`의 `VITE_API_BASE_URL=/api`, `vite.config.js` 프록시가 접두사를 떼지 않음) **어떤 요청과도 매칭되지 않았습니다.** 관리자·내부 API가 무방비로 열려 있었습니다.
- `/api/admin/**`, `/api/internal/**`을 추가했습니다. 접두사 없는 패턴도 함께 남겨둡니다 — 컨텍스트 경로 설정에 따라 어느 쪽으로 들어올지 확정할 수 없고, 권한 검증은 과하게 걸리는 것보다 빠지는 쪽이 훨씬 위험하기 때문입니다.
- 기존 테스트는 테스트 코드가 직접 만든 매핑을 검증해 이 결함을 잡지 못했습니다. `ServletConfig`의 실제 설정을 읽어 검증하는 `ServletConfigInterceptorPathTest`를 추가했습니다.