### PR TITLE
feat: 강의 컨텐츠 업로드 API 구현

### DIFF
--- a/src/main/java/org/firstfolio/content/controller/AdminContentVersionController.java
+++ b/src/main/java/org/firstfolio/content/controller/AdminContentVersionController.java
@@ -1,0 +1,49 @@
+package org.firstfolio.content.controller;
+
+import org.firstfolio.auth.annotation.CurrentUser;
+import org.firstfolio.auth.domain.AuthenticatedUser;
+import org.firstfolio.common.response.ApiResponse;
+import org.firstfolio.common.web.RequestIdFilter;
+import org.firstfolio.content.dto.request.LessonContentUploadRequest;
+import org.firstfolio.content.dto.response.ContentVersionCreateResponse;
+import org.firstfolio.content.service.ContentVersionService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequestMapping("/api/admin/sub-chapters")
+public class AdminContentVersionController {
+
+    private final ContentVersionService contentVersionService;
+
+    public AdminContentVersionController(
+            ContentVersionService contentVersionService
+    ) {
+        this.contentVersionService = contentVersionService;
+    }
+
+    @PostMapping("/{subChapterId}/content-versions")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<ContentVersionCreateResponse> uploadLesson(
+            @PathVariable long subChapterId,
+            @RequestBody(required = false) LessonContentUploadRequest request,
+            @CurrentUser AuthenticatedUser currentUser,
+            HttpServletRequest servletRequest
+    ) {
+        return ApiResponse.of(ContentVersionCreateResponse.from(
+                contentVersionService.uploadLesson(
+                        subChapterId,
+                        request,
+                        currentUser.userId(),
+                        RequestIdFilter.currentRequestId(servletRequest)
+                )
+        ));
+    }
+}

--- a/src/main/java/org/firstfolio/content/domain/ContentVersion.java
+++ b/src/main/java/org/firstfolio/content/domain/ContentVersion.java
@@ -1,0 +1,120 @@
+package org.firstfolio.content.domain;
+
+import java.time.LocalDateTime;
+
+public class ContentVersion {
+
+    private Long contentVersionId;
+    private long subChapterId;
+    private int versionNo;
+    private String schemaVersion;
+    private String storageObjectKey;
+    private String storageVersionId;
+    private ContentVersionStatus status;
+    private LocalDateTime publishedAt;
+    private long createdBy;
+    private LocalDateTime createdAt;
+
+    public ContentVersion() {
+    }
+
+    public static ContentVersion draft(
+            long subChapterId,
+            int versionNo,
+            String schemaVersion,
+            StoredObjectRef storedObject,
+            long createdBy,
+            LocalDateTime createdAt
+    ) {
+        ContentVersion version = new ContentVersion();
+        version.subChapterId = subChapterId;
+        version.versionNo = versionNo;
+        version.schemaVersion = schemaVersion;
+        version.storageObjectKey = storedObject.objectKey();
+        version.storageVersionId = storedObject.versionId();
+        version.status = ContentVersionStatus.DRAFT;
+        version.createdBy = createdBy;
+        version.createdAt = createdAt;
+        return version;
+    }
+
+    public Long getContentVersionId() {
+        return contentVersionId;
+    }
+
+    public void setContentVersionId(Long contentVersionId) {
+        this.contentVersionId = contentVersionId;
+    }
+
+    public long getSubChapterId() {
+        return subChapterId;
+    }
+
+    public void setSubChapterId(long subChapterId) {
+        this.subChapterId = subChapterId;
+    }
+
+    public int getVersionNo() {
+        return versionNo;
+    }
+
+    public void setVersionNo(int versionNo) {
+        this.versionNo = versionNo;
+    }
+
+    public String getSchemaVersion() {
+        return schemaVersion;
+    }
+
+    public void setSchemaVersion(String schemaVersion) {
+        this.schemaVersion = schemaVersion;
+    }
+
+    public String getStorageObjectKey() {
+        return storageObjectKey;
+    }
+
+    public void setStorageObjectKey(String storageObjectKey) {
+        this.storageObjectKey = storageObjectKey;
+    }
+
+    public String getStorageVersionId() {
+        return storageVersionId;
+    }
+
+    public void setStorageVersionId(String storageVersionId) {
+        this.storageVersionId = storageVersionId;
+    }
+
+    public ContentVersionStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(ContentVersionStatus status) {
+        this.status = status;
+    }
+
+    public LocalDateTime getPublishedAt() {
+        return publishedAt;
+    }
+
+    public void setPublishedAt(LocalDateTime publishedAt) {
+        this.publishedAt = publishedAt;
+    }
+
+    public long getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(long createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/org/firstfolio/content/domain/ContentVersionStatus.java
+++ b/src/main/java/org/firstfolio/content/domain/ContentVersionStatus.java
@@ -1,0 +1,8 @@
+package org.firstfolio.content.domain;
+
+public enum ContentVersionStatus {
+    DRAFT,
+    REVIEW,
+    PUBLISHED,
+    RETIRED
+}

--- a/src/main/java/org/firstfolio/content/dto/request/LessonContentUploadRequest.java
+++ b/src/main/java/org/firstfolio/content/dto/request/LessonContentUploadRequest.java
@@ -1,0 +1,9 @@
+package org.firstfolio.content.dto.request;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public record LessonContentUploadRequest(
+        Integer versionNo,
+        JsonNode lesson
+) {
+}

--- a/src/main/java/org/firstfolio/content/dto/response/ContentVersionCreateResponse.java
+++ b/src/main/java/org/firstfolio/content/dto/response/ContentVersionCreateResponse.java
@@ -1,0 +1,25 @@
+package org.firstfolio.content.dto.response;
+
+import org.firstfolio.content.domain.ContentVersion;
+import org.firstfolio.content.domain.ContentVersionStatus;
+
+public record ContentVersionCreateResponse(
+        long contentVersionId,
+        long subChapterId,
+        int versionNo,
+        String schemaVersion,
+        ContentVersionStatus status,
+        boolean validated
+) {
+
+    public static ContentVersionCreateResponse from(ContentVersion version) {
+        return new ContentVersionCreateResponse(
+                version.getContentVersionId(),
+                version.getSubChapterId(),
+                version.getVersionNo(),
+                version.getSchemaVersion(),
+                version.getStatus(),
+                true
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/content/mapper/ContentVersionMapper.java
+++ b/src/main/java/org/firstfolio/content/mapper/ContentVersionMapper.java
@@ -1,0 +1,16 @@
+package org.firstfolio.content.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.firstfolio.content.domain.ContentVersion;
+
+@Mapper
+public interface ContentVersionMapper {
+
+    int countBySubChapterIdAndVersionNo(
+            @Param("subChapterId") long subChapterId,
+            @Param("versionNo") int versionNo
+    );
+
+    int insert(ContentVersion contentVersion);
+}

--- a/src/main/java/org/firstfolio/content/service/ContentVersionService.java
+++ b/src/main/java/org/firstfolio/content/service/ContentVersionService.java
@@ -1,0 +1,215 @@
+package org.firstfolio.content.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.firstfolio.common.json.ApiObjectMapperFactory;
+import org.firstfolio.content.domain.ContentVersion;
+import org.firstfolio.content.domain.ContentWriteRequest;
+import org.firstfolio.content.domain.StoredObjectRef;
+import org.firstfolio.content.dto.request.LessonContentUploadRequest;
+import org.firstfolio.content.mapper.ContentVersionMapper;
+import org.firstfolio.content.validation.LessonContentValidationService;
+import org.firstfolio.content.validation.LessonValidationError;
+import org.firstfolio.content.validation.LessonValidationErrorCode;
+import org.firstfolio.content.validation.LessonValidationResult;
+import org.firstfolio.curriculum.mapper.AdminAuditLogMapper;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Service
+public class ContentVersionService {
+
+    private static final Logger log = LogManager.getLogger(ContentVersionService.class);
+    private static final String CONTENT_TYPE_JSON = "application/json";
+    private static final String AUDIT_ENTITY_TYPE = "CONTENT_VERSION";
+
+    private final LessonContentValidationService validationService;
+    private final StaticContentStorage contentStorage;
+    private final ContentVersionMapper contentVersionMapper;
+    private final AdminAuditLogMapper auditLogMapper;
+    private final Clock clock;
+    private final ObjectMapper auditObjectMapper;
+
+    public ContentVersionService(
+            LessonContentValidationService validationService,
+            StaticContentStorage contentStorage,
+            ContentVersionMapper contentVersionMapper,
+            AdminAuditLogMapper auditLogMapper,
+            Clock clock
+    ) {
+        this.validationService = validationService;
+        this.contentStorage = contentStorage;
+        this.contentVersionMapper = contentVersionMapper;
+        this.auditLogMapper = auditLogMapper;
+        this.clock = clock;
+        this.auditObjectMapper = ApiObjectMapperFactory.create();
+    }
+
+    @Transactional
+    public ContentVersion uploadLesson(
+            long subChapterId,
+            LessonContentUploadRequest request,
+            long actorUserId,
+            String requestId
+    ) {
+        requireRequest(request);
+
+        byte[] lessonContent = request.lesson().toString()
+                .getBytes(StandardCharsets.UTF_8);
+        LessonValidationResult validationResult = validationService.validate(
+                subChapterId,
+                lessonContent
+        );
+        requireValidContent(validationResult);
+
+        int versionNo = request.versionNo();
+        if (contentVersionMapper.countBySubChapterIdAndVersionNo(
+                subChapterId,
+                versionNo
+        ) > 0) {
+            throw new ApiException(ErrorCode.CONTENT_VERSION_CONFLICT);
+        }
+
+        String objectKey = lessonObjectKey(subChapterId);
+        StoredObjectRef storedObject = contentStorage.store(new ContentWriteRequest(
+                objectKey,
+                lessonContent,
+                CONTENT_TYPE_JSON
+        ));
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        ContentVersion contentVersion = ContentVersion.draft(
+                subChapterId,
+                versionNo,
+                request.lesson().path("schemaVersion").textValue(),
+                storedObject,
+                actorUserId,
+                now
+        );
+
+        try {
+            contentVersionMapper.insert(contentVersion);
+            auditLogMapper.insert(
+                    actorUserId,
+                    "CREATE",
+                    AUDIT_ENTITY_TYPE,
+                    contentVersion.getContentVersionId(),
+                    null,
+                    snapshot(contentVersion),
+                    requestId,
+                    now
+            );
+        } catch (DuplicateKeyException exception) {
+            logOrphanedStorageVersion(
+                    storedObject,
+                    subChapterId,
+                    versionNo,
+                    requestId,
+                    exception
+            );
+            throw new ApiException(
+                    ErrorCode.CONTENT_VERSION_CONFLICT,
+                    ErrorCode.CONTENT_VERSION_CONFLICT.getDefaultMessage(),
+                    exception
+            );
+        } catch (RuntimeException exception) {
+            logOrphanedStorageVersion(
+                    storedObject,
+                    subChapterId,
+                    versionNo,
+                    requestId,
+                    exception
+            );
+            throw exception;
+        }
+        return contentVersion;
+    }
+
+    private void requireRequest(LessonContentUploadRequest request) {
+        if (request == null || request.versionNo() == null || request.versionNo() <= 0) {
+            throw new ApiException(
+                    ErrorCode.INVALID_REQUEST,
+                    "version_no는 1 이상의 정수여야 합니다."
+            );
+        }
+        if (request.lesson() == null || !request.lesson().isObject()) {
+            throw new ApiException(
+                    ErrorCode.INVALID_REQUEST,
+                    "lesson은 JSON 객체여야 합니다."
+            );
+        }
+    }
+
+    private void requireValidContent(LessonValidationResult result) {
+        if (result.isValid()) {
+            return;
+        }
+
+        LessonValidationError firstError = result.errors().get(0);
+        if (firstError.code() == LessonValidationErrorCode.SUB_CHAPTER_NOT_FOUND) {
+            throw new ApiException(ErrorCode.SUB_CHAPTER_NOT_FOUND);
+        }
+
+        String location = firstError.path().isBlank()
+                ? ""
+                : " (" + firstError.path() + ")";
+        throw new ApiException(
+                ErrorCode.CONTENT_VALIDATION_FAILED,
+                ErrorCode.CONTENT_VALIDATION_FAILED.getDefaultMessage()
+                        + location + " " + firstError.message()
+        );
+    }
+
+    private String lessonObjectKey(long subChapterId) {
+        return "learning/sub-chapters/" + subChapterId + "/lesson.json";
+    }
+
+    private String snapshot(ContentVersion version) {
+        Map<String, Object> snapshot = new LinkedHashMap<>();
+        snapshot.put("content_version_id", version.getContentVersionId());
+        snapshot.put("sub_chapter_id", version.getSubChapterId());
+        snapshot.put("version_no", version.getVersionNo());
+        snapshot.put("schema_version", version.getSchemaVersion());
+        snapshot.put("storage_object_key", version.getStorageObjectKey());
+        snapshot.put("storage_version_id", version.getStorageVersionId());
+        snapshot.put("status", version.getStatus());
+        snapshot.put("created_by", version.getCreatedBy());
+        snapshot.put("created_at", version.getCreatedAt());
+
+        try {
+            return auditObjectMapper.writeValueAsString(snapshot);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("콘텐츠 버전 감사 이력을 직렬화할 수 없습니다.", exception);
+        }
+    }
+
+    private void logOrphanedStorageVersion(
+            StoredObjectRef storedObject,
+            long subChapterId,
+            int versionNo,
+            String requestId,
+            RuntimeException exception
+    ) {
+        log.error(
+                "콘텐츠 DB 등록 실패로 저장소 버전 정리 필요 objectKey={} "
+                        + "storageVersionId={} subChapterId={} versionNo={} requestId={}",
+                storedObject.objectKey(),
+                storedObject.versionId(),
+                subChapterId,
+                versionNo,
+                requestId,
+                exception
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/exception/ErrorCode.java
+++ b/src/main/java/org/firstfolio/exception/ErrorCode.java
@@ -27,6 +27,10 @@ public enum ErrorCode {
     SUB_CHAPTER_ORDER_CONFLICT(HttpStatus.CONFLICT, "같은 순서의 소단원이 이미 존재합니다."),
     FOUNDATION_CONFLICT(HttpStatus.CONFLICT, "활성 포트폴리오 기초 과정이 이미 존재합니다."),
 
+    // 강좌 콘텐츠 버전
+    CONTENT_VERSION_CONFLICT(HttpStatus.CONFLICT, "같은 소단원 콘텐츠 버전이 이미 존재합니다."),
+    CONTENT_VALIDATION_FAILED(HttpStatus.UNPROCESSABLE_ENTITY, "강좌 콘텐츠 검증에 실패했습니다."),
+
     // 포트폴리오 (FUNC-033, 034, 036)
     PORTFOLIO_ALREADY_CONFIGURED(HttpStatus.CONFLICT, "이미 최초 포트폴리오를 구성했습니다."),
     INSUFFICIENT_SIMULATION_CASH(HttpStatus.UNPROCESSABLE_ENTITY, "사용 가능한 모의 현금이 부족합니다."),

--- a/src/main/resources/mappers/content/ContentVersionMapper.xml
+++ b/src/main/resources/mappers/content/ContentVersionMapper.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.firstfolio.content.mapper.ContentVersionMapper">
+
+    <resultMap id="contentVersionResultMap"
+               type="org.firstfolio.content.domain.ContentVersion">
+        <id property="contentVersionId" column="content_version_id" />
+        <result property="subChapterId" column="sub_chapter_id" />
+        <result property="versionNo" column="version_no" />
+        <result property="schemaVersion" column="schema_version" />
+        <result property="storageObjectKey" column="storage_object_key" />
+        <result property="storageVersionId" column="storage_version_id" />
+        <result property="status" column="status" />
+        <result property="publishedAt" column="published_at" />
+        <result property="createdBy" column="created_by" />
+        <result property="createdAt" column="created_at" />
+    </resultMap>
+
+    <select id="countBySubChapterIdAndVersionNo" resultType="int">
+        SELECT COUNT(*)
+        FROM content_versions
+        WHERE sub_chapter_id = #{subChapterId}
+          AND version_no = #{versionNo}
+    </select>
+
+    <insert id="insert"
+            parameterType="org.firstfolio.content.domain.ContentVersion"
+            useGeneratedKeys="true"
+            keyProperty="contentVersionId"
+            keyColumn="content_version_id">
+        INSERT INTO content_versions (
+            sub_chapter_id,
+            version_no,
+            schema_version,
+            storage_object_key,
+            storage_version_id,
+            status,
+            published_at,
+            created_by,
+            created_at
+        ) VALUES (
+            #{subChapterId},
+            #{versionNo},
+            #{schemaVersion},
+            #{storageObjectKey},
+            #{storageVersionId},
+            #{status},
+            #{publishedAt,jdbcType=TIMESTAMP},
+            #{createdBy},
+            #{createdAt}
+        )
+    </insert>
+
+</mapper>

--- a/src/test/java/org/firstfolio/content/controller/AdminContentVersionControllerTest.java
+++ b/src/test/java/org/firstfolio/content/controller/AdminContentVersionControllerTest.java
@@ -1,0 +1,160 @@
+package org.firstfolio.content.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.firstfolio.auth.domain.AuthenticatedUser;
+import org.firstfolio.auth.web.AuthenticationRequestAttributes;
+import org.firstfolio.auth.web.CurrentUserArgumentResolver;
+import org.firstfolio.common.json.ApiObjectMapperFactory;
+import org.firstfolio.common.web.RequestIdFilter;
+import org.firstfolio.content.domain.ContentVersion;
+import org.firstfolio.content.domain.StoredObjectRef;
+import org.firstfolio.content.dto.request.LessonContentUploadRequest;
+import org.firstfolio.content.service.ContentVersionService;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.CommonExceptionAdvice;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.user.domain.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class AdminContentVersionControllerTest {
+
+    private static final AuthenticatedUser ADMIN = new AuthenticatedUser(
+            900L,
+            "firebase-admin",
+            "관리자",
+            UserRole.ADMIN
+    );
+
+    private ContentVersionService service;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        service = mock(ContentVersionService.class);
+        MappingJackson2HttpMessageConverter converter =
+                new MappingJackson2HttpMessageConverter(ApiObjectMapperFactory.create());
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new AdminContentVersionController(service))
+                .setControllerAdvice(new CommonExceptionAdvice())
+                .setCustomArgumentResolvers(new CurrentUserArgumentResolver())
+                .setMessageConverters(converter)
+                .addFilter(new RequestIdFilter())
+                .build();
+    }
+
+    @Test
+    void uploadsLessonAndReturnsDraftMetadata() throws Exception {
+        when(service.uploadLesson(eq(103L), any(), eq(900L), anyString()))
+                .thenReturn(contentVersion());
+
+        mockMvc.perform(post("/api/admin/sub-chapters/103/content-versions")
+                        .requestAttr(AuthenticationRequestAttributes.CURRENT_USER, ADMIN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody()))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.content_version_id").value(302))
+                .andExpect(jsonPath("$.data.sub_chapter_id").value(103))
+                .andExpect(jsonPath("$.data.version_no").value(2))
+                .andExpect(jsonPath("$.data.schema_version").value("1.0"))
+                .andExpect(jsonPath("$.data.status").value("DRAFT"))
+                .andExpect(jsonPath("$.data.validated").value(true))
+                .andExpect(jsonPath("$.data.storage_object_key").doesNotExist())
+                .andExpect(jsonPath("$.data.storage_version_id").doesNotExist());
+
+        ArgumentCaptor<LessonContentUploadRequest> request =
+                ArgumentCaptor.forClass(LessonContentUploadRequest.class);
+        verify(service).uploadLesson(eq(103L), request.capture(), eq(900L), anyString());
+        assertEquals(2, request.getValue().versionNo());
+        assertEquals("1.0", request.getValue().lesson().path("schemaVersion").textValue());
+        assertTrue(request.getValue().lesson().path("pages").isArray());
+    }
+
+    @Test
+    void rejectsLegacyStorageReferenceRequestFields() throws Exception {
+        mockMvc.perform(post("/api/admin/sub-chapters/103/content-versions")
+                        .requestAttr(AuthenticationRequestAttributes.CURRENT_USER, ADMIN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "version_no": 2,
+                                  "schema_version": "1.0",
+                                  "s3_object_key": "learning/old.json",
+                                  "s3_version_id": "old-version"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("INVALID_REQUEST"));
+    }
+
+    @Test
+    void returnsContentValidationFailureFromService() throws Exception {
+        when(service.uploadLesson(eq(103L), any(), eq(900L), anyString()))
+                .thenThrow(new ApiException(ErrorCode.CONTENT_VALIDATION_FAILED));
+
+        mockMvc.perform(post("/api/admin/sub-chapters/103/content-versions")
+                        .requestAttr(AuthenticationRequestAttributes.CURRENT_USER, ADMIN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody()))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.error.code")
+                        .value("CONTENT_VALIDATION_FAILED"));
+    }
+
+    private ContentVersion contentVersion() {
+        ContentVersion version = ContentVersion.draft(
+                103L,
+                2,
+                "1.0",
+                new StoredObjectRef(
+                        "learning/sub-chapters/103/lesson.json",
+                        "storage-version-1"
+                ),
+                900L,
+                LocalDateTime.of(2026, 8, 7, 1, 0)
+        );
+        version.setContentVersionId(302L);
+        return version;
+    }
+
+    private String requestBody() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(mapper.readTree("""
+                {
+                  "version_no": 2,
+                  "lesson": {
+                    "schemaVersion": "1.0",
+                    "pages": [
+                      {
+                        "id": "interest-rate",
+                        "title": "금리",
+                        "blocks": [
+                          {"type": "text", "content": "금리를 알아봅니다."}
+                        ]
+                      }
+                    ],
+                    "subChapterQuiz": {"questionIds": [1021]}
+                  }
+                }
+                """));
+    }
+}

--- a/src/test/java/org/firstfolio/content/mapper/ContentVersionMapperXmlTest.java
+++ b/src/test/java/org/firstfolio/content/mapper/ContentVersionMapperXmlTest.java
@@ -1,0 +1,39 @@
+package org.firstfolio.content.mapper;
+
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ContentVersionMapperXmlTest {
+
+    private static final String RESOURCE = "mappers/content/ContentVersionMapper.xml";
+
+    @Test
+    void parsesMapperAndRegistersContentVersionStatements() throws IOException {
+        Configuration configuration = new Configuration();
+
+        try (InputStream input = Resources.getResourceAsStream(RESOURCE)) {
+            XMLMapperBuilder builder = new XMLMapperBuilder(
+                    input,
+                    configuration,
+                    RESOURCE,
+                    configuration.getSqlFragments()
+            );
+            builder.parse();
+        }
+
+        assertTrue(configuration.hasMapper(ContentVersionMapper.class));
+        assertTrue(configuration.hasStatement(
+                ContentVersionMapper.class.getName() + ".countBySubChapterIdAndVersionNo"
+        ));
+        assertTrue(configuration.hasStatement(
+                ContentVersionMapper.class.getName() + ".insert"
+        ));
+    }
+}

--- a/src/test/java/org/firstfolio/content/service/ContentVersionLocalStorageIntegrationTest.java
+++ b/src/test/java/org/firstfolio/content/service/ContentVersionLocalStorageIntegrationTest.java
@@ -1,0 +1,120 @@
+package org.firstfolio.content.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.firstfolio.content.domain.ContentVersion;
+import org.firstfolio.content.domain.StoredContent;
+import org.firstfolio.content.domain.StoredObjectRef;
+import org.firstfolio.content.dto.request.LessonContentUploadRequest;
+import org.firstfolio.content.mapper.ContentVersionMapper;
+import org.firstfolio.content.storage.LocalContentStorage;
+import org.firstfolio.content.validation.LessonContentValidationService;
+import org.firstfolio.content.validation.LessonSchemaValidator;
+import org.firstfolio.curriculum.domain.SubChapter;
+import org.firstfolio.curriculum.mapper.AdminAuditLogMapper;
+import org.firstfolio.curriculum.mapper.SubChapterMapper;
+import org.firstfolio.quiz.domain.QuizQuestionReference;
+import org.firstfolio.quiz.domain.QuizQuestionStatus;
+import org.firstfolio.quiz.domain.QuizUsageType;
+import org.firstfolio.quiz.mapper.QuizQuestionMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ContentVersionLocalStorageIntegrationTest {
+
+    private static final long SUB_CHAPTER_ID = 103L;
+    private static final String VALID_LESSON_RESOURCE =
+            "content/lesson/valid-lesson-1.0.json";
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void uploadsValidatedLessonAndLoadsRegisteredLocalVersion() throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode lesson = readLesson(objectMapper);
+        SubChapterMapper subChapterMapper = mock(SubChapterMapper.class);
+        QuizQuestionMapper quizQuestionMapper = mock(QuizQuestionMapper.class);
+        ContentVersionMapper contentVersionMapper = mock(ContentVersionMapper.class);
+        AdminAuditLogMapper auditLogMapper = mock(AdminAuditLogMapper.class);
+
+        SubChapter subChapter = new SubChapter();
+        subChapter.setSubChapterId(SUB_CHAPTER_ID);
+        when(subChapterMapper.findById(SUB_CHAPTER_ID)).thenReturn(subChapter);
+        when(quizQuestionMapper.findReferencesByIds(List.of(1021L, 1022L, 1023L)))
+                .thenReturn(List.of(
+                        publishedQuestion(1021L),
+                        publishedQuestion(1022L),
+                        publishedQuestion(1023L)
+                ));
+        doAnswer(invocation -> {
+            ContentVersion version = invocation.getArgument(0);
+            version.setContentVersionId(302L);
+            return 1;
+        }).when(contentVersionMapper).insert(any(ContentVersion.class));
+
+        LocalContentStorage storage = new LocalContentStorage(
+                temporaryDirectory.resolve("content"),
+                5L * 1024L * 1024L
+        );
+        LessonContentValidationService validationService =
+                new LessonContentValidationService(
+                        new LessonSchemaValidator(),
+                        subChapterMapper,
+                        quizQuestionMapper
+                );
+        ContentVersionService service = new ContentVersionService(
+                validationService,
+                storage,
+                contentVersionMapper,
+                auditLogMapper,
+                Clock.systemUTC()
+        );
+
+        ContentVersion version = service.uploadLesson(
+                SUB_CHAPTER_ID,
+                new LessonContentUploadRequest(1, lesson),
+                900L,
+                "req-local-upload"
+        );
+        StoredContent stored = storage.load(new StoredObjectRef(
+                version.getStorageObjectKey(),
+                version.getStorageVersionId()
+        ));
+
+        assertEquals("application/json", stored.contentType());
+        assertEquals(lesson, objectMapper.readTree(stored.content()));
+        assertEquals(302L, version.getContentVersionId());
+    }
+
+    private JsonNode readLesson(ObjectMapper objectMapper) throws IOException {
+        try (InputStream inputStream = getClass().getClassLoader()
+                .getResourceAsStream(VALID_LESSON_RESOURCE)) {
+            if (inputStream == null) {
+                throw new IllegalStateException("테스트 강좌 JSON을 찾을 수 없습니다.");
+            }
+            return objectMapper.readTree(inputStream);
+        }
+    }
+
+    private QuizQuestionReference publishedQuestion(long questionId) {
+        return new QuizQuestionReference(
+                questionId,
+                QuizUsageType.SUB_CHAPTER,
+                SUB_CHAPTER_ID,
+                QuizQuestionStatus.PUBLISHED
+        );
+    }
+}

--- a/src/test/java/org/firstfolio/content/service/ContentVersionServiceTest.java
+++ b/src/test/java/org/firstfolio/content/service/ContentVersionServiceTest.java
@@ -1,0 +1,264 @@
+package org.firstfolio.content.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.firstfolio.content.domain.ContentVersion;
+import org.firstfolio.content.domain.ContentVersionStatus;
+import org.firstfolio.content.domain.ContentWriteRequest;
+import org.firstfolio.content.domain.StoredObjectRef;
+import org.firstfolio.content.dto.request.LessonContentUploadRequest;
+import org.firstfolio.content.mapper.ContentVersionMapper;
+import org.firstfolio.content.validation.LessonContentValidationService;
+import org.firstfolio.content.validation.LessonValidationError;
+import org.firstfolio.content.validation.LessonValidationErrorCode;
+import org.firstfolio.content.validation.LessonValidationResult;
+import org.firstfolio.curriculum.mapper.AdminAuditLogMapper;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.dao.DuplicateKeyException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ContentVersionServiceTest {
+
+    private static final long SUB_CHAPTER_ID = 103L;
+    private static final long ACTOR_ID = 900L;
+    private static final String REQUEST_ID = "req-content-upload";
+    private static final String OBJECT_KEY =
+            "learning/sub-chapters/103/lesson.json";
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 8, 7, 1, 0);
+    private static final String VALID_LESSON_RESOURCE =
+            "content/lesson/valid-lesson-1.0.json";
+
+    private LessonContentValidationService validationService;
+    private StaticContentStorage contentStorage;
+    private ContentVersionMapper contentVersionMapper;
+    private AdminAuditLogMapper auditLogMapper;
+    private ContentVersionService service;
+
+    @BeforeEach
+    void setUp() {
+        validationService = mock(LessonContentValidationService.class);
+        contentStorage = mock(StaticContentStorage.class);
+        contentVersionMapper = mock(ContentVersionMapper.class);
+        auditLogMapper = mock(AdminAuditLogMapper.class);
+        service = new ContentVersionService(
+                validationService,
+                contentStorage,
+                contentVersionMapper,
+                auditLogMapper,
+                Clock.fixed(Instant.parse("2026-08-07T01:00:00Z"), ZoneOffset.UTC)
+        );
+    }
+
+    @Test
+    void validatesStoresAndRegistersDraftContentVersion() throws IOException {
+        LessonContentUploadRequest request = uploadRequest();
+        byte[] expectedContent = request.lesson().toString()
+                .getBytes(StandardCharsets.UTF_8);
+        when(validationService.validate(eq(SUB_CHAPTER_ID), any()))
+                .thenReturn(LessonValidationResult.valid());
+        when(contentStorage.store(any())).thenReturn(new StoredObjectRef(
+                OBJECT_KEY,
+                "storage-version-1"
+        ));
+        doAnswer(invocation -> {
+            ContentVersion version = invocation.getArgument(0);
+            version.setContentVersionId(302L);
+            return 1;
+        }).when(contentVersionMapper).insert(any(ContentVersion.class));
+
+        ContentVersion created = service.uploadLesson(
+                SUB_CHAPTER_ID,
+                request,
+                ACTOR_ID,
+                REQUEST_ID
+        );
+
+        assertEquals(302L, created.getContentVersionId());
+        assertEquals(SUB_CHAPTER_ID, created.getSubChapterId());
+        assertEquals(2, created.getVersionNo());
+        assertEquals("1.0", created.getSchemaVersion());
+        assertEquals(OBJECT_KEY, created.getStorageObjectKey());
+        assertEquals("storage-version-1", created.getStorageVersionId());
+        assertEquals(ContentVersionStatus.DRAFT, created.getStatus());
+        assertNull(created.getPublishedAt());
+        assertEquals(ACTOR_ID, created.getCreatedBy());
+        assertEquals(NOW, created.getCreatedAt());
+
+        ArgumentCaptor<ContentWriteRequest> storageRequest =
+                ArgumentCaptor.forClass(ContentWriteRequest.class);
+        verify(contentStorage).store(storageRequest.capture());
+        assertEquals(OBJECT_KEY, storageRequest.getValue().objectKey());
+        assertEquals("application/json", storageRequest.getValue().contentType());
+        assertArrayEquals(expectedContent, storageRequest.getValue().content());
+        verify(auditLogMapper).insert(
+                eq(ACTOR_ID),
+                eq("CREATE"),
+                eq("CONTENT_VERSION"),
+                eq(302L),
+                isNull(),
+                anyString(),
+                eq(REQUEST_ID),
+                eq(NOW)
+        );
+    }
+
+    @Test
+    void rejectsSchemaOrQuestionValidationFailureBeforeStorage() throws IOException {
+        when(validationService.validate(eq(SUB_CHAPTER_ID), any()))
+                .thenReturn(LessonValidationResult.invalid(new LessonValidationError(
+                        LessonValidationErrorCode.QUESTION_NOT_PUBLISHED,
+                        "/subChapterQuiz/questionIds/0",
+                        "게시 상태가 아닌 퀴즈 문항입니다: 1021"
+                )));
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.uploadLesson(
+                        SUB_CHAPTER_ID,
+                        uploadRequest(),
+                        ACTOR_ID,
+                        REQUEST_ID
+                )
+        );
+
+        assertEquals(ErrorCode.CONTENT_VALIDATION_FAILED, exception.getErrorCode());
+        verify(contentStorage, never()).store(any());
+        verify(contentVersionMapper, never()).insert(any());
+    }
+
+    @Test
+    void mapsMissingTargetSubChapterToNotFound() throws IOException {
+        when(validationService.validate(eq(SUB_CHAPTER_ID), any()))
+                .thenReturn(LessonValidationResult.invalid(new LessonValidationError(
+                        LessonValidationErrorCode.SUB_CHAPTER_NOT_FOUND,
+                        "/subChapterId",
+                        "소단원이 없습니다."
+                )));
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.uploadLesson(
+                        SUB_CHAPTER_ID,
+                        uploadRequest(),
+                        ACTOR_ID,
+                        REQUEST_ID
+                )
+        );
+
+        assertEquals(ErrorCode.SUB_CHAPTER_NOT_FOUND, exception.getErrorCode());
+        verify(contentStorage, never()).store(any());
+    }
+
+    @Test
+    void rejectsExistingVersionNumberBeforeStorage() throws IOException {
+        when(validationService.validate(eq(SUB_CHAPTER_ID), any()))
+                .thenReturn(LessonValidationResult.valid());
+        when(contentVersionMapper.countBySubChapterIdAndVersionNo(SUB_CHAPTER_ID, 2))
+                .thenReturn(1);
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.uploadLesson(
+                        SUB_CHAPTER_ID,
+                        uploadRequest(),
+                        ACTOR_ID,
+                        REQUEST_ID
+                )
+        );
+
+        assertEquals(ErrorCode.CONTENT_VERSION_CONFLICT, exception.getErrorCode());
+        verify(contentStorage, never()).store(any());
+    }
+
+    @Test
+    void mapsConcurrentVersionInsertConflictAfterStorage() throws IOException {
+        when(validationService.validate(eq(SUB_CHAPTER_ID), any()))
+                .thenReturn(LessonValidationResult.valid());
+        when(contentStorage.store(any())).thenReturn(new StoredObjectRef(
+                OBJECT_KEY,
+                "orphaned-storage-version"
+        ));
+        doThrow(new DuplicateKeyException("duplicate"))
+                .when(contentVersionMapper).insert(any(ContentVersion.class));
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.uploadLesson(
+                        SUB_CHAPTER_ID,
+                        uploadRequest(),
+                        ACTOR_ID,
+                        REQUEST_ID
+                )
+        );
+
+        assertEquals(ErrorCode.CONTENT_VERSION_CONFLICT, exception.getErrorCode());
+        verify(contentStorage).store(any());
+        verify(auditLogMapper, never()).insert(
+                anyLong(), anyString(), anyString(), any(), any(), any(), any(), any()
+        );
+    }
+
+    @Test
+    void rejectsMissingVersionOrLessonBeforeValidation() {
+        ApiException missingVersion = assertThrows(
+                ApiException.class,
+                () -> service.uploadLesson(
+                        SUB_CHAPTER_ID,
+                        new LessonContentUploadRequest(null, new ObjectMapper().createObjectNode()),
+                        ACTOR_ID,
+                        REQUEST_ID
+                )
+        );
+        ApiException missingLesson = assertThrows(
+                ApiException.class,
+                () -> service.uploadLesson(
+                        SUB_CHAPTER_ID,
+                        new LessonContentUploadRequest(1, null),
+                        ACTOR_ID,
+                        REQUEST_ID
+                )
+        );
+
+        assertEquals(ErrorCode.INVALID_REQUEST, missingVersion.getErrorCode());
+        assertEquals(ErrorCode.INVALID_REQUEST, missingLesson.getErrorCode());
+        verify(validationService, never()).validate(anyLong(), any());
+    }
+
+    private LessonContentUploadRequest uploadRequest() throws IOException {
+        try (InputStream inputStream = getClass().getClassLoader()
+                .getResourceAsStream(VALID_LESSON_RESOURCE)) {
+            if (inputStream == null) {
+                throw new IllegalStateException("테스트 강좌 JSON을 찾을 수 없습니다.");
+            }
+            JsonNode lesson = new ObjectMapper().readTree(inputStream);
+            return new LessonContentUploadRequest(2, lesson);
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용

- 관리자용 강좌 콘텐츠 업로드 API 구현
- 강좌 JSON Schema 및 DB 참조 검증 연결
- 로컬/S3 공통 저장소를 통한 콘텐츠 업로드 구현
- `content_versions` 버전 메타데이터 및 관리자 감사 이력 등록
- 버전 번호 중복 및 콘텐츠 검증 오류 처리
- 컨트롤러·서비스·로컬 저장소 연동·Mapper 테스트 작성
- 강좌 콘텐츠 업로드 API 명세 최신화

## API

`POST /api/admin/sub-chapters/{subChapterId}/content-versions`

업로드된 콘텐츠는 다음 객체 키로 저장됩니다.

`learning/sub-chapters/{subChapterId}/lesson.json`

신규 콘텐츠 버전은 `DRAFT` 상태로 등록됩니다.

## 참고 사항

저장소 업로드 후 DB 등록에 실패하면 해당 저장소 버전을 정리 대상으로 로그에 기록합니다.

## 테스트

- `./gradlew clean test`
- 전체 테스트 통과