### PR TITLE
feat: 강좌 콘텐츠 공개 및 버전 관리 #36

### DIFF
--- a/src/main/java/org/firstfolio/content/controller/AdminContentVersionController.java
+++ b/src/main/java/org/firstfolio/content/controller/AdminContentVersionController.java
@@ -6,9 +6,12 @@ import org.firstfolio.common.response.ApiResponse;
 import org.firstfolio.common.web.RequestIdFilter;
 import org.firstfolio.content.dto.request.LessonContentUploadRequest;
 import org.firstfolio.content.dto.response.ContentVersionCreateResponse;
+import org.firstfolio.content.dto.response.ContentVersionListResponse;
+import org.firstfolio.content.dto.response.ContentVersionPublishResponse;
 import org.firstfolio.content.service.ContentVersionService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 import javax.servlet.http.HttpServletRequest;
 
 @RestController
-@RequestMapping("/api/admin/sub-chapters")
+@RequestMapping("/api/admin")
 public class AdminContentVersionController {
 
     private final ContentVersionService contentVersionService;
@@ -29,7 +32,16 @@ public class AdminContentVersionController {
         this.contentVersionService = contentVersionService;
     }
 
-    @PostMapping("/{subChapterId}/content-versions")
+    @GetMapping("/sub-chapters/{subChapterId}/content-versions")
+    public ApiResponse<ContentVersionListResponse> getContentVersions(
+            @PathVariable long subChapterId
+    ) {
+        return ApiResponse.of(ContentVersionListResponse.from(
+                contentVersionService.getContentVersions(subChapterId)
+        ));
+    }
+
+    @PostMapping("/sub-chapters/{subChapterId}/content-versions")
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<ContentVersionCreateResponse> uploadLesson(
             @PathVariable long subChapterId,
@@ -41,6 +53,21 @@ public class AdminContentVersionController {
                 contentVersionService.uploadLesson(
                         subChapterId,
                         request,
+                        currentUser.userId(),
+                        RequestIdFilter.currentRequestId(servletRequest)
+                )
+        ));
+    }
+
+    @PostMapping("/content-versions/{contentVersionId}/publish")
+    public ApiResponse<ContentVersionPublishResponse> publishContentVersion(
+            @PathVariable long contentVersionId,
+            @CurrentUser AuthenticatedUser currentUser,
+            HttpServletRequest servletRequest
+    ) {
+        return ApiResponse.of(ContentVersionPublishResponse.from(
+                contentVersionService.publishContentVersion(
+                        contentVersionId,
                         currentUser.userId(),
                         RequestIdFilter.currentRequestId(servletRequest)
                 )

--- a/src/main/java/org/firstfolio/content/domain/ContentVersion.java
+++ b/src/main/java/org/firstfolio/content/domain/ContentVersion.java
@@ -38,6 +38,15 @@ public class ContentVersion {
         return version;
     }
 
+    public void publish(LocalDateTime publishedAt) {
+        this.status = ContentVersionStatus.PUBLISHED;
+        this.publishedAt = publishedAt;
+    }
+
+    public void retire() {
+        this.status = ContentVersionStatus.RETIRED;
+    }
+
     public Long getContentVersionId() {
         return contentVersionId;
     }

--- a/src/main/java/org/firstfolio/content/domain/ContentVersionHistory.java
+++ b/src/main/java/org/firstfolio/content/domain/ContentVersionHistory.java
@@ -1,0 +1,12 @@
+package org.firstfolio.content.domain;
+
+import java.util.List;
+
+public record ContentVersionHistory(
+        List<ContentVersion> versions,
+        Long currentContentVersionId
+) {
+    public ContentVersionHistory {
+        versions = List.copyOf(versions);
+    }
+}

--- a/src/main/java/org/firstfolio/content/dto/response/ContentVersionListItemResponse.java
+++ b/src/main/java/org/firstfolio/content/dto/response/ContentVersionListItemResponse.java
@@ -1,0 +1,35 @@
+package org.firstfolio.content.dto.response;
+
+import org.firstfolio.content.domain.ContentVersion;
+import org.firstfolio.content.domain.ContentVersionStatus;
+
+import java.time.LocalDateTime;
+
+public record ContentVersionListItemResponse(
+        long contentVersionId,
+        long subChapterId,
+        int versionNo,
+        String schemaVersion,
+        ContentVersionStatus status,
+        LocalDateTime publishedAt,
+        long createdBy,
+        LocalDateTime createdAt,
+        boolean current
+) {
+    public static ContentVersionListItemResponse from(
+            ContentVersion version,
+            Long currentContentVersionId
+    ) {
+        return new ContentVersionListItemResponse(
+                version.getContentVersionId(),
+                version.getSubChapterId(),
+                version.getVersionNo(),
+                version.getSchemaVersion(),
+                version.getStatus(),
+                version.getPublishedAt(),
+                version.getCreatedBy(),
+                version.getCreatedAt(),
+                version.getContentVersionId().equals(currentContentVersionId)
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/content/dto/response/ContentVersionListResponse.java
+++ b/src/main/java/org/firstfolio/content/dto/response/ContentVersionListResponse.java
@@ -1,0 +1,20 @@
+package org.firstfolio.content.dto.response;
+
+import org.firstfolio.content.domain.ContentVersionHistory;
+
+import java.util.List;
+
+public record ContentVersionListResponse(
+        List<ContentVersionListItemResponse> items
+) {
+    public static ContentVersionListResponse from(ContentVersionHistory history) {
+        return new ContentVersionListResponse(
+                history.versions().stream()
+                        .map(version -> ContentVersionListItemResponse.from(
+                                version,
+                                history.currentContentVersionId()
+                        ))
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/content/dto/response/ContentVersionPublishResponse.java
+++ b/src/main/java/org/firstfolio/content/dto/response/ContentVersionPublishResponse.java
@@ -1,0 +1,24 @@
+package org.firstfolio.content.dto.response;
+
+import org.firstfolio.content.domain.ContentVersion;
+import org.firstfolio.content.domain.ContentVersionStatus;
+
+import java.time.LocalDateTime;
+
+public record ContentVersionPublishResponse(
+        long contentVersionId,
+        ContentVersionStatus status,
+        LocalDateTime publishedAt,
+        long subChapterId,
+        boolean current
+) {
+    public static ContentVersionPublishResponse from(ContentVersion version) {
+        return new ContentVersionPublishResponse(
+                version.getContentVersionId(),
+                version.getStatus(),
+                version.getPublishedAt(),
+                version.getSubChapterId(),
+                true
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/content/mapper/ContentVersionMapper.java
+++ b/src/main/java/org/firstfolio/content/mapper/ContentVersionMapper.java
@@ -4,8 +4,21 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.firstfolio.content.domain.ContentVersion;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Mapper
 public interface ContentVersionMapper {
+
+    List<ContentVersion> findAllBySubChapterId(
+            @Param("subChapterId") long subChapterId
+    );
+
+    ContentVersion findById(@Param("contentVersionId") long contentVersionId);
+
+    ContentVersion findByIdForUpdate(
+            @Param("contentVersionId") long contentVersionId
+    );
 
     int countBySubChapterIdAndVersionNo(
             @Param("subChapterId") long subChapterId,
@@ -13,4 +26,11 @@ public interface ContentVersionMapper {
     );
 
     int insert(ContentVersion contentVersion);
+
+    int publishDraft(
+            @Param("contentVersionId") long contentVersionId,
+            @Param("publishedAt") LocalDateTime publishedAt
+    );
+
+    int retirePublished(@Param("contentVersionId") long contentVersionId);
 }

--- a/src/main/java/org/firstfolio/content/service/ContentVersionService.java
+++ b/src/main/java/org/firstfolio/content/service/ContentVersionService.java
@@ -6,6 +6,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.firstfolio.common.json.ApiObjectMapperFactory;
 import org.firstfolio.content.domain.ContentVersion;
+import org.firstfolio.content.domain.ContentVersionHistory;
+import org.firstfolio.content.domain.ContentVersionStatus;
 import org.firstfolio.content.domain.ContentWriteRequest;
 import org.firstfolio.content.domain.StoredObjectRef;
 import org.firstfolio.content.dto.request.LessonContentUploadRequest;
@@ -15,6 +17,8 @@ import org.firstfolio.content.validation.LessonValidationError;
 import org.firstfolio.content.validation.LessonValidationErrorCode;
 import org.firstfolio.content.validation.LessonValidationResult;
 import org.firstfolio.curriculum.mapper.AdminAuditLogMapper;
+import org.firstfolio.curriculum.domain.SubChapter;
+import org.firstfolio.curriculum.mapper.SubChapterMapper;
 import org.firstfolio.exception.ApiException;
 import org.firstfolio.exception.ErrorCode;
 import org.springframework.dao.DuplicateKeyException;
@@ -37,6 +41,7 @@ public class ContentVersionService {
     private final LessonContentValidationService validationService;
     private final StaticContentStorage contentStorage;
     private final ContentVersionMapper contentVersionMapper;
+    private final SubChapterMapper subChapterMapper;
     private final AdminAuditLogMapper auditLogMapper;
     private final Clock clock;
     private final ObjectMapper auditObjectMapper;
@@ -45,12 +50,14 @@ public class ContentVersionService {
             LessonContentValidationService validationService,
             StaticContentStorage contentStorage,
             ContentVersionMapper contentVersionMapper,
+            SubChapterMapper subChapterMapper,
             AdminAuditLogMapper auditLogMapper,
             Clock clock
     ) {
         this.validationService = validationService;
         this.contentStorage = contentStorage;
         this.contentVersionMapper = contentVersionMapper;
+        this.subChapterMapper = subChapterMapper;
         this.auditLogMapper = auditLogMapper;
         this.clock = clock;
         this.auditObjectMapper = ApiObjectMapperFactory.create();
@@ -136,6 +143,117 @@ public class ContentVersionService {
         return contentVersion;
     }
 
+    @Transactional(readOnly = true)
+    public ContentVersionHistory getContentVersions(long subChapterId) {
+        SubChapter subChapter = subChapterMapper.findById(subChapterId);
+        if (subChapter == null) {
+            throw new ApiException(ErrorCode.SUB_CHAPTER_NOT_FOUND);
+        }
+        return new ContentVersionHistory(
+                contentVersionMapper.findAllBySubChapterId(subChapterId),
+                subChapter.getCurrentContentVersionId()
+        );
+    }
+
+    @Transactional
+    public ContentVersion publishContentVersion(
+            long contentVersionId,
+            long actorUserId,
+            String requestId
+    ) {
+        ContentVersion reference = contentVersionMapper.findById(contentVersionId);
+        if (reference == null) {
+            throw new ApiException(ErrorCode.CONTENT_VERSION_NOT_FOUND);
+        }
+
+        SubChapter subChapter = subChapterMapper.findByIdForUpdate(
+                reference.getSubChapterId()
+        );
+        if (subChapter == null) {
+            throw new ApiException(ErrorCode.SUB_CHAPTER_NOT_FOUND);
+        }
+
+        ContentVersion target = contentVersionMapper.findByIdForUpdate(contentVersionId);
+        if (target == null) {
+            throw new ApiException(ErrorCode.CONTENT_VERSION_NOT_FOUND);
+        }
+        if (target.getStatus() != ContentVersionStatus.DRAFT) {
+            throw new ApiException(ErrorCode.CONTENT_NOT_PUBLISHABLE);
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        retireCurrentVersion(
+                subChapter,
+                target,
+                actorUserId,
+                requestId,
+                now
+        );
+
+        String beforePublish = snapshot(target);
+        if (contentVersionMapper.publishDraft(contentVersionId, now) != 1) {
+            throw new ApiException(ErrorCode.CONTENT_NOT_PUBLISHABLE);
+        }
+        target.publish(now);
+
+        if (subChapterMapper.updateCurrentContentVersion(
+                subChapter.getSubChapterId(),
+                contentVersionId,
+                now
+        ) != 1) {
+            throw new IllegalStateException("소단원의 현재 콘텐츠 버전을 변경하지 못했습니다.");
+        }
+
+        auditLogMapper.insert(
+                actorUserId,
+                "PUBLISH",
+                AUDIT_ENTITY_TYPE,
+                contentVersionId,
+                beforePublish,
+                snapshot(target),
+                requestId,
+                now
+        );
+        return target;
+    }
+
+    private void retireCurrentVersion(
+            SubChapter subChapter,
+            ContentVersion target,
+            long actorUserId,
+            String requestId,
+            LocalDateTime now
+    ) {
+        Long currentVersionId = subChapter.getCurrentContentVersionId();
+        if (currentVersionId == null
+                || currentVersionId.equals(target.getContentVersionId())) {
+            return;
+        }
+
+        ContentVersion current = contentVersionMapper.findByIdForUpdate(currentVersionId);
+        if (current == null
+                || current.getSubChapterId() != subChapter.getSubChapterId()
+                || current.getStatus() != ContentVersionStatus.PUBLISHED) {
+            throw new IllegalStateException("현재 공개 콘텐츠 버전 연결이 올바르지 않습니다.");
+        }
+
+        String beforeRetire = snapshot(current);
+        if (contentVersionMapper.retirePublished(currentVersionId) != 1) {
+            throw new IllegalStateException("기존 공개 콘텐츠 버전을 보관하지 못했습니다.");
+        }
+        current.retire();
+        auditLogMapper.insert(
+                actorUserId,
+                "RETIRE",
+                AUDIT_ENTITY_TYPE,
+                currentVersionId,
+                beforeRetire,
+                snapshot(current),
+                requestId,
+                now
+        );
+    }
+
     private void requireRequest(LessonContentUploadRequest request) {
         if (request == null || request.versionNo() == null || request.versionNo() <= 0) {
             throw new ApiException(
@@ -184,6 +302,7 @@ public class ContentVersionService {
         snapshot.put("storage_object_key", version.getStorageObjectKey());
         snapshot.put("storage_version_id", version.getStorageVersionId());
         snapshot.put("status", version.getStatus());
+        snapshot.put("published_at", version.getPublishedAt());
         snapshot.put("created_by", version.getCreatedBy());
         snapshot.put("created_at", version.getCreatedAt());
 

--- a/src/main/java/org/firstfolio/curriculum/mapper/SubChapterMapper.java
+++ b/src/main/java/org/firstfolio/curriculum/mapper/SubChapterMapper.java
@@ -16,6 +16,8 @@ public interface SubChapterMapper {
 
     SubChapter findById(@Param("subChapterId") long subChapterId);
 
+    SubChapter findByIdForUpdate(@Param("subChapterId") long subChapterId);
+
     int countDisplayOrderConflict(
             @Param("mainChapterId") long mainChapterId,
             @Param("displayOrder") int displayOrder,
@@ -30,6 +32,12 @@ public interface SubChapterMapper {
             @Param("description") String description,
             @Param("displayOrder") int displayOrder,
             @Param("active") boolean active,
+            @Param("updatedAt") LocalDateTime updatedAt
+    );
+
+    int updateCurrentContentVersion(
+            @Param("subChapterId") long subChapterId,
+            @Param("contentVersionId") long contentVersionId,
             @Param("updatedAt") LocalDateTime updatedAt
     );
 }

--- a/src/main/java/org/firstfolio/exception/ErrorCode.java
+++ b/src/main/java/org/firstfolio/exception/ErrorCode.java
@@ -28,7 +28,9 @@ public enum ErrorCode {
     FOUNDATION_CONFLICT(HttpStatus.CONFLICT, "활성 포트폴리오 기초 과정이 이미 존재합니다."),
 
     // 강좌 콘텐츠 버전
+    CONTENT_VERSION_NOT_FOUND(HttpStatus.NOT_FOUND, "강좌 콘텐츠 버전을 찾을 수 없습니다."),
     CONTENT_VERSION_CONFLICT(HttpStatus.CONFLICT, "같은 소단원 콘텐츠 버전이 이미 존재합니다."),
+    CONTENT_NOT_PUBLISHABLE(HttpStatus.CONFLICT, "공개할 수 없는 강좌 콘텐츠 버전입니다."),
     CONTENT_VALIDATION_FAILED(HttpStatus.UNPROCESSABLE_ENTITY, "강좌 콘텐츠 검증에 실패했습니다."),
 
     // 포트폴리오 (FUNC-033, 034, 036)

--- a/src/main/resources/mappers/content/ContentVersionMapper.xml
+++ b/src/main/resources/mappers/content/ContentVersionMapper.xml
@@ -19,6 +19,39 @@
         <result property="createdAt" column="created_at" />
     </resultMap>
 
+    <sql id="contentVersionColumns">
+        content_version_id,
+        sub_chapter_id,
+        version_no,
+        schema_version,
+        storage_object_key,
+        storage_version_id,
+        status,
+        published_at,
+        created_by,
+        created_at
+    </sql>
+
+    <select id="findAllBySubChapterId" resultMap="contentVersionResultMap">
+        SELECT <include refid="contentVersionColumns" />
+        FROM content_versions
+        WHERE sub_chapter_id = #{subChapterId}
+        ORDER BY version_no DESC, content_version_id DESC
+    </select>
+
+    <select id="findById" resultMap="contentVersionResultMap">
+        SELECT <include refid="contentVersionColumns" />
+        FROM content_versions
+        WHERE content_version_id = #{contentVersionId}
+    </select>
+
+    <select id="findByIdForUpdate" resultMap="contentVersionResultMap">
+        SELECT <include refid="contentVersionColumns" />
+        FROM content_versions
+        WHERE content_version_id = #{contentVersionId}
+        FOR UPDATE
+    </select>
+
     <select id="countBySubChapterIdAndVersionNo" resultType="int">
         SELECT COUNT(*)
         FROM content_versions
@@ -53,5 +86,20 @@
             #{createdAt}
         )
     </insert>
+
+    <update id="publishDraft">
+        UPDATE content_versions
+        SET status = 'PUBLISHED',
+            published_at = #{publishedAt}
+        WHERE content_version_id = #{contentVersionId}
+          AND status = 'DRAFT'
+    </update>
+
+    <update id="retirePublished">
+        UPDATE content_versions
+        SET status = 'RETIRED'
+        WHERE content_version_id = #{contentVersionId}
+          AND status = 'PUBLISHED'
+    </update>
 
 </mapper>

--- a/src/main/resources/mappers/curriculum/SubChapterMapper.xml
+++ b/src/main/resources/mappers/curriculum/SubChapterMapper.xml
@@ -43,6 +43,13 @@
         WHERE sub_chapter_id = #{subChapterId}
     </select>
 
+    <select id="findByIdForUpdate" resultMap="subChapterResultMap">
+        SELECT <include refid="subChapterColumns" />
+        FROM sub_chapters
+        WHERE sub_chapter_id = #{subChapterId}
+        FOR UPDATE
+    </select>
+
     <select id="countDisplayOrderConflict" resultType="int">
         SELECT COUNT(*)
         FROM sub_chapters
@@ -85,6 +92,13 @@
             description = #{description},
             display_order = #{displayOrder},
             is_active = #{active},
+            updated_at = #{updatedAt}
+        WHERE sub_chapter_id = #{subChapterId}
+    </update>
+
+    <update id="updateCurrentContentVersion">
+        UPDATE sub_chapters
+        SET current_content_version_id = #{contentVersionId},
             updated_at = #{updatedAt}
         WHERE sub_chapter_id = #{subChapterId}
     </update>

--- a/src/test/java/org/firstfolio/content/controller/AdminContentVersionControllerTest.java
+++ b/src/test/java/org/firstfolio/content/controller/AdminContentVersionControllerTest.java
@@ -7,6 +7,7 @@ import org.firstfolio.auth.web.CurrentUserArgumentResolver;
 import org.firstfolio.common.json.ApiObjectMapperFactory;
 import org.firstfolio.common.web.RequestIdFilter;
 import org.firstfolio.content.domain.ContentVersion;
+import org.firstfolio.content.domain.ContentVersionHistory;
 import org.firstfolio.content.domain.StoredObjectRef;
 import org.firstfolio.content.dto.request.LessonContentUploadRequest;
 import org.firstfolio.content.service.ContentVersionService;
@@ -23,6 +24,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -33,6 +35,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -120,6 +123,59 @@ class AdminContentVersionControllerTest {
                         .value("CONTENT_VALIDATION_FAILED"));
     }
 
+    @Test
+    void returnsContentVersionsAndMarksCurrentVersion() throws Exception {
+        ContentVersion current = publishedContentVersion();
+        ContentVersion draft = contentVersion();
+        when(service.getContentVersions(103L)).thenReturn(new ContentVersionHistory(
+                List.of(draft, current),
+                301L
+        ));
+
+        mockMvc.perform(get("/api/admin/sub-chapters/103/content-versions")
+                        .requestAttr(AuthenticationRequestAttributes.CURRENT_USER, ADMIN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items[0].content_version_id").value(302))
+                .andExpect(jsonPath("$.data.items[0].status").value("DRAFT"))
+                .andExpect(jsonPath("$.data.items[0].current").value(false))
+                .andExpect(jsonPath("$.data.items[1].content_version_id").value(301))
+                .andExpect(jsonPath("$.data.items[1].status").value("PUBLISHED"))
+                .andExpect(jsonPath("$.data.items[1].current").value(true));
+
+        verify(service).getContentVersions(103L);
+    }
+
+    @Test
+    void publishesDraftContentVersion() throws Exception {
+        ContentVersion published = contentVersion();
+        published.publish(LocalDateTime.of(2026, 8, 7, 2, 0));
+        when(service.publishContentVersion(eq(302L), eq(900L), anyString()))
+                .thenReturn(published);
+
+        mockMvc.perform(post("/api/admin/content-versions/302/publish")
+                        .requestAttr(AuthenticationRequestAttributes.CURRENT_USER, ADMIN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content_version_id").value(302))
+                .andExpect(jsonPath("$.data.sub_chapter_id").value(103))
+                .andExpect(jsonPath("$.data.status").value("PUBLISHED"))
+                .andExpect(jsonPath("$.data.published_at").value("2026-08-07T02:00:00Z"))
+                .andExpect(jsonPath("$.data.current").value(true));
+
+        verify(service).publishContentVersion(eq(302L), eq(900L), anyString());
+    }
+
+    @Test
+    void returnsConflictForNonPublishableContentVersion() throws Exception {
+        when(service.publishContentVersion(eq(302L), eq(900L), anyString()))
+                .thenThrow(new ApiException(ErrorCode.CONTENT_NOT_PUBLISHABLE));
+
+        mockMvc.perform(post("/api/admin/content-versions/302/publish")
+                        .requestAttr(AuthenticationRequestAttributes.CURRENT_USER, ADMIN))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code")
+                        .value("CONTENT_NOT_PUBLISHABLE"));
+    }
+
     private ContentVersion contentVersion() {
         ContentVersion version = ContentVersion.draft(
                 103L,
@@ -133,6 +189,23 @@ class AdminContentVersionControllerTest {
                 LocalDateTime.of(2026, 8, 7, 1, 0)
         );
         version.setContentVersionId(302L);
+        return version;
+    }
+
+    private ContentVersion publishedContentVersion() {
+        ContentVersion version = ContentVersion.draft(
+                103L,
+                1,
+                "1.0",
+                new StoredObjectRef(
+                        "learning/sub-chapters/103/lesson.json",
+                        "storage-version-0"
+                ),
+                900L,
+                LocalDateTime.of(2026, 8, 6, 1, 0)
+        );
+        version.setContentVersionId(301L);
+        version.publish(LocalDateTime.of(2026, 8, 6, 2, 0));
         return version;
     }
 

--- a/src/test/java/org/firstfolio/content/mapper/ContentVersionMapperXmlTest.java
+++ b/src/test/java/org/firstfolio/content/mapper/ContentVersionMapperXmlTest.java
@@ -35,5 +35,20 @@ class ContentVersionMapperXmlTest {
         assertTrue(configuration.hasStatement(
                 ContentVersionMapper.class.getName() + ".insert"
         ));
+        assertTrue(configuration.hasStatement(
+                ContentVersionMapper.class.getName() + ".findAllBySubChapterId"
+        ));
+        assertTrue(configuration.hasStatement(
+                ContentVersionMapper.class.getName() + ".findById"
+        ));
+        assertTrue(configuration.hasStatement(
+                ContentVersionMapper.class.getName() + ".findByIdForUpdate"
+        ));
+        assertTrue(configuration.hasStatement(
+                ContentVersionMapper.class.getName() + ".publishDraft"
+        ));
+        assertTrue(configuration.hasStatement(
+                ContentVersionMapper.class.getName() + ".retirePublished"
+        ));
     }
 }

--- a/src/test/java/org/firstfolio/content/service/ContentVersionLocalStorageIntegrationTest.java
+++ b/src/test/java/org/firstfolio/content/service/ContentVersionLocalStorageIntegrationTest.java
@@ -79,6 +79,7 @@ class ContentVersionLocalStorageIntegrationTest {
                 validationService,
                 storage,
                 contentVersionMapper,
+                subChapterMapper,
                 auditLogMapper,
                 Clock.systemUTC()
         );

--- a/src/test/java/org/firstfolio/content/service/ContentVersionServiceTest.java
+++ b/src/test/java/org/firstfolio/content/service/ContentVersionServiceTest.java
@@ -3,6 +3,7 @@ package org.firstfolio.content.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.firstfolio.content.domain.ContentVersion;
+import org.firstfolio.content.domain.ContentVersionHistory;
 import org.firstfolio.content.domain.ContentVersionStatus;
 import org.firstfolio.content.domain.ContentWriteRequest;
 import org.firstfolio.content.domain.StoredObjectRef;
@@ -13,6 +14,8 @@ import org.firstfolio.content.validation.LessonValidationError;
 import org.firstfolio.content.validation.LessonValidationErrorCode;
 import org.firstfolio.content.validation.LessonValidationResult;
 import org.firstfolio.curriculum.mapper.AdminAuditLogMapper;
+import org.firstfolio.curriculum.domain.SubChapter;
+import org.firstfolio.curriculum.mapper.SubChapterMapper;
 import org.firstfolio.exception.ApiException;
 import org.firstfolio.exception.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,6 +30,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -58,6 +62,7 @@ class ContentVersionServiceTest {
     private LessonContentValidationService validationService;
     private StaticContentStorage contentStorage;
     private ContentVersionMapper contentVersionMapper;
+    private SubChapterMapper subChapterMapper;
     private AdminAuditLogMapper auditLogMapper;
     private ContentVersionService service;
 
@@ -66,11 +71,13 @@ class ContentVersionServiceTest {
         validationService = mock(LessonContentValidationService.class);
         contentStorage = mock(StaticContentStorage.class);
         contentVersionMapper = mock(ContentVersionMapper.class);
+        subChapterMapper = mock(SubChapterMapper.class);
         auditLogMapper = mock(AdminAuditLogMapper.class);
         service = new ContentVersionService(
                 validationService,
                 contentStorage,
                 contentVersionMapper,
+                subChapterMapper,
                 auditLogMapper,
                 Clock.fixed(Instant.parse("2026-08-07T01:00:00Z"), ZoneOffset.UTC)
         );
@@ -251,6 +258,174 @@ class ContentVersionServiceTest {
         verify(validationService, never()).validate(anyLong(), any());
     }
 
+    @Test
+    void returnsContentVersionHistoryWithCurrentVersion() {
+        SubChapter subChapter = subChapter(301L);
+        ContentVersion current = contentVersion(
+                301L,
+                1,
+                ContentVersionStatus.PUBLISHED,
+                NOW.minusDays(1)
+        );
+        ContentVersion draft = contentVersion(
+                302L,
+                2,
+                ContentVersionStatus.DRAFT,
+                null
+        );
+        when(subChapterMapper.findById(SUB_CHAPTER_ID)).thenReturn(subChapter);
+        when(contentVersionMapper.findAllBySubChapterId(SUB_CHAPTER_ID))
+                .thenReturn(List.of(draft, current));
+
+        ContentVersionHistory history = service.getContentVersions(SUB_CHAPTER_ID);
+
+        assertEquals(2, history.versions().size());
+        assertEquals(301L, history.currentContentVersionId());
+        assertEquals(302L, history.versions().get(0).getContentVersionId());
+    }
+
+    @Test
+    void rejectsContentVersionHistoryForMissingSubChapter() {
+        when(subChapterMapper.findById(SUB_CHAPTER_ID)).thenReturn(null);
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.getContentVersions(SUB_CHAPTER_ID)
+        );
+
+        assertEquals(ErrorCode.SUB_CHAPTER_NOT_FOUND, exception.getErrorCode());
+        verify(contentVersionMapper, never()).findAllBySubChapterId(anyLong());
+    }
+
+    @Test
+    void publishesDraftAndUpdatesCurrentVersion() {
+        ContentVersion target = contentVersion(
+                302L,
+                2,
+                ContentVersionStatus.DRAFT,
+                null
+        );
+        SubChapter subChapter = subChapter(null);
+        when(contentVersionMapper.findById(302L)).thenReturn(target);
+        when(subChapterMapper.findByIdForUpdate(SUB_CHAPTER_ID)).thenReturn(subChapter);
+        when(contentVersionMapper.findByIdForUpdate(302L)).thenReturn(target);
+        when(contentVersionMapper.publishDraft(302L, NOW)).thenReturn(1);
+        when(subChapterMapper.updateCurrentContentVersion(
+                SUB_CHAPTER_ID,
+                302L,
+                NOW
+        )).thenReturn(1);
+
+        ContentVersion published = service.publishContentVersion(
+                302L,
+                ACTOR_ID,
+                REQUEST_ID
+        );
+
+        assertEquals(ContentVersionStatus.PUBLISHED, published.getStatus());
+        assertEquals(NOW, published.getPublishedAt());
+        verify(contentVersionMapper, never()).retirePublished(anyLong());
+        verify(auditLogMapper).insert(
+                eq(ACTOR_ID),
+                eq("PUBLISH"),
+                eq("CONTENT_VERSION"),
+                eq(302L),
+                anyString(),
+                anyString(),
+                eq(REQUEST_ID),
+                eq(NOW)
+        );
+    }
+
+    @Test
+    void retiresPreviousVersionWhenPublishingNewDraft() {
+        ContentVersion previous = contentVersion(
+                301L,
+                1,
+                ContentVersionStatus.PUBLISHED,
+                NOW.minusDays(1)
+        );
+        ContentVersion target = contentVersion(
+                302L,
+                2,
+                ContentVersionStatus.DRAFT,
+                null
+        );
+        SubChapter subChapter = subChapter(301L);
+        when(contentVersionMapper.findById(302L)).thenReturn(target);
+        when(subChapterMapper.findByIdForUpdate(SUB_CHAPTER_ID)).thenReturn(subChapter);
+        when(contentVersionMapper.findByIdForUpdate(302L)).thenReturn(target);
+        when(contentVersionMapper.findByIdForUpdate(301L)).thenReturn(previous);
+        when(contentVersionMapper.retirePublished(301L)).thenReturn(1);
+        when(contentVersionMapper.publishDraft(302L, NOW)).thenReturn(1);
+        when(subChapterMapper.updateCurrentContentVersion(
+                SUB_CHAPTER_ID,
+                302L,
+                NOW
+        )).thenReturn(1);
+
+        ContentVersion published = service.publishContentVersion(
+                302L,
+                ACTOR_ID,
+                REQUEST_ID
+        );
+
+        assertEquals(ContentVersionStatus.RETIRED, previous.getStatus());
+        assertEquals(ContentVersionStatus.PUBLISHED, published.getStatus());
+        verify(auditLogMapper).insert(
+                eq(ACTOR_ID),
+                eq("RETIRE"),
+                eq("CONTENT_VERSION"),
+                eq(301L),
+                anyString(),
+                anyString(),
+                eq(REQUEST_ID),
+                eq(NOW)
+        );
+        verify(auditLogMapper).insert(
+                eq(ACTOR_ID),
+                eq("PUBLISH"),
+                eq("CONTENT_VERSION"),
+                eq(302L),
+                anyString(),
+                anyString(),
+                eq(REQUEST_ID),
+                eq(NOW)
+        );
+    }
+
+    @Test
+    void rejectsMissingOrNonDraftContentVersionForPublishing() {
+        when(contentVersionMapper.findById(999L)).thenReturn(null);
+
+        ApiException missing = assertThrows(
+                ApiException.class,
+                () -> service.publishContentVersion(999L, ACTOR_ID, REQUEST_ID)
+        );
+        assertEquals(ErrorCode.CONTENT_VERSION_NOT_FOUND, missing.getErrorCode());
+
+        ContentVersion published = contentVersion(
+                302L,
+                2,
+                ContentVersionStatus.PUBLISHED,
+                NOW.minusDays(1)
+        );
+        when(contentVersionMapper.findById(302L)).thenReturn(published);
+        when(subChapterMapper.findByIdForUpdate(SUB_CHAPTER_ID))
+                .thenReturn(subChapter(302L));
+        when(contentVersionMapper.findByIdForUpdate(302L)).thenReturn(published);
+
+        ApiException notPublishable = assertThrows(
+                ApiException.class,
+                () -> service.publishContentVersion(302L, ACTOR_ID, REQUEST_ID)
+        );
+        assertEquals(ErrorCode.CONTENT_NOT_PUBLISHABLE, notPublishable.getErrorCode());
+        verify(contentVersionMapper, never()).publishDraft(anyLong(), any());
+        verify(subChapterMapper, never()).updateCurrentContentVersion(
+                anyLong(), anyLong(), any()
+        );
+    }
+
     private LessonContentUploadRequest uploadRequest() throws IOException {
         try (InputStream inputStream = getClass().getClassLoader()
                 .getResourceAsStream(VALID_LESSON_RESOURCE)) {
@@ -260,5 +435,39 @@ class ContentVersionServiceTest {
             JsonNode lesson = new ObjectMapper().readTree(inputStream);
             return new LessonContentUploadRequest(2, lesson);
         }
+    }
+
+    private SubChapter subChapter(Long currentContentVersionId) {
+        SubChapter subChapter = new SubChapter();
+        subChapter.setSubChapterId(SUB_CHAPTER_ID);
+        subChapter.setCurrentContentVersionId(currentContentVersionId);
+        return subChapter;
+    }
+
+    private ContentVersion contentVersion(
+            long contentVersionId,
+            int versionNo,
+            ContentVersionStatus status,
+            LocalDateTime publishedAt
+    ) {
+        ContentVersion version = ContentVersion.draft(
+                SUB_CHAPTER_ID,
+                versionNo,
+                "1.0",
+                new StoredObjectRef(OBJECT_KEY, "storage-version-" + versionNo),
+                ACTOR_ID,
+                NOW.minusDays(2)
+        );
+        version.setContentVersionId(contentVersionId);
+        if (status == ContentVersionStatus.PUBLISHED) {
+            version.publish(publishedAt);
+        } else if (status == ContentVersionStatus.RETIRED) {
+            version.publish(publishedAt);
+            version.retire();
+        } else {
+            version.setStatus(status);
+            version.setPublishedAt(publishedAt);
+        }
+        return version;
     }
 }

--- a/src/test/java/org/firstfolio/curriculum/mapper/ChapterMapperXmlTest.java
+++ b/src/test/java/org/firstfolio/curriculum/mapper/ChapterMapperXmlTest.java
@@ -30,6 +30,12 @@ class ChapterMapperXmlTest {
                 SubChapterMapper.class.getName() + ".updateMetadata"
         ));
         assertTrue(configuration.hasStatement(
+                SubChapterMapper.class.getName() + ".findByIdForUpdate"
+        ));
+        assertTrue(configuration.hasStatement(
+                SubChapterMapper.class.getName() + ".updateCurrentContentVersion"
+        ));
+        assertTrue(configuration.hasStatement(
                 AdminAuditLogMapper.class.getName() + ".insert"
         ));
     }


### PR DESCRIPTION
## 작업 내용

- 관리자용 강좌 콘텐츠 버전 목록 조회 API 구현
- 강좌 콘텐츠 버전 공개 API 구현
- 신규 콘텐츠 버전 `DRAFT → PUBLISHED` 상태 전환
- 기존 공개 버전 `PUBLISHED → RETIRED` 처리
- 콘텐츠 공개 일시 및 소단원의 현재 콘텐츠 버전 갱신
- 콘텐츠 공개·보관 상태 변경 감사 이력 저장
- 컨트롤러·서비스·MyBatis Mapper 테스트 작성

## API

- `GET /api/admin/sub-chapters/{subChapterId}/content-versions`
- `POST /api/admin/content-versions/{contentVersionId}/publish`

## 처리 방식

콘텐츠 공개 시 기존 공개 버전 보관, 신규 버전 공개, `current_content_version_id` 변경 및 감사 이력 저장을 하나의 트랜잭션으로 처리합니다.

초기 운영에서는 별도 `REVIEW` 단계 없이 다음 상태 흐름을 사용합니다.

`DRAFT → PUBLISHED → RETIRED`

## 테스트

- 전체 158개 테스트 통과
- WAR 빌드 성공