### PR TITLE
feat: 사용자용 강좌 조회 API 구현 #38

### DIFF
--- a/src/main/java/org/firstfolio/content/domain/PublishedLessonReference.java
+++ b/src/main/java/org/firstfolio/content/domain/PublishedLessonReference.java
@@ -1,0 +1,66 @@
+package org.firstfolio.content.domain;
+
+public class PublishedLessonReference {
+
+    private long subChapterId;
+    private String title;
+    private long contentVersionId;
+    private String schemaVersion;
+    private String storageObjectKey;
+    private String storageVersionId;
+
+    public PublishedLessonReference() {
+    }
+
+    public long getSubChapterId() {
+        return subChapterId;
+    }
+
+    public void setSubChapterId(long subChapterId) {
+        this.subChapterId = subChapterId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public long getContentVersionId() {
+        return contentVersionId;
+    }
+
+    public void setContentVersionId(long contentVersionId) {
+        this.contentVersionId = contentVersionId;
+    }
+
+    public String getSchemaVersion() {
+        return schemaVersion;
+    }
+
+    public void setSchemaVersion(String schemaVersion) {
+        this.schemaVersion = schemaVersion;
+    }
+
+    public String getStorageObjectKey() {
+        return storageObjectKey;
+    }
+
+    public void setStorageObjectKey(String storageObjectKey) {
+        this.storageObjectKey = storageObjectKey;
+    }
+
+    public String getStorageVersionId() {
+        return storageVersionId;
+    }
+
+    public void setStorageVersionId(String storageVersionId) {
+        this.storageVersionId = storageVersionId;
+    }
+
+    public StoredObjectRef toStoredObjectRef() {
+        return new StoredObjectRef(storageObjectKey, storageVersionId);
+    }
+}

--- a/src/main/java/org/firstfolio/content/mapper/ContentVersionMapper.java
+++ b/src/main/java/org/firstfolio/content/mapper/ContentVersionMapper.java
@@ -3,12 +3,17 @@ package org.firstfolio.content.mapper;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.firstfolio.content.domain.ContentVersion;
+import org.firstfolio.content.domain.PublishedLessonReference;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Mapper
 public interface ContentVersionMapper {
+
+    PublishedLessonReference findCurrentPublishedLesson(
+            @Param("subChapterId") long subChapterId
+    );
 
     List<ContentVersion> findAllBySubChapterId(
             @Param("subChapterId") long subChapterId

--- a/src/main/java/org/firstfolio/exception/ErrorCode.java
+++ b/src/main/java/org/firstfolio/exception/ErrorCode.java
@@ -32,6 +32,8 @@ public enum ErrorCode {
     CONTENT_VERSION_CONFLICT(HttpStatus.CONFLICT, "같은 소단원 콘텐츠 버전이 이미 존재합니다."),
     CONTENT_NOT_PUBLISHABLE(HttpStatus.CONFLICT, "공개할 수 없는 강좌 콘텐츠 버전입니다."),
     CONTENT_VALIDATION_FAILED(HttpStatus.UNPROCESSABLE_ENTITY, "강좌 콘텐츠 검증에 실패했습니다."),
+    CONTENT_NOT_PUBLISHED(HttpStatus.NOT_FOUND, "공개된 강좌 콘텐츠가 없습니다."),
+    CONTENT_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "강좌 콘텐츠를 불러올 수 없습니다."),
 
     // 포트폴리오 (FUNC-033, 034, 036)
     PORTFOLIO_ALREADY_CONFIGURED(HttpStatus.CONFLICT, "이미 최초 포트폴리오를 구성했습니다."),

--- a/src/main/java/org/firstfolio/learning/controller/LessonContentController.java
+++ b/src/main/java/org/firstfolio/learning/controller/LessonContentController.java
@@ -1,0 +1,31 @@
+package org.firstfolio.learning.controller;
+
+import org.firstfolio.common.response.ApiResponse;
+import org.firstfolio.learning.dto.response.LessonContentResponse;
+import org.firstfolio.learning.service.LessonContentQueryService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/learning/sub-chapters")
+public class LessonContentController {
+
+    private final LessonContentQueryService lessonContentQueryService;
+
+    public LessonContentController(
+            LessonContentQueryService lessonContentQueryService
+    ) {
+        this.lessonContentQueryService = lessonContentQueryService;
+    }
+
+    @GetMapping("/{subChapterId}")
+    public ApiResponse<LessonContentResponse> getLessonContent(
+            @PathVariable long subChapterId
+    ) {
+        return ApiResponse.of(LessonContentResponse.from(
+                lessonContentQueryService.getPublishedLesson(subChapterId)
+        ));
+    }
+}

--- a/src/main/java/org/firstfolio/learning/domain/LessonContent.java
+++ b/src/main/java/org/firstfolio/learning/domain/LessonContent.java
@@ -1,0 +1,25 @@
+package org.firstfolio.learning.domain;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.Objects;
+
+public record LessonContent(
+        long subChapterId,
+        String title,
+        long contentVersionId,
+        String schemaVersion,
+        JsonNode lesson
+) {
+    public LessonContent {
+        Objects.requireNonNull(title, "title must not be null");
+        Objects.requireNonNull(schemaVersion, "schemaVersion must not be null");
+        Objects.requireNonNull(lesson, "lesson must not be null");
+        lesson = lesson.deepCopy();
+    }
+
+    @Override
+    public JsonNode lesson() {
+        return lesson.deepCopy();
+    }
+}

--- a/src/main/java/org/firstfolio/learning/dto/response/LessonContentResponse.java
+++ b/src/main/java/org/firstfolio/learning/dto/response/LessonContentResponse.java
@@ -1,0 +1,22 @@
+package org.firstfolio.learning.dto.response;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.firstfolio.learning.domain.LessonContent;
+
+public record LessonContentResponse(
+        long subChapterId,
+        String title,
+        long contentVersionId,
+        String schemaVersion,
+        JsonNode lesson
+) {
+    public static LessonContentResponse from(LessonContent content) {
+        return new LessonContentResponse(
+                content.subChapterId(),
+                content.title(),
+                content.contentVersionId(),
+                content.schemaVersion(),
+                content.lesson()
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/learning/service/LessonContentQueryService.java
+++ b/src/main/java/org/firstfolio/learning/service/LessonContentQueryService.java
@@ -1,0 +1,126 @@
+package org.firstfolio.learning.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.firstfolio.content.domain.PublishedLessonReference;
+import org.firstfolio.content.domain.StoredContent;
+import org.firstfolio.content.exception.ContentStorageException;
+import org.firstfolio.content.mapper.ContentVersionMapper;
+import org.firstfolio.content.service.StaticContentStorage;
+import org.firstfolio.curriculum.domain.SubChapter;
+import org.firstfolio.curriculum.mapper.SubChapterMapper;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.learning.domain.LessonContent;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+
+@Service
+public class LessonContentQueryService {
+
+    private static final String JSON_CONTENT_TYPE = "application/json";
+
+    private final ContentVersionMapper contentVersionMapper;
+    private final SubChapterMapper subChapterMapper;
+    private final StaticContentStorage contentStorage;
+    private final ObjectMapper objectMapper;
+
+    public LessonContentQueryService(
+            ContentVersionMapper contentVersionMapper,
+            SubChapterMapper subChapterMapper,
+            StaticContentStorage contentStorage
+    ) {
+        this(
+                contentVersionMapper,
+                subChapterMapper,
+                contentStorage,
+                new ObjectMapper()
+        );
+    }
+
+    LessonContentQueryService(
+            ContentVersionMapper contentVersionMapper,
+            SubChapterMapper subChapterMapper,
+            StaticContentStorage contentStorage,
+            ObjectMapper objectMapper
+    ) {
+        this.contentVersionMapper = contentVersionMapper;
+        this.subChapterMapper = subChapterMapper;
+        this.contentStorage = contentStorage;
+        this.objectMapper = objectMapper;
+    }
+
+    public LessonContent getPublishedLesson(long subChapterId) {
+        PublishedLessonReference reference =
+                contentVersionMapper.findCurrentPublishedLesson(subChapterId);
+        if (reference == null) {
+            throw missingPublishedContent(subChapterId);
+        }
+
+        StoredContent storedContent;
+        try {
+            storedContent = contentStorage.load(reference.toStoredObjectRef());
+        } catch (ContentStorageException exception) {
+            throw unavailable(exception);
+        }
+
+        JsonNode lesson = parseLesson(storedContent, reference.getSchemaVersion());
+        return new LessonContent(
+                reference.getSubChapterId(),
+                reference.getTitle(),
+                reference.getContentVersionId(),
+                reference.getSchemaVersion(),
+                lesson
+        );
+    }
+
+    private ApiException missingPublishedContent(long subChapterId) {
+        SubChapter subChapter = subChapterMapper.findById(subChapterId);
+        if (subChapter == null || !subChapter.isActive()) {
+            return new ApiException(ErrorCode.SUB_CHAPTER_NOT_FOUND);
+        }
+        return new ApiException(ErrorCode.CONTENT_NOT_PUBLISHED);
+    }
+
+    private JsonNode parseLesson(
+            StoredContent storedContent,
+            String expectedSchemaVersion
+    ) {
+        if (!isJson(storedContent.contentType())) {
+            throw unavailable(null);
+        }
+
+        try {
+            JsonNode lesson = objectMapper.readTree(new String(
+                    storedContent.content(),
+                    StandardCharsets.UTF_8
+            ));
+            if (lesson == null
+                    || !lesson.isObject()
+                    || !expectedSchemaVersion.equals(
+                            lesson.path("schemaVersion").textValue()
+                    )) {
+                throw unavailable(null);
+            }
+            return lesson;
+        } catch (JsonProcessingException exception) {
+            throw unavailable(exception);
+        }
+    }
+
+    private boolean isJson(String contentType) {
+        return JSON_CONTENT_TYPE.equalsIgnoreCase(
+                contentType.split(";", 2)[0].trim()
+        );
+    }
+
+    private ApiException unavailable(Throwable cause) {
+        return new ApiException(
+                ErrorCode.CONTENT_UNAVAILABLE,
+                ErrorCode.CONTENT_UNAVAILABLE.getDefaultMessage(),
+                cause
+        );
+    }
+}

--- a/src/main/resources/mappers/content/ContentVersionMapper.xml
+++ b/src/main/resources/mappers/content/ContentVersionMapper.xml
@@ -19,6 +19,34 @@
         <result property="createdAt" column="created_at" />
     </resultMap>
 
+    <resultMap id="publishedLessonReferenceResultMap"
+               type="org.firstfolio.content.domain.PublishedLessonReference">
+        <id property="contentVersionId" column="content_version_id" />
+        <result property="subChapterId" column="sub_chapter_id" />
+        <result property="title" column="title" />
+        <result property="schemaVersion" column="schema_version" />
+        <result property="storageObjectKey" column="storage_object_key" />
+        <result property="storageVersionId" column="storage_version_id" />
+    </resultMap>
+
+    <select id="findCurrentPublishedLesson"
+            resultMap="publishedLessonReferenceResultMap">
+        SELECT
+            sc.sub_chapter_id,
+            sc.title,
+            cv.content_version_id,
+            cv.schema_version,
+            cv.storage_object_key,
+            cv.storage_version_id
+        FROM sub_chapters sc
+        INNER JOIN content_versions cv
+            ON cv.content_version_id = sc.current_content_version_id
+           AND cv.sub_chapter_id = sc.sub_chapter_id
+        WHERE sc.sub_chapter_id = #{subChapterId}
+          AND sc.is_active = TRUE
+          AND cv.status = 'PUBLISHED'
+    </select>
+
     <sql id="contentVersionColumns">
         content_version_id,
         sub_chapter_id,

--- a/src/test/java/org/firstfolio/content/mapper/ContentVersionMapperXmlTest.java
+++ b/src/test/java/org/firstfolio/content/mapper/ContentVersionMapperXmlTest.java
@@ -30,6 +30,9 @@ class ContentVersionMapperXmlTest {
 
         assertTrue(configuration.hasMapper(ContentVersionMapper.class));
         assertTrue(configuration.hasStatement(
+                ContentVersionMapper.class.getName() + ".findCurrentPublishedLesson"
+        ));
+        assertTrue(configuration.hasStatement(
                 ContentVersionMapper.class.getName() + ".countBySubChapterIdAndVersionNo"
         ));
         assertTrue(configuration.hasStatement(

--- a/src/test/java/org/firstfolio/learning/controller/LessonContentControllerTest.java
+++ b/src/test/java/org/firstfolio/learning/controller/LessonContentControllerTest.java
@@ -1,0 +1,92 @@
+package org.firstfolio.learning.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.firstfolio.common.json.ApiObjectMapperFactory;
+import org.firstfolio.common.web.RequestIdFilter;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.CommonExceptionAdvice;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.learning.domain.LessonContent;
+import org.firstfolio.learning.service.LessonContentQueryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class LessonContentControllerTest {
+
+    private LessonContentQueryService service;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        service = mock(LessonContentQueryService.class);
+        MappingJackson2HttpMessageConverter converter =
+                new MappingJackson2HttpMessageConverter(ApiObjectMapperFactory.create());
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new LessonContentController(service))
+                .setControllerAdvice(new CommonExceptionAdvice())
+                .setMessageConverters(converter)
+                .addFilter(new RequestIdFilter())
+                .build();
+    }
+
+    @Test
+    void returnsPublishedLessonJsonWithoutStorageReference() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        when(service.getPublishedLesson(103L)).thenReturn(new LessonContent(
+                103L,
+                "예금의 기초",
+                302L,
+                "1.0",
+                objectMapper.readTree("""
+                        {
+                          "schemaVersion": "1.0",
+                          "pages": [{"id": "interest", "blocks": []}],
+                          "subChapterQuiz": {"questionIds": [1021]}
+                        }
+                        """)
+        ));
+
+        mockMvc.perform(get("/api/learning/sub-chapters/103"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.sub_chapter_id").value(103))
+                .andExpect(jsonPath("$.data.title").value("예금의 기초"))
+                .andExpect(jsonPath("$.data.content_version_id").value(302))
+                .andExpect(jsonPath("$.data.schema_version").value("1.0"))
+                .andExpect(jsonPath("$.data.lesson.schemaVersion").value("1.0"))
+                .andExpect(jsonPath("$.data.lesson.pages[0].id").value("interest"))
+                .andExpect(jsonPath("$.data.storage_object_key").doesNotExist())
+                .andExpect(jsonPath("$.data.storage_version_id").doesNotExist());
+
+        verify(service).getPublishedLesson(103L);
+    }
+
+    @Test
+    void returnsNotFoundWhenContentIsNotPublished() throws Exception {
+        when(service.getPublishedLesson(103L))
+                .thenThrow(new ApiException(ErrorCode.CONTENT_NOT_PUBLISHED));
+
+        mockMvc.perform(get("/api/learning/sub-chapters/103"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("CONTENT_NOT_PUBLISHED"));
+    }
+
+    @Test
+    void returnsServiceUnavailableWhenStorageCannotLoadContent() throws Exception {
+        when(service.getPublishedLesson(103L))
+                .thenThrow(new ApiException(ErrorCode.CONTENT_UNAVAILABLE));
+
+        mockMvc.perform(get("/api/learning/sub-chapters/103"))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(jsonPath("$.error.code").value("CONTENT_UNAVAILABLE"));
+    }
+}

--- a/src/test/java/org/firstfolio/learning/service/LessonContentLocalStorageIntegrationTest.java
+++ b/src/test/java/org/firstfolio/learning/service/LessonContentLocalStorageIntegrationTest.java
@@ -1,0 +1,66 @@
+package org.firstfolio.learning.service;
+
+import org.firstfolio.content.domain.ContentWriteRequest;
+import org.firstfolio.content.domain.PublishedLessonReference;
+import org.firstfolio.content.domain.StoredObjectRef;
+import org.firstfolio.content.mapper.ContentVersionMapper;
+import org.firstfolio.content.storage.LocalContentStorage;
+import org.firstfolio.curriculum.mapper.SubChapterMapper;
+import org.firstfolio.learning.domain.LessonContent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class LessonContentLocalStorageIntegrationTest {
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void loadsPublishedLessonFromLocalImmutableVersion() {
+        String objectKey = "learning/sub-chapters/103/lesson.json";
+        String json = """
+                {
+                  "schemaVersion": "1.0",
+                  "pages": [{"id": "page-1", "blocks": []}],
+                  "subChapterQuiz": {"questionIds": [1021]}
+                }
+                """;
+        LocalContentStorage storage = new LocalContentStorage(
+                temporaryDirectory.resolve("content"),
+                5L * 1024L * 1024L
+        );
+        StoredObjectRef storedObject = storage.store(new ContentWriteRequest(
+                objectKey,
+                json.getBytes(StandardCharsets.UTF_8),
+                "application/json"
+        ));
+
+        ContentVersionMapper contentVersionMapper = mock(ContentVersionMapper.class);
+        PublishedLessonReference reference = new PublishedLessonReference();
+        reference.setSubChapterId(103L);
+        reference.setTitle("예금의 기초");
+        reference.setContentVersionId(302L);
+        reference.setSchemaVersion("1.0");
+        reference.setStorageObjectKey(storedObject.objectKey());
+        reference.setStorageVersionId(storedObject.versionId());
+        when(contentVersionMapper.findCurrentPublishedLesson(103L)).thenReturn(reference);
+
+        LessonContentQueryService service = new LessonContentQueryService(
+                contentVersionMapper,
+                mock(SubChapterMapper.class),
+                storage
+        );
+
+        LessonContent content = service.getPublishedLesson(103L);
+
+        assertEquals(302L, content.contentVersionId());
+        assertEquals("page-1", content.lesson().path("pages").get(0).path("id").textValue());
+    }
+}

--- a/src/test/java/org/firstfolio/learning/service/LessonContentQueryServiceTest.java
+++ b/src/test/java/org/firstfolio/learning/service/LessonContentQueryServiceTest.java
@@ -1,0 +1,177 @@
+package org.firstfolio.learning.service;
+
+import org.firstfolio.content.domain.PublishedLessonReference;
+import org.firstfolio.content.domain.StoredContent;
+import org.firstfolio.content.domain.StoredObjectRef;
+import org.firstfolio.content.exception.ContentStorageError;
+import org.firstfolio.content.exception.ContentStorageException;
+import org.firstfolio.content.mapper.ContentVersionMapper;
+import org.firstfolio.content.service.StaticContentStorage;
+import org.firstfolio.curriculum.domain.SubChapter;
+import org.firstfolio.curriculum.mapper.SubChapterMapper;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.learning.domain.LessonContent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class LessonContentQueryServiceTest {
+
+    private static final long SUB_CHAPTER_ID = 103L;
+    private static final StoredObjectRef STORED_OBJECT = new StoredObjectRef(
+            "learning/sub-chapters/103/lesson.json",
+            "storage-version-2"
+    );
+
+    private ContentVersionMapper contentVersionMapper;
+    private SubChapterMapper subChapterMapper;
+    private StaticContentStorage contentStorage;
+    private LessonContentQueryService service;
+
+    @BeforeEach
+    void setUp() {
+        contentVersionMapper = mock(ContentVersionMapper.class);
+        subChapterMapper = mock(SubChapterMapper.class);
+        contentStorage = mock(StaticContentStorage.class);
+        service = new LessonContentQueryService(
+                contentVersionMapper,
+                subChapterMapper,
+                contentStorage
+        );
+    }
+
+    @Test
+    void loadsCurrentPublishedLessonFromExactStorageVersion() {
+        PublishedLessonReference reference = publishedReference();
+        when(contentVersionMapper.findCurrentPublishedLesson(SUB_CHAPTER_ID))
+                .thenReturn(reference);
+        when(contentStorage.load(STORED_OBJECT)).thenReturn(storedJson("""
+                {
+                  "schemaVersion": "1.0",
+                  "pages": [],
+                  "subChapterQuiz": {"questionIds": [1021]}
+                }
+                """));
+
+        LessonContent content = service.getPublishedLesson(SUB_CHAPTER_ID);
+
+        assertEquals(SUB_CHAPTER_ID, content.subChapterId());
+        assertEquals("예금의 기초", content.title());
+        assertEquals(302L, content.contentVersionId());
+        assertEquals("1.0", content.schemaVersion());
+        assertEquals("1.0", content.lesson().path("schemaVersion").textValue());
+        verify(contentStorage).load(STORED_OBJECT);
+        verify(subChapterMapper, never()).findById(SUB_CHAPTER_ID);
+    }
+
+    @Test
+    void hidesMissingOrInactiveSubChapter() {
+        when(contentVersionMapper.findCurrentPublishedLesson(SUB_CHAPTER_ID))
+                .thenReturn(null);
+        when(subChapterMapper.findById(SUB_CHAPTER_ID)).thenReturn(null);
+
+        ApiException missing = assertThrows(
+                ApiException.class,
+                () -> service.getPublishedLesson(SUB_CHAPTER_ID)
+        );
+        assertEquals(ErrorCode.SUB_CHAPTER_NOT_FOUND, missing.getErrorCode());
+
+        SubChapter inactive = new SubChapter();
+        inactive.setSubChapterId(SUB_CHAPTER_ID);
+        inactive.setActive(false);
+        when(subChapterMapper.findById(SUB_CHAPTER_ID)).thenReturn(inactive);
+
+        ApiException hidden = assertThrows(
+                ApiException.class,
+                () -> service.getPublishedLesson(SUB_CHAPTER_ID)
+        );
+        assertEquals(ErrorCode.SUB_CHAPTER_NOT_FOUND, hidden.getErrorCode());
+        verify(contentStorage, never()).load(STORED_OBJECT);
+    }
+
+    @Test
+    void rejectsActiveSubChapterWithoutPublishedContent() {
+        when(contentVersionMapper.findCurrentPublishedLesson(SUB_CHAPTER_ID))
+                .thenReturn(null);
+        SubChapter active = new SubChapter();
+        active.setSubChapterId(SUB_CHAPTER_ID);
+        active.setActive(true);
+        when(subChapterMapper.findById(SUB_CHAPTER_ID)).thenReturn(active);
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.getPublishedLesson(SUB_CHAPTER_ID)
+        );
+
+        assertEquals(ErrorCode.CONTENT_NOT_PUBLISHED, exception.getErrorCode());
+    }
+
+    @Test
+    void mapsStorageFailureToContentUnavailable() {
+        when(contentVersionMapper.findCurrentPublishedLesson(SUB_CHAPTER_ID))
+                .thenReturn(publishedReference());
+        when(contentStorage.load(STORED_OBJECT)).thenThrow(new ContentStorageException(
+                ContentStorageError.OBJECT_NOT_FOUND,
+                "missing"
+        ));
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.getPublishedLesson(SUB_CHAPTER_ID)
+        );
+
+        assertEquals(ErrorCode.CONTENT_UNAVAILABLE, exception.getErrorCode());
+    }
+
+    @Test
+    void rejectsInvalidMediaTypeOrSchemaVersion() {
+        when(contentVersionMapper.findCurrentPublishedLesson(SUB_CHAPTER_ID))
+                .thenReturn(publishedReference());
+        when(contentStorage.load(STORED_OBJECT)).thenReturn(new StoredContent(
+                "{}".getBytes(StandardCharsets.UTF_8),
+                "text/plain"
+        ));
+
+        ApiException invalidMediaType = assertThrows(
+                ApiException.class,
+                () -> service.getPublishedLesson(SUB_CHAPTER_ID)
+        );
+        assertEquals(ErrorCode.CONTENT_UNAVAILABLE, invalidMediaType.getErrorCode());
+
+        when(contentStorage.load(STORED_OBJECT)).thenReturn(storedJson("""
+                {"schemaVersion": "2.0", "pages": []}
+                """));
+        ApiException schemaMismatch = assertThrows(
+                ApiException.class,
+                () -> service.getPublishedLesson(SUB_CHAPTER_ID)
+        );
+        assertEquals(ErrorCode.CONTENT_UNAVAILABLE, schemaMismatch.getErrorCode());
+    }
+
+    private PublishedLessonReference publishedReference() {
+        PublishedLessonReference reference = new PublishedLessonReference();
+        reference.setSubChapterId(SUB_CHAPTER_ID);
+        reference.setTitle("예금의 기초");
+        reference.setContentVersionId(302L);
+        reference.setSchemaVersion("1.0");
+        reference.setStorageObjectKey(STORED_OBJECT.objectKey());
+        reference.setStorageVersionId(STORED_OBJECT.versionId());
+        return reference;
+    }
+
+    private StoredContent storedJson(String json) {
+        return new StoredContent(
+                json.getBytes(StandardCharsets.UTF_8),
+                "application/json; charset=UTF-8"
+        );
+    }
+}


### PR DESCRIPTION
## 작업 내용

- 사용자용 강좌 콘텐츠 조회 API 구현
- 소단원의 현재 공개 콘텐츠 버전 조회
- 객체 키와 버전 ID를 이용한 로컬/S3 강좌 JSON 로드
- 비활성 소단원 및 미공개 콘텐츠 조회 차단
- 저장소 조회 실패와 콘텐츠 무결성 오류 처리
- 서비스·컨트롤러·Mapper·로컬 저장소 연동 테스트 작성
- Notion API 명세 최신화

## API

`GET /api/learning/sub-chapters/{subChapterId}`

활성 소단원의 `current_content_version_id`로 연결된 `PUBLISHED` 콘텐츠를 조회하고, 저장소에서 읽은 강좌 JSON을 `lesson` 필드로 반환합니다.

저장소 객체 키와 버전 ID는 사용자 응답에 노출하지 않습니다.

## 오류 처리

- `SUB_CHAPTER_NOT_FOUND`: 소단원이 없거나 비활성 상태
- `CONTENT_NOT_PUBLISHED`: 현재 공개된 콘텐츠가 없음
- `CONTENT_UNAVAILABLE`: 저장소 조회 실패 또는 콘텐츠 형식·스키마 버전 오류

## 테스트

- 전체 167개 테스트 통과
- WAR 빌드 성공