### PR TITLE
fix: UserMapper 값 누락 수정 #46

### DIFF
--- a/src/main/resources/mappers/user/UserMapper.xml
+++ b/src/main/resources/mappers/user/UserMapper.xml
@@ -53,6 +53,9 @@
             #{nickname},
             #{roleCode},
             #{status},
+            #{pointBalance},
+            #{lastAttendanceDate,jdbcType=DATE},
+            #{newsletterOptIn},
             #{createdAt},
             #{updatedAt}
         )

--- a/src/test/java/org/firstfolio/persistence/MapperStatementTest.java
+++ b/src/test/java/org/firstfolio/persistence/MapperStatementTest.java
@@ -8,6 +8,7 @@ import org.apache.ibatis.session.SqlSessionFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.SqlSessionFactoryBean;
+import org.firstfolio.user.domain.User;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
@@ -15,12 +16,14 @@ import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 
 import java.lang.reflect.Method;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -157,6 +160,40 @@ class MapperStatementTest {
         assertTrue(sql.contains("IN"));
         assertTrue(sql.contains("MAX(reference_at)"));
         assertFalse(sql.contains("IN ( )"), "빈 IN 절이 만들어지면 안 됩니다.");
+    }
+
+    @Test
+    @DisplayName("회원 INSERT는 모든 컬럼에 값을 바인딩한다")
+    void bindsEveryUserInsertColumn() {
+        String statementId = "org.firstfolio.user.mapper.UserMapper.insert";
+        User user = User.signup(
+                "firebase-uid",
+                "user@example.com",
+                "nickname",
+                LocalDateTime.of(2026, 8, 10, 0, 0)
+        );
+
+        BoundSql boundSql = configuration.getMappedStatement(statementId).getBoundSql(user);
+        List<String> parameterProperties = boundSql.getParameterMappings().stream()
+                .map(mapping -> mapping.getProperty())
+                .toList();
+
+        assertEquals(
+                List.of(
+                        "firebaseUid",
+                        "email",
+                        "nickname",
+                        "roleCode",
+                        "status",
+                        "pointBalance",
+                        "lastAttendanceDate",
+                        "newsletterOptIn",
+                        "createdAt",
+                        "updatedAt"
+                ),
+                parameterProperties
+        );
+        assertEquals(10, boundSql.getSql().chars().filter(character -> character == '?').count());
     }
 
     private String sqlOf(String statementId, Map<String, Object> parameters) {


### PR DESCRIPTION
UserMapper.xml의 회원 생성 INSERT 구문에서 컬럼은 10개였지만 VALUES 바인딩은 7개만 정의되어 있었습니다. 누락된 아래 필드의 바인딩을 추가했습니다.

- point_balance → #{pointBalance}
- last_attendance_date → #{lastAttendanceDate,jdbcType=DATE}
- newsletter_opt_in → #{newsletterOptIn}

같은 문제가 재발하지 않도록 INSERT 컬럼과 파라미터의 순서 및 개수(10개)를 검증하는 회귀 테스트도 추가했습니다.

전체 테스트 503개가 모두 통과했으며, 실패 및 오류는 없습니다.