### PR TITLE
chore: 배포 트리거에서 임시 작업 브랜치 제거

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-      # 병합 시 아래 한 줄 삭제
-      - feat/aws-deploy-poc
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
main 병합과 배포가 정상 확인되어, 테스트용으로 열어뒀던 feat/aws-deploy-poc 브랜치 트리거를 제거합니다.