### PR TITLE
사용자 학습 진행 및 퀴즈 흐름 구현

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -205,6 +205,45 @@ CREATE TABLE user_learning_progress (
     INDEX idx_user_learning_progress_continue (user_id, status, updated_at)
 ) ENGINE = InnoDB COMMENT = '사용자별 소단원 진행 위치와 최초 완료 상태';
 
+CREATE TABLE user_learning_progress_events (
+    progress_event_id BIGINT NOT NULL AUTO_INCREMENT COMMENT '학습 진도 변경 이벤트 식별자',
+    progress_id BIGINT NOT NULL COMMENT '대상 현재 진도 행',
+    user_id BIGINT NOT NULL COMMENT '학습 사용자',
+    sub_chapter_id BIGINT NOT NULL COMMENT '대상 소단원',
+    content_version_id BIGINT NOT NULL COMMENT '실제로 학습한 콘텐츠 버전',
+    event_type VARCHAR(30) NOT NULL COMMENT 'PROGRESS_UPDATED 또는 COMPLETED',
+    previous_status VARCHAR(20) NULL COMMENT '변경 전 상태. 최초 생성이면 NOT_STARTED',
+    status VARCHAR(20) NOT NULL COMMENT '변경 후 상태',
+    previous_page_id VARCHAR(100) NULL COMMENT '변경 전 마지막 페이지 ID',
+    last_page_id VARCHAR(100) NULL COMMENT '변경 후 마지막 페이지 ID',
+    occurred_at DATETIME NOT NULL COMMENT '진도 변경 발생 시각',
+    CONSTRAINT pk_user_learning_progress_events PRIMARY KEY (progress_event_id),
+    CONSTRAINT fk_learning_progress_events_progress
+        FOREIGN KEY (progress_id) REFERENCES user_learning_progress (progress_id)
+            ON UPDATE RESTRICT ON DELETE RESTRICT,
+    CONSTRAINT fk_learning_progress_events_user
+        FOREIGN KEY (user_id) REFERENCES users (user_id)
+            ON UPDATE RESTRICT ON DELETE RESTRICT,
+    CONSTRAINT fk_learning_progress_events_sub
+        FOREIGN KEY (sub_chapter_id) REFERENCES sub_chapters (sub_chapter_id)
+            ON UPDATE RESTRICT ON DELETE RESTRICT,
+    CONSTRAINT fk_learning_progress_events_content
+        FOREIGN KEY (content_version_id) REFERENCES content_versions (content_version_id)
+            ON UPDATE RESTRICT ON DELETE RESTRICT,
+    CONSTRAINT chk_learning_progress_events_type CHECK (
+        event_type IN ('PROGRESS_UPDATED', 'COMPLETED')
+        ),
+    CONSTRAINT chk_learning_progress_events_previous_status CHECK (
+        previous_status IS NULL
+        OR previous_status IN ('NOT_STARTED', 'IN_PROGRESS', 'COMPLETED')
+        ),
+    CONSTRAINT chk_learning_progress_events_status CHECK (
+        status IN ('IN_PROGRESS', 'COMPLETED')
+        ),
+    INDEX idx_learning_progress_events_progress_time (progress_id, occurred_at),
+    INDEX idx_learning_progress_events_user_time (user_id, occurred_at)
+) ENGINE = InnoDB COMMENT = '사용자 소단원 학습 진도의 생성·이동·최초 완료 변경 이력';
+
 CREATE TABLE quiz_questions (
     question_id BIGINT NOT NULL AUTO_INCREMENT COMMENT '특정 문항 버전 행의 식별자',
     question_key VARCHAR(100) NOT NULL COMMENT '버전 간 동일 문항을 묶는 논리 키',

--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- FirstFolio service database baseline DDL
--- Source: Notion "ERD 2.1" (24 tables total)
--- Scope: 23 non-AI tables. AI/RAG metadata is defined in the AI service DDL.
+-- Source: Notion "ERD 2.1" plus approved schema changes.
+-- Scope: 24 non-AI tables. AI/RAG metadata is defined in the AI service DDL.
 -- Target: MySQL 8.0.16+ (CHECK constraints are enforced from 8.0.16).
 -- Time policy: application code writes UTC values to DATETIME columns.
 
@@ -252,14 +252,15 @@ CREATE TABLE quiz_questions (
     main_chapter_id BIGINT NULL COMMENT '소속 대단원',
     sub_chapter_id BIGINT NULL COMMENT '소속 소단원. 대단원 퀴즈 문항은 NULL',
     display_order INT NULL COMMENT 'DB 범위 내 기본 문항 순서',
-    question_type VARCHAR(30) NOT NULL COMMENT 'SINGLE_CHOICE, MULTIPLE_CHOICE, TRUE_FALSE, SCENARIO',
+    question_type VARCHAR(30) NOT NULL COMMENT 'SINGLE_CHOICE, TRUE_FALSE, SCENARIO',
     difficulty VARCHAR(20) NULL COMMENT 'EASY, MEDIUM, HARD',
     prompt TEXT NOT NULL COMMENT '모든 문항에 공통으로 사용하는 질문 문장',
     scenario_json JSON NULL COMMENT '상황판단형의 캐릭터 상황, 금융시장 상황과 제약 조건',
     options_json JSON NULL COMMENT '선택지 배열',
     correct_answer_json JSON NOT NULL COMMENT '정답 데이터',
     explanation TEXT NOT NULL COMMENT '정답 해설',
-    source_refs_json JSON NULL COMMENT 'AI DB knowledge_contents ID, 근거 출처와 기준 시점. DB 간 FK는 애플리케이션에서 검증',
+    generation_type VARCHAR(20) NOT NULL COMMENT 'HUMAN, AI',
+    source_refs_json JSON NULL COMMENT 'AI 생성 문항의 knowledge_contents ID, 근거 출처와 기준 시점. DB 간 FK는 애플리케이션에서 검증',
     status VARCHAR(20) NOT NULL COMMENT 'DRAFT, REVIEW, PUBLISHED, RETIRED',
     created_by BIGINT NOT NULL COMMENT '작성자 또는 생성 작업 관리자',
     published_at DATETIME NULL COMMENT '게시 일시',
@@ -288,7 +289,6 @@ CREATE TABLE quiz_questions (
     CONSTRAINT chk_quiz_questions_type CHECK (
         question_type IN (
                           'SINGLE_CHOICE',
-                          'MULTIPLE_CHOICE',
                           'TRUE_FALSE',
                           'SCENARIO'
             )
@@ -300,6 +300,17 @@ CREATE TABLE quiz_questions (
         (question_type = 'SCENARIO' AND scenario_json IS NOT NULL)
             OR
         (question_type <> 'SCENARIO' AND scenario_json IS NULL)
+        ),
+    CONSTRAINT chk_quiz_questions_generation_type CHECK (
+        generation_type IN ('HUMAN', 'AI')
+        ),
+    CONSTRAINT chk_quiz_questions_source_refs CHECK (
+        (generation_type = 'HUMAN' AND source_refs_json IS NULL)
+            OR
+        (generation_type = 'AI'
+            AND source_refs_json IS NOT NULL
+            AND JSON_TYPE(source_refs_json) = 'ARRAY'
+            AND JSON_LENGTH(source_refs_json) > 0)
         ),
     CONSTRAINT chk_quiz_questions_status CHECK (
         status IN ('DRAFT', 'REVIEW', 'PUBLISHED', 'RETIRED')

--- a/database.sql
+++ b/database.sql
@@ -340,6 +340,8 @@ CREATE TABLE quiz_attempts (
     total_count INT NOT NULL DEFAULT 0 COMMENT '전체 문제 수',
     correct_count INT NOT NULL DEFAULT 0 COMMENT '정답 수',
     score INT NOT NULL DEFAULT 0 COMMENT '채점 점수',
+    reward_policy_id BIGINT NULL COMMENT '완료 시 적용한 QUIZ_REWARD 정책 버전',
+    point_transaction_id BIGINT NULL COMMENT '최초 응시 완료 보상 원장. 미지급이면 NULL',
     started_at DATETIME NOT NULL COMMENT '응시 시작 일시',
     submitted_at DATETIME NULL COMMENT '최종 제출 일시',
     CONSTRAINT pk_quiz_attempts PRIMARY KEY (attempt_id),
@@ -354,6 +356,9 @@ CREATE TABLE quiz_attempts (
            ON UPDATE RESTRICT ON DELETE RESTRICT,
     CONSTRAINT fk_quiz_attempts_content_version
        FOREIGN KEY (content_version_id) REFERENCES content_versions (content_version_id)
+           ON UPDATE RESTRICT ON DELETE RESTRICT,
+    CONSTRAINT fk_quiz_attempts_reward_policy
+       FOREIGN KEY (reward_policy_id) REFERENCES system_policies (policy_id)
            ON UPDATE RESTRICT ON DELETE RESTRICT,
     CONSTRAINT chk_quiz_attempts_type CHECK (
        quiz_type IN ('LEVEL_TEST', 'SUB_CHAPTER', 'MAIN_CHAPTER')
@@ -377,7 +382,8 @@ CREATE TABLE quiz_attempts (
        ),
     INDEX idx_quiz_attempts_user_status (user_id, quiz_type, status, started_at),
     INDEX idx_quiz_attempts_main_chapter (main_chapter_id, user_id, attempt_no),
-    INDEX idx_quiz_attempts_sub_chapter (sub_chapter_id, user_id, attempt_no)
+    INDEX idx_quiz_attempts_sub_chapter (sub_chapter_id, user_id, attempt_no),
+    INDEX idx_quiz_attempts_reward_policy (reward_policy_id)
 ) ENGINE = InnoDB COMMENT = '레벨·소단원·대단원 퀴즈 응시';
 
 CREATE TABLE quiz_answers (
@@ -426,6 +432,12 @@ CREATE TABLE point_transactions (
     INDEX idx_point_transactions_user_time (user_id, occurred_at),
     INDEX idx_point_transactions_reason (reason_type, reason_id)
 ) ENGINE = InnoDB COMMENT = '포인트 적립·사용·취소·만료 원장';
+
+ALTER TABLE quiz_attempts
+    ADD CONSTRAINT uq_quiz_attempts_point_transaction UNIQUE (point_transaction_id),
+    ADD CONSTRAINT fk_quiz_attempts_point_transaction
+        FOREIGN KEY (point_transaction_id) REFERENCES point_transactions (point_transaction_id)
+            ON UPDATE RESTRICT ON DELETE RESTRICT;
 
 CREATE TABLE daily_quests (
     daily_quest_id BIGINT NOT NULL AUTO_INCREMENT COMMENT '일일 퀘스트 식별자',

--- a/src/main/java/org/firstfolio/config/OpenApiResponseSchemas.java
+++ b/src/main/java/org/firstfolio/config/OpenApiResponseSchemas.java
@@ -27,6 +27,7 @@ import org.firstfolio.portfolio.dto.response.PortfolioResetResponse;
 import org.firstfolio.portfolio.dto.response.PortfolioTransactionPageResponse;
 import org.firstfolio.portfolio.dto.response.TradeResponse;
 import org.firstfolio.quiz.dto.response.QuizQuestionCreateResponse;
+import org.firstfolio.quiz.dto.response.QuizAttemptStartResponse;
 import org.firstfolio.simulation.dto.response.PriceRefreshResponse;
 import org.firstfolio.simulation.dto.response.ProductDetailResponse;
 import org.firstfolio.simulation.dto.response.ProductPageResponse;
@@ -102,6 +103,9 @@ public final class OpenApiResponseSchemas {
 
     @Schema(name = "QuizQuestionCreateApiResponse")
     public record QuizQuestionCreate(QuizQuestionCreateResponse data) { }
+
+    @Schema(name = "QuizAttemptStartApiResponse")
+    public record QuizAttemptStart(QuizAttemptStartResponse data) { }
 
     @Schema(name = "PortfolioDetailApiResponse")
     public record PortfolioDetail(PortfolioDetailResponse data) { }

--- a/src/main/java/org/firstfolio/config/OpenApiResponseSchemas.java
+++ b/src/main/java/org/firstfolio/config/OpenApiResponseSchemas.java
@@ -16,6 +16,8 @@ import org.firstfolio.curriculum.dto.response.SubChapterCreateResponse;
 import org.firstfolio.curriculum.dto.response.SubChapterListResponse;
 import org.firstfolio.curriculum.dto.response.SubChapterPatchResponse;
 import org.firstfolio.learning.dto.response.LessonContentResponse;
+import org.firstfolio.learning.dto.response.PublicMainChapterListResponse;
+import org.firstfolio.learning.dto.response.PublicSubChapterListResponse;
 import org.firstfolio.portfolio.dto.response.PortfolioDetailResponse;
 import org.firstfolio.portfolio.dto.response.PortfolioEventProcessResponse;
 import org.firstfolio.portfolio.dto.response.PortfolioEventRetryResponse;
@@ -55,6 +57,12 @@ public final class OpenApiResponseSchemas {
 
     @Schema(name = "LessonContentApiResponse")
     public record LessonContent(LessonContentResponse data) { }
+
+    @Schema(name = "PublicMainChapterListApiResponse")
+    public record PublicMainChapterList(PublicMainChapterListResponse data) { }
+
+    @Schema(name = "PublicSubChapterListApiResponse")
+    public record PublicSubChapterList(PublicSubChapterListResponse data) { }
 
     @Schema(name = "MainChapterListApiResponse")
     public record MainChapterList(MainChapterListResponse data) { }

--- a/src/main/java/org/firstfolio/config/OpenApiResponseSchemas.java
+++ b/src/main/java/org/firstfolio/config/OpenApiResponseSchemas.java
@@ -26,6 +26,7 @@ import org.firstfolio.portfolio.dto.response.PortfolioEventRetryResponse;
 import org.firstfolio.portfolio.dto.response.PortfolioResetResponse;
 import org.firstfolio.portfolio.dto.response.PortfolioTransactionPageResponse;
 import org.firstfolio.portfolio.dto.response.TradeResponse;
+import org.firstfolio.quiz.dto.response.QuizQuestionCreateResponse;
 import org.firstfolio.simulation.dto.response.PriceRefreshResponse;
 import org.firstfolio.simulation.dto.response.ProductDetailResponse;
 import org.firstfolio.simulation.dto.response.ProductPageResponse;
@@ -98,6 +99,9 @@ public final class OpenApiResponseSchemas {
 
     @Schema(name = "ContentVersionPublishApiResponse")
     public record ContentVersionPublish(ContentVersionPublishResponse data) { }
+
+    @Schema(name = "QuizQuestionCreateApiResponse")
+    public record QuizQuestionCreate(QuizQuestionCreateResponse data) { }
 
     @Schema(name = "PortfolioDetailApiResponse")
     public record PortfolioDetail(PortfolioDetailResponse data) { }

--- a/src/main/java/org/firstfolio/config/OpenApiResponseSchemas.java
+++ b/src/main/java/org/firstfolio/config/OpenApiResponseSchemas.java
@@ -18,6 +18,7 @@ import org.firstfolio.curriculum.dto.response.SubChapterPatchResponse;
 import org.firstfolio.learning.dto.response.LessonContentResponse;
 import org.firstfolio.learning.dto.response.LearningProgressResponse;
 import org.firstfolio.learning.dto.response.LearningProgressUpdateResponse;
+import org.firstfolio.learning.dto.response.LearningContinueResponse;
 import org.firstfolio.learning.dto.response.PublicMainChapterListResponse;
 import org.firstfolio.learning.dto.response.PublicSubChapterListResponse;
 import org.firstfolio.portfolio.dto.response.PortfolioDetailResponse;
@@ -68,6 +69,9 @@ public final class OpenApiResponseSchemas {
 
     @Schema(name = "LearningProgressUpdateApiResponse")
     public record LearningProgressUpdate(LearningProgressUpdateResponse data) { }
+
+    @Schema(name = "LearningContinueApiResponse")
+    public record LearningContinue(LearningContinueResponse data) { }
 
     @Schema(name = "PublicMainChapterListApiResponse")
     public record PublicMainChapterList(PublicMainChapterListResponse data) { }

--- a/src/main/java/org/firstfolio/config/OpenApiResponseSchemas.java
+++ b/src/main/java/org/firstfolio/config/OpenApiResponseSchemas.java
@@ -16,6 +16,8 @@ import org.firstfolio.curriculum.dto.response.SubChapterCreateResponse;
 import org.firstfolio.curriculum.dto.response.SubChapterListResponse;
 import org.firstfolio.curriculum.dto.response.SubChapterPatchResponse;
 import org.firstfolio.learning.dto.response.LessonContentResponse;
+import org.firstfolio.learning.dto.response.LearningProgressResponse;
+import org.firstfolio.learning.dto.response.LearningProgressUpdateResponse;
 import org.firstfolio.learning.dto.response.PublicMainChapterListResponse;
 import org.firstfolio.learning.dto.response.PublicSubChapterListResponse;
 import org.firstfolio.portfolio.dto.response.PortfolioDetailResponse;
@@ -57,6 +59,12 @@ public final class OpenApiResponseSchemas {
 
     @Schema(name = "LessonContentApiResponse")
     public record LessonContent(LessonContentResponse data) { }
+
+    @Schema(name = "LearningProgressApiResponse")
+    public record LearningProgress(LearningProgressResponse data) { }
+
+    @Schema(name = "LearningProgressUpdateApiResponse")
+    public record LearningProgressUpdate(LearningProgressUpdateResponse data) { }
 
     @Schema(name = "PublicMainChapterListApiResponse")
     public record PublicMainChapterList(PublicMainChapterListResponse data) { }

--- a/src/main/java/org/firstfolio/config/OpenApiResponseSchemas.java
+++ b/src/main/java/org/firstfolio/config/OpenApiResponseSchemas.java
@@ -28,6 +28,7 @@ import org.firstfolio.portfolio.dto.response.PortfolioTransactionPageResponse;
 import org.firstfolio.portfolio.dto.response.TradeResponse;
 import org.firstfolio.quiz.dto.response.QuizQuestionCreateResponse;
 import org.firstfolio.quiz.dto.response.QuizAttemptStartResponse;
+import org.firstfolio.quiz.dto.response.QuizAnswerGradingResponse;
 import org.firstfolio.simulation.dto.response.PriceRefreshResponse;
 import org.firstfolio.simulation.dto.response.ProductDetailResponse;
 import org.firstfolio.simulation.dto.response.ProductPageResponse;
@@ -106,6 +107,9 @@ public final class OpenApiResponseSchemas {
 
     @Schema(name = "QuizAttemptStartApiResponse")
     public record QuizAttemptStart(QuizAttemptStartResponse data) { }
+
+    @Schema(name = "QuizAnswerGradingApiResponse")
+    public record QuizAnswerGrading(QuizAnswerGradingResponse data) { }
 
     @Schema(name = "PortfolioDetailApiResponse")
     public record PortfolioDetail(PortfolioDetailResponse data) { }

--- a/src/main/java/org/firstfolio/curriculum/domain/PublicSubChapter.java
+++ b/src/main/java/org/firstfolio/curriculum/domain/PublicSubChapter.java
@@ -1,0 +1,62 @@
+package org.firstfolio.curriculum.domain;
+
+public class PublicSubChapter {
+
+    private long subChapterId;
+    private long mainChapterId;
+    private String title;
+    private String description;
+    private int displayOrder;
+    private boolean contentAvailable;
+
+    public PublicSubChapter() {
+    }
+
+    public long getSubChapterId() {
+        return subChapterId;
+    }
+
+    public void setSubChapterId(long subChapterId) {
+        this.subChapterId = subChapterId;
+    }
+
+    public long getMainChapterId() {
+        return mainChapterId;
+    }
+
+    public void setMainChapterId(long mainChapterId) {
+        this.mainChapterId = mainChapterId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public int getDisplayOrder() {
+        return displayOrder;
+    }
+
+    public void setDisplayOrder(int displayOrder) {
+        this.displayOrder = displayOrder;
+    }
+
+    public boolean isContentAvailable() {
+        return contentAvailable;
+    }
+
+    public void setContentAvailable(boolean contentAvailable) {
+        this.contentAvailable = contentAvailable;
+    }
+}

--- a/src/main/java/org/firstfolio/curriculum/mapper/SubChapterMapper.java
+++ b/src/main/java/org/firstfolio/curriculum/mapper/SubChapterMapper.java
@@ -3,12 +3,17 @@ package org.firstfolio.curriculum.mapper;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.firstfolio.curriculum.domain.SubChapter;
+import org.firstfolio.curriculum.domain.PublicSubChapter;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Mapper
 public interface SubChapterMapper {
+
+    List<PublicSubChapter> findPublicByMainChapterId(
+            @Param("mainChapterId") long mainChapterId
+    );
 
     List<SubChapter> findAllByMainChapterId(
             @Param("mainChapterId") long mainChapterId

--- a/src/main/java/org/firstfolio/exception/ErrorCode.java
+++ b/src/main/java/org/firstfolio/exception/ErrorCode.java
@@ -35,6 +35,10 @@ public enum ErrorCode {
     CONTENT_NOT_PUBLISHED(HttpStatus.NOT_FOUND, "공개된 강좌 콘텐츠가 없습니다."),
     CONTENT_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "강좌 콘텐츠를 불러올 수 없습니다."),
 
+    // 학습 진도
+    CONTENT_VERSION_MISMATCH(HttpStatus.CONFLICT, "소단원과 콘텐츠 버전이 일치하지 않습니다."),
+    INVALID_PAGE_ID(HttpStatus.UNPROCESSABLE_ENTITY, "존재하지 않는 학습 페이지 ID입니다."),
+
     // 포트폴리오 (FUNC-034, 036)
     // PORTFOLIO_ALREADY_CONFIGURED(409)는 POST /portfolios와 함께 폐기됐다.
     // "최초 구성" 단계 자체가 없어져 두 번 구성할 일이 없다 (2026-08-05 팀 확정).

--- a/src/main/java/org/firstfolio/exception/ErrorCode.java
+++ b/src/main/java/org/firstfolio/exception/ErrorCode.java
@@ -49,6 +49,7 @@ public enum ErrorCode {
     ATTEMPT_ALREADY_GRADED(HttpStatus.CONFLICT, "이미 종료된 퀴즈 응시입니다."),
     ANSWER_ALREADY_SUBMITTED(HttpStatus.CONFLICT, "이미 제출한 답안은 변경할 수 없습니다."),
     INVALID_SELECTED_CHOICE(HttpStatus.UNPROCESSABLE_ENTITY, "선택한 답안이 올바르지 않습니다."),
+    SUB_CHAPTERS_INCOMPLETE(HttpStatus.FORBIDDEN, "대단원의 모든 소단원 학습을 먼저 완료해야 합니다."),
 
     // 학습 진도
     CONTENT_VERSION_MISMATCH(HttpStatus.CONFLICT, "소단원과 콘텐츠 버전이 일치하지 않습니다."),

--- a/src/main/java/org/firstfolio/exception/ErrorCode.java
+++ b/src/main/java/org/firstfolio/exception/ErrorCode.java
@@ -41,6 +41,9 @@ public enum ErrorCode {
     QUESTION_VERSION_CONFLICT(HttpStatus.CONFLICT, "퀴즈 문항 버전을 생성할 수 없습니다."),
     QUESTION_VALIDATION_FAILED(HttpStatus.UNPROCESSABLE_ENTITY, "퀴즈 문항 검증에 실패했습니다."),
 
+    // 퀴즈 응시
+    QUIZ_NOT_AVAILABLE(HttpStatus.FORBIDDEN, "현재 조건에서는 퀴즈에 응시할 수 없습니다."),
+
     // 학습 진도
     CONTENT_VERSION_MISMATCH(HttpStatus.CONFLICT, "소단원과 콘텐츠 버전이 일치하지 않습니다."),
     INVALID_PAGE_ID(HttpStatus.UNPROCESSABLE_ENTITY, "존재하지 않는 학습 페이지 ID입니다."),

--- a/src/main/java/org/firstfolio/exception/ErrorCode.java
+++ b/src/main/java/org/firstfolio/exception/ErrorCode.java
@@ -35,6 +35,12 @@ public enum ErrorCode {
     CONTENT_NOT_PUBLISHED(HttpStatus.NOT_FOUND, "공개된 강좌 콘텐츠가 없습니다."),
     CONTENT_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "강좌 콘텐츠를 불러올 수 없습니다."),
 
+    // 퀴즈 문항 콘텐츠
+    QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "퀴즈 문항을 찾을 수 없습니다."),
+    QUESTION_KEY_CONFLICT(HttpStatus.CONFLICT, "이미 존재하는 퀴즈 문항 논리 키입니다."),
+    QUESTION_VERSION_CONFLICT(HttpStatus.CONFLICT, "퀴즈 문항 버전을 생성할 수 없습니다."),
+    QUESTION_VALIDATION_FAILED(HttpStatus.UNPROCESSABLE_ENTITY, "퀴즈 문항 검증에 실패했습니다."),
+
     // 학습 진도
     CONTENT_VERSION_MISMATCH(HttpStatus.CONFLICT, "소단원과 콘텐츠 버전이 일치하지 않습니다."),
     INVALID_PAGE_ID(HttpStatus.UNPROCESSABLE_ENTITY, "존재하지 않는 학습 페이지 ID입니다."),

--- a/src/main/java/org/firstfolio/exception/ErrorCode.java
+++ b/src/main/java/org/firstfolio/exception/ErrorCode.java
@@ -43,6 +43,12 @@ public enum ErrorCode {
 
     // 퀴즈 응시
     QUIZ_NOT_AVAILABLE(HttpStatus.FORBIDDEN, "현재 조건에서는 퀴즈에 응시할 수 없습니다."),
+    QUIZ_ATTEMPT_FORBIDDEN(HttpStatus.FORBIDDEN, "본인 소유의 퀴즈 응시가 아닙니다."),
+    QUIZ_ATTEMPT_NOT_FOUND(HttpStatus.NOT_FOUND, "퀴즈 응시를 찾을 수 없습니다."),
+    QUESTION_NOT_IN_ATTEMPT(HttpStatus.NOT_FOUND, "해당 응시에 포함된 문항이 아닙니다."),
+    ATTEMPT_ALREADY_GRADED(HttpStatus.CONFLICT, "이미 종료된 퀴즈 응시입니다."),
+    ANSWER_ALREADY_SUBMITTED(HttpStatus.CONFLICT, "이미 제출한 답안은 변경할 수 없습니다."),
+    INVALID_SELECTED_CHOICE(HttpStatus.UNPROCESSABLE_ENTITY, "선택한 답안이 올바르지 않습니다."),
 
     // 학습 진도
     CONTENT_VERSION_MISMATCH(HttpStatus.CONFLICT, "소단원과 콘텐츠 버전이 일치하지 않습니다."),

--- a/src/main/java/org/firstfolio/exception/ErrorCode.java
+++ b/src/main/java/org/firstfolio/exception/ErrorCode.java
@@ -52,6 +52,7 @@ public enum ErrorCode {
     SUB_CHAPTERS_INCOMPLETE(HttpStatus.FORBIDDEN, "대단원의 모든 소단원 학습을 먼저 완료해야 합니다."),
 
     // 학습 진도
+    CONTINUE_POSITION_NOT_FOUND(HttpStatus.NOT_FOUND, "이어갈 미완료 학습 위치가 없습니다."),
     CONTENT_VERSION_MISMATCH(HttpStatus.CONFLICT, "소단원과 콘텐츠 버전이 일치하지 않습니다."),
     INVALID_PAGE_ID(HttpStatus.UNPROCESSABLE_ENTITY, "존재하지 않는 학습 페이지 ID입니다."),
 

--- a/src/main/java/org/firstfolio/learning/controller/LearningContinueController.java
+++ b/src/main/java/org/firstfolio/learning/controller/LearningContinueController.java
@@ -1,0 +1,63 @@
+package org.firstfolio.learning.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.firstfolio.auth.annotation.CurrentUser;
+import org.firstfolio.auth.domain.AuthenticatedUser;
+import org.firstfolio.common.response.ApiResponse;
+import org.firstfolio.config.OpenApiResponseSchemas;
+import org.firstfolio.learning.dto.response.LearningContinueResponse;
+import org.firstfolio.learning.service.LearningContinueService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/learning/continue")
+@Tag(name = "학습", description = "사용자용 학습 진행 API")
+public class LearningContinueController {
+
+    private final LearningContinueService learningContinueService;
+
+    public LearningContinueController(
+            LearningContinueService learningContinueService
+    ) {
+        this.learningContinueService = learningContinueService;
+    }
+
+    @GetMapping
+    @Operation(
+            summary = "학습 이어하기 위치 조회",
+            description = "현재 사용자의 가장 최근 IN_PROGRESS 소단원과 마지막 페이지 이동 정보를 반환합니다. "
+                    + "저장된 콘텐츠 버전이 현재 공개 버전과 다르면 안전한 호환 정책 확정 전까지 조회하지 않습니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            description = "학습 이어하기 조회 성공",
+                            content = @io.swagger.v3.oas.annotations.media.Content(
+                                    mediaType = "application/json",
+                                    schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                            implementation = OpenApiResponseSchemas.LearningContinue.class
+                                    )
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "404",
+                            description = "CONTINUE_POSITION_NOT_FOUND - 이어갈 미완료 학습 위치 없음"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "503",
+                            description = "CONTENT_UNAVAILABLE - 비활성 단원, 버전 불일치 또는 저장소 조회 실패"
+                    )
+            }
+    )
+    public ApiResponse<LearningContinueResponse> getContinuePosition(
+            @CurrentUser AuthenticatedUser currentUser
+    ) {
+        return ApiResponse.of(LearningContinueResponse.from(
+                learningContinueService.getContinuePosition(
+                        currentUser.userId()
+                )
+        ));
+    }
+}

--- a/src/main/java/org/firstfolio/learning/controller/LearningProgressController.java
+++ b/src/main/java/org/firstfolio/learning/controller/LearningProgressController.java
@@ -1,0 +1,115 @@
+package org.firstfolio.learning.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.firstfolio.auth.annotation.CurrentUser;
+import org.firstfolio.auth.domain.AuthenticatedUser;
+import org.firstfolio.common.response.ApiResponse;
+import org.firstfolio.config.OpenApiResponseSchemas;
+import org.firstfolio.learning.dto.request.LearningProgressUpdateRequest;
+import org.firstfolio.learning.dto.response.LearningProgressResponse;
+import org.firstfolio.learning.dto.response.LearningProgressUpdateResponse;
+import org.firstfolio.learning.service.LearningProgressService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/learning/sub-chapters/{subChapterId}/progress")
+@Tag(name = "학습", description = "사용자용 학습 진행 API")
+public class LearningProgressController {
+
+    private final LearningProgressService learningProgressService;
+
+    public LearningProgressController(LearningProgressService learningProgressService) {
+        this.learningProgressService = learningProgressService;
+    }
+
+    @PutMapping
+    @Operation(
+            summary = "소단원 학습 진도 저장",
+            description = "진도가 없으면 현재 공개 콘텐츠 버전으로 최초 생성하고, 있으면 마지막 페이지 또는 완료 상태를 갱신합니다. "
+                    + "동일 요청과 최초 완료 이후 요청은 기존 상태를 변경하지 않습니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            description = "학습 진도 생성 또는 갱신 성공",
+                            content = @io.swagger.v3.oas.annotations.media.Content(
+                                    mediaType = "application/json",
+                                    schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                            implementation = OpenApiResponseSchemas.LearningProgressUpdate.class
+                                    )
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "404",
+                            description = "SUB_CHAPTER_NOT_FOUND 또는 CONTENT_NOT_PUBLISHED"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "409",
+                            description = "CONTENT_VERSION_MISMATCH"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "422",
+                            description = "INVALID_PAGE_ID"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "503",
+                            description = "CONTENT_UNAVAILABLE"
+                    )
+            }
+    )
+    public ApiResponse<LearningProgressUpdateResponse> save(
+            @CurrentUser AuthenticatedUser currentUser,
+            @Parameter(description = "저장할 소단원 ID", example = "101", required = true)
+            @PathVariable long subChapterId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    description = "콘텐츠 버전, 마지막 페이지와 IN_PROGRESS/COMPLETED 상태"
+            )
+            @RequestBody LearningProgressUpdateRequest request
+    ) {
+        return ApiResponse.of(LearningProgressUpdateResponse.from(
+                learningProgressService.save(
+                        currentUser.userId(),
+                        subChapterId,
+                        request.toCommand()
+                )
+        ));
+    }
+
+    @GetMapping
+    @Operation(
+            summary = "소단원 학습 진행 상태 조회",
+            description = "현재 사용자의 소단원 진도를 조회합니다. 저장된 진도가 없으면 현재 공개 콘텐츠 버전과 NOT_STARTED 상태를 반환합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            description = "학습 진행 상태 조회 성공",
+                            content = @io.swagger.v3.oas.annotations.media.Content(
+                                    mediaType = "application/json",
+                                    schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                            implementation = OpenApiResponseSchemas.LearningProgress.class
+                                    )
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "404",
+                            description = "SUB_CHAPTER_NOT_FOUND 또는 CONTENT_NOT_PUBLISHED"
+                    )
+            }
+    )
+    public ApiResponse<LearningProgressResponse> getStatus(
+            @CurrentUser AuthenticatedUser currentUser,
+            @Parameter(description = "조회할 소단원 ID", example = "101", required = true)
+            @PathVariable long subChapterId
+    ) {
+        return ApiResponse.of(LearningProgressResponse.from(
+                learningProgressService.getStatus(currentUser.userId(), subChapterId)
+        ));
+    }
+}

--- a/src/main/java/org/firstfolio/learning/controller/PublicChapterController.java
+++ b/src/main/java/org/firstfolio/learning/controller/PublicChapterController.java
@@ -1,0 +1,77 @@
+package org.firstfolio.learning.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.firstfolio.common.response.ApiResponse;
+import org.firstfolio.config.OpenApiResponseSchemas;
+import org.firstfolio.learning.dto.response.PublicMainChapterListResponse;
+import org.firstfolio.learning.dto.response.PublicSubChapterListResponse;
+import org.firstfolio.learning.service.PublicChapterQueryService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/learning/main-chapters")
+@Tag(name = "학습", description = "사용자용 학습 콘텐츠 조회 API")
+public class PublicChapterController {
+
+    private final PublicChapterQueryService publicChapterQueryService;
+
+    public PublicChapterController(PublicChapterQueryService publicChapterQueryService) {
+        this.publicChapterQueryService = publicChapterQueryService;
+    }
+
+    @GetMapping
+    @Operation(
+            summary = "공개 대단원 목록 조회",
+            description = "활성 대단원을 표시 순서대로 조회합니다.",
+            responses = @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "공개 대단원 목록 조회 성공",
+                    content = @io.swagger.v3.oas.annotations.media.Content(
+                            mediaType = "application/json",
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                    implementation = OpenApiResponseSchemas.PublicMainChapterList.class
+                            )
+                    )
+            )
+    )
+    public ApiResponse<PublicMainChapterListResponse> getMainChapters() {
+        return ApiResponse.of(PublicMainChapterListResponse.from(
+                publicChapterQueryService.getMainChapters()
+        ));
+    }
+
+    @GetMapping("/{mainChapterId}/sub-chapters")
+    @Operation(
+            summary = "공개 소단원 목록 조회",
+            description = "활성 대단원 아래 활성 소단원을 표시 순서대로 조회하고 현재 공개 강좌 콘텐츠 존재 여부를 반환합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            description = "공개 소단원 목록 조회 성공",
+                            content = @io.swagger.v3.oas.annotations.media.Content(
+                                    mediaType = "application/json",
+                                    schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                            implementation = OpenApiResponseSchemas.PublicSubChapterList.class
+                                    )
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "404",
+                            description = "MAIN_CHAPTER_NOT_FOUND - 대단원이 없거나 비활성 상태"
+                    )
+            }
+    )
+    public ApiResponse<PublicSubChapterListResponse> getSubChapters(
+            @Parameter(description = "조회할 대단원 ID", example = "2", required = true)
+            @PathVariable long mainChapterId
+    ) {
+        return ApiResponse.of(PublicSubChapterListResponse.from(
+                publicChapterQueryService.getSubChapters(mainChapterId)
+        ));
+    }
+}

--- a/src/main/java/org/firstfolio/learning/domain/LearningContinueCandidate.java
+++ b/src/main/java/org/firstfolio/learning/domain/LearningContinueCandidate.java
@@ -1,0 +1,88 @@
+package org.firstfolio.learning.domain;
+
+import java.time.LocalDateTime;
+
+public class LearningContinueCandidate {
+
+    private long curriculumItemId;
+    private long mainChapterId;
+    private boolean mainChapterActive;
+    private long subChapterId;
+    private boolean subChapterActive;
+    private Long currentContentVersionId;
+    private long contentVersionId;
+    private String lastPageId;
+    private LocalDateTime updatedAt;
+
+    public long getCurriculumItemId() {
+        return curriculumItemId;
+    }
+
+    public void setCurriculumItemId(long curriculumItemId) {
+        this.curriculumItemId = curriculumItemId;
+    }
+
+    public long getMainChapterId() {
+        return mainChapterId;
+    }
+
+    public void setMainChapterId(long mainChapterId) {
+        this.mainChapterId = mainChapterId;
+    }
+
+    public boolean isMainChapterActive() {
+        return mainChapterActive;
+    }
+
+    public void setMainChapterActive(boolean mainChapterActive) {
+        this.mainChapterActive = mainChapterActive;
+    }
+
+    public long getSubChapterId() {
+        return subChapterId;
+    }
+
+    public void setSubChapterId(long subChapterId) {
+        this.subChapterId = subChapterId;
+    }
+
+    public boolean isSubChapterActive() {
+        return subChapterActive;
+    }
+
+    public void setSubChapterActive(boolean subChapterActive) {
+        this.subChapterActive = subChapterActive;
+    }
+
+    public Long getCurrentContentVersionId() {
+        return currentContentVersionId;
+    }
+
+    public void setCurrentContentVersionId(Long currentContentVersionId) {
+        this.currentContentVersionId = currentContentVersionId;
+    }
+
+    public long getContentVersionId() {
+        return contentVersionId;
+    }
+
+    public void setContentVersionId(long contentVersionId) {
+        this.contentVersionId = contentVersionId;
+    }
+
+    public String getLastPageId() {
+        return lastPageId;
+    }
+
+    public void setLastPageId(String lastPageId) {
+        this.lastPageId = lastPageId;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/org/firstfolio/learning/domain/LearningContinueResult.java
+++ b/src/main/java/org/firstfolio/learning/domain/LearningContinueResult.java
@@ -1,0 +1,22 @@
+package org.firstfolio.learning.domain;
+
+import java.util.Objects;
+
+public record LearningContinueResult(
+        long curriculumItemId,
+        long mainChapterId,
+        long subChapterId,
+        long contentVersionId,
+        String lastPageId,
+        int progressPercent,
+        String route
+) {
+    public LearningContinueResult {
+        if (progressPercent < 0 || progressPercent > 100) {
+            throw new IllegalArgumentException(
+                    "progressPercent must be between 0 and 100"
+            );
+        }
+        Objects.requireNonNull(route, "route must not be null");
+    }
+}

--- a/src/main/java/org/firstfolio/learning/domain/LearningProgress.java
+++ b/src/main/java/org/firstfolio/learning/domain/LearningProgress.java
@@ -1,0 +1,88 @@
+package org.firstfolio.learning.domain;
+
+import java.time.LocalDateTime;
+
+public class LearningProgress {
+
+    private Long progressId;
+    private long userId;
+    private long subChapterId;
+    private long contentVersionId;
+    private String lastPageId;
+    private LearningProgressStatus status;
+    private LocalDateTime startedAt;
+    private LocalDateTime completedAt;
+    private LocalDateTime updatedAt;
+
+    public Long getProgressId() {
+        return progressId;
+    }
+
+    public void setProgressId(Long progressId) {
+        this.progressId = progressId;
+    }
+
+    public long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(long userId) {
+        this.userId = userId;
+    }
+
+    public long getSubChapterId() {
+        return subChapterId;
+    }
+
+    public void setSubChapterId(long subChapterId) {
+        this.subChapterId = subChapterId;
+    }
+
+    public long getContentVersionId() {
+        return contentVersionId;
+    }
+
+    public void setContentVersionId(long contentVersionId) {
+        this.contentVersionId = contentVersionId;
+    }
+
+    public String getLastPageId() {
+        return lastPageId;
+    }
+
+    public void setLastPageId(String lastPageId) {
+        this.lastPageId = lastPageId;
+    }
+
+    public LearningProgressStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(LearningProgressStatus status) {
+        this.status = status;
+    }
+
+    public LocalDateTime getStartedAt() {
+        return startedAt;
+    }
+
+    public void setStartedAt(LocalDateTime startedAt) {
+        this.startedAt = startedAt;
+    }
+
+    public LocalDateTime getCompletedAt() {
+        return completedAt;
+    }
+
+    public void setCompletedAt(LocalDateTime completedAt) {
+        this.completedAt = completedAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/org/firstfolio/learning/domain/LearningProgressEvent.java
+++ b/src/main/java/org/firstfolio/learning/domain/LearningProgressEvent.java
@@ -1,0 +1,106 @@
+package org.firstfolio.learning.domain;
+
+import java.time.LocalDateTime;
+
+public class LearningProgressEvent {
+
+    private Long progressEventId;
+    private long progressId;
+    private long userId;
+    private long subChapterId;
+    private long contentVersionId;
+    private String eventType;
+    private LearningProgressStatus previousStatus;
+    private LearningProgressStatus status;
+    private String previousPageId;
+    private String lastPageId;
+    private LocalDateTime occurredAt;
+
+    public Long getProgressEventId() {
+        return progressEventId;
+    }
+
+    public void setProgressEventId(Long progressEventId) {
+        this.progressEventId = progressEventId;
+    }
+
+    public long getProgressId() {
+        return progressId;
+    }
+
+    public void setProgressId(long progressId) {
+        this.progressId = progressId;
+    }
+
+    public long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(long userId) {
+        this.userId = userId;
+    }
+
+    public long getSubChapterId() {
+        return subChapterId;
+    }
+
+    public void setSubChapterId(long subChapterId) {
+        this.subChapterId = subChapterId;
+    }
+
+    public long getContentVersionId() {
+        return contentVersionId;
+    }
+
+    public void setContentVersionId(long contentVersionId) {
+        this.contentVersionId = contentVersionId;
+    }
+
+    public String getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(String eventType) {
+        this.eventType = eventType;
+    }
+
+    public LearningProgressStatus getPreviousStatus() {
+        return previousStatus;
+    }
+
+    public void setPreviousStatus(LearningProgressStatus previousStatus) {
+        this.previousStatus = previousStatus;
+    }
+
+    public LearningProgressStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(LearningProgressStatus status) {
+        this.status = status;
+    }
+
+    public String getPreviousPageId() {
+        return previousPageId;
+    }
+
+    public void setPreviousPageId(String previousPageId) {
+        this.previousPageId = previousPageId;
+    }
+
+    public String getLastPageId() {
+        return lastPageId;
+    }
+
+    public void setLastPageId(String lastPageId) {
+        this.lastPageId = lastPageId;
+    }
+
+    public LocalDateTime getOccurredAt() {
+        return occurredAt;
+    }
+
+    public void setOccurredAt(LocalDateTime occurredAt) {
+        this.occurredAt = occurredAt;
+    }
+}

--- a/src/main/java/org/firstfolio/learning/domain/LearningProgressStatus.java
+++ b/src/main/java/org/firstfolio/learning/domain/LearningProgressStatus.java
@@ -1,0 +1,7 @@
+package org.firstfolio.learning.domain;
+
+public enum LearningProgressStatus {
+    NOT_STARTED,
+    IN_PROGRESS,
+    COMPLETED
+}

--- a/src/main/java/org/firstfolio/learning/domain/LearningProgressUpdateCommand.java
+++ b/src/main/java/org/firstfolio/learning/domain/LearningProgressUpdateCommand.java
@@ -1,0 +1,50 @@
+package org.firstfolio.learning.domain;
+
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+
+public record LearningProgressUpdateCommand(
+        long contentVersionId,
+        String lastPageId,
+        LearningProgressStatus status
+) {
+    public static LearningProgressUpdateCommand of(
+            Long contentVersionId,
+            String lastPageId,
+            String status
+    ) {
+        if (contentVersionId == null || contentVersionId <= 0) {
+            throw new ApiException(
+                    ErrorCode.INVALID_REQUEST,
+                    "콘텐츠 버전 ID가 필요합니다."
+            );
+        }
+
+        LearningProgressStatus parsed;
+        try {
+            parsed = LearningProgressStatus.valueOf(status);
+        } catch (NullPointerException | IllegalArgumentException exception) {
+            throw new ApiException(
+                    ErrorCode.INVALID_REQUEST,
+                    "학습 상태는 IN_PROGRESS 또는 COMPLETED여야 합니다."
+            );
+        }
+
+        if (parsed == LearningProgressStatus.NOT_STARTED) {
+            throw new ApiException(
+                    ErrorCode.INVALID_REQUEST,
+                    "NOT_STARTED는 진도 저장 상태로 사용할 수 없습니다."
+            );
+        }
+
+        if (lastPageId != null && lastPageId.isBlank()) {
+            throw new ApiException(ErrorCode.INVALID_PAGE_ID);
+        }
+
+        return new LearningProgressUpdateCommand(
+                contentVersionId,
+                lastPageId,
+                parsed
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/learning/domain/LearningProgressUpdateResult.java
+++ b/src/main/java/org/firstfolio/learning/domain/LearningProgressUpdateResult.java
@@ -1,0 +1,7 @@
+package org.firstfolio.learning.domain;
+
+public record LearningProgressUpdateResult(
+        LearningProgress progress,
+        boolean updated
+) {
+}

--- a/src/main/java/org/firstfolio/learning/domain/MainChapterCompletionResult.java
+++ b/src/main/java/org/firstfolio/learning/domain/MainChapterCompletionResult.java
@@ -1,0 +1,28 @@
+package org.firstfolio.learning.domain;
+
+import org.firstfolio.curriculum.domain.ChapterType;
+import org.firstfolio.portfolio.service.InitialGrantResult;
+
+import java.util.Objects;
+
+public record MainChapterCompletionResult(
+        ChapterType chapterType,
+        boolean completedNow,
+        InitialGrantResult foundationGrant
+) {
+    public MainChapterCompletionResult {
+        Objects.requireNonNull(chapterType, "chapterType must not be null");
+        if (chapterType == ChapterType.FOUNDATION
+                && foundationGrant == null) {
+            throw new IllegalArgumentException(
+                    "foundation completion must include grant result"
+            );
+        }
+        if (chapterType != ChapterType.FOUNDATION
+                && foundationGrant != null) {
+            throw new IllegalArgumentException(
+                    "asset completion must not include foundation grant"
+            );
+        }
+    }
+}

--- a/src/main/java/org/firstfolio/learning/domain/UserCurriculumItem.java
+++ b/src/main/java/org/firstfolio/learning/domain/UserCurriculumItem.java
@@ -1,0 +1,52 @@
+package org.firstfolio.learning.domain;
+
+import java.time.LocalDateTime;
+
+public class UserCurriculumItem {
+
+    private long curriculumItemId;
+    private long userId;
+    private long mainChapterId;
+    private String status;
+    private LocalDateTime completedAt;
+
+    public long getCurriculumItemId() {
+        return curriculumItemId;
+    }
+
+    public void setCurriculumItemId(long curriculumItemId) {
+        this.curriculumItemId = curriculumItemId;
+    }
+
+    public long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(long userId) {
+        this.userId = userId;
+    }
+
+    public long getMainChapterId() {
+        return mainChapterId;
+    }
+
+    public void setMainChapterId(long mainChapterId) {
+        this.mainChapterId = mainChapterId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public LocalDateTime getCompletedAt() {
+        return completedAt;
+    }
+
+    public void setCompletedAt(LocalDateTime completedAt) {
+        this.completedAt = completedAt;
+    }
+}

--- a/src/main/java/org/firstfolio/learning/dto/request/LearningProgressUpdateRequest.java
+++ b/src/main/java/org/firstfolio/learning/dto/request/LearningProgressUpdateRequest.java
@@ -1,0 +1,25 @@
+package org.firstfolio.learning.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.firstfolio.learning.domain.LearningProgressUpdateCommand;
+
+@Schema(description = "소단원 학습 진도 저장 정보")
+public record LearningProgressUpdateRequest(
+        @Schema(description = "실제로 학습 중인 콘텐츠 버전 ID", example = "301")
+        Long contentVersionId,
+        @Schema(description = "JSON 내부 마지막 학습 페이지 ID", example = "page-2",
+                nullable = true)
+        String lastPageId,
+        @Schema(description = "저장할 학습 상태", allowableValues = {
+                "IN_PROGRESS", "COMPLETED"
+        }, example = "IN_PROGRESS")
+        String status
+) {
+    public LearningProgressUpdateCommand toCommand() {
+        return LearningProgressUpdateCommand.of(
+                contentVersionId,
+                lastPageId,
+                status
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/learning/dto/response/LearningContinueResponse.java
+++ b/src/main/java/org/firstfolio/learning/dto/response/LearningContinueResponse.java
@@ -1,0 +1,31 @@
+package org.firstfolio.learning.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.firstfolio.learning.domain.LearningContinueResult;
+
+@Schema(description = "마지막 미완료 학습 위치와 이동 정보")
+public record LearningContinueResponse(
+        @Schema(description = "개인 커리큘럼 항목 ID", example = "502") long curriculumItemId,
+        @Schema(description = "대단원 ID", example = "2") long mainChapterId,
+        @Schema(description = "소단원 ID", example = "101") long subChapterId,
+        @Schema(description = "학습 중인 콘텐츠 버전 ID", example = "301") long contentVersionId,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "JSON 내부 마지막 학습 페이지 ID", example = "page-2", nullable = true)
+        String lastPageId,
+        @Schema(description = "현재 소단원 페이지 진행률", example = "35") int progressPercent,
+        @Schema(description = "프론트엔드 이동 경로", example = "/learning/sub-chapters/101?page=page-2")
+        String route
+) {
+    public static LearningContinueResponse from(LearningContinueResult result) {
+        return new LearningContinueResponse(
+                result.curriculumItemId(),
+                result.mainChapterId(),
+                result.subChapterId(),
+                result.contentVersionId(),
+                result.lastPageId(),
+                result.progressPercent(),
+                result.route()
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/learning/dto/response/LearningProgressResponse.java
+++ b/src/main/java/org/firstfolio/learning/dto/response/LearningProgressResponse.java
@@ -1,0 +1,32 @@
+package org.firstfolio.learning.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.firstfolio.learning.domain.LearningProgress;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "사용자의 소단원 학습 진행 상태")
+public record LearningProgressResponse(
+        @Schema(description = "소단원 ID", example = "101") long subChapterId,
+        @Schema(description = "실제로 학습하는 강좌 콘텐츠 버전 ID", example = "301")
+        long contentVersionId,
+        @Schema(description = "마지막으로 학습한 JSON 페이지 ID", example = "page-2",
+                nullable = true)
+        String lastPageId,
+        @Schema(description = "학습 상태", example = "IN_PROGRESS") String status,
+        @Schema(description = "최초 학습 시작 시각", nullable = true)
+        LocalDateTime startedAt,
+        @Schema(description = "최초 학습 완료 시각", nullable = true)
+        LocalDateTime completedAt
+) {
+    public static LearningProgressResponse from(LearningProgress progress) {
+        return new LearningProgressResponse(
+                progress.getSubChapterId(),
+                progress.getContentVersionId(),
+                progress.getLastPageId(),
+                progress.getStatus().name(),
+                progress.getStartedAt(),
+                progress.getCompletedAt()
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/learning/dto/response/LearningProgressUpdateResponse.java
+++ b/src/main/java/org/firstfolio/learning/dto/response/LearningProgressUpdateResponse.java
@@ -1,0 +1,39 @@
+package org.firstfolio.learning.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.firstfolio.learning.domain.LearningProgress;
+import org.firstfolio.learning.domain.LearningProgressUpdateResult;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "소단원 학습 진도 저장 결과")
+public record LearningProgressUpdateResponse(
+        @Schema(description = "소단원 ID", example = "101") long subChapterId,
+        @Schema(description = "실제로 학습 중인 콘텐츠 버전 ID", example = "301")
+        long contentVersionId,
+        @Schema(description = "마지막으로 학습한 JSON 페이지 ID", example = "page-2",
+                nullable = true)
+        String lastPageId,
+        @Schema(description = "학습 상태", example = "IN_PROGRESS") String status,
+        @Schema(description = "최초 학습 시작 시각") LocalDateTime startedAt,
+        @Schema(description = "최초 학습 완료 시각", nullable = true)
+        LocalDateTime completedAt,
+        @Schema(description = "이번 요청에서 진도가 생성 또는 변경됐는지 여부",
+                example = "true")
+        boolean updated
+) {
+    public static LearningProgressUpdateResponse from(
+            LearningProgressUpdateResult result
+    ) {
+        LearningProgress progress = result.progress();
+        return new LearningProgressUpdateResponse(
+                progress.getSubChapterId(),
+                progress.getContentVersionId(),
+                progress.getLastPageId(),
+                progress.getStatus().name(),
+                progress.getStartedAt(),
+                progress.getCompletedAt(),
+                result.updated()
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/learning/dto/response/PublicMainChapterListItemResponse.java
+++ b/src/main/java/org/firstfolio/learning/dto/response/PublicMainChapterListItemResponse.java
@@ -1,0 +1,32 @@
+package org.firstfolio.learning.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.firstfolio.curriculum.domain.AssetType;
+import org.firstfolio.curriculum.domain.MainChapter;
+
+@Schema(description = "사용자에게 공개되는 대단원 목록 항목")
+public record PublicMainChapterListItemResponse(
+        @Schema(description = "대단원 ID", example = "2") long mainChapterId,
+        @Schema(description = "대단원 유형", example = "ASSET") String chapterType,
+        @Schema(description = "자산군. FOUNDATION이면 null", example = "DEPOSIT_SAVINGS")
+        AssetType assetType,
+        @Schema(description = "대단원 제목", example = "예·적금") String title,
+        @Schema(description = "대단원 설명", example = "예금과 적금의 기본 원리")
+        String description,
+        @Schema(description = "표시 순서", example = "2") int displayOrder,
+        @JsonProperty("is_required")
+        @Schema(description = "필수 과정 여부", example = "false") boolean isRequired
+) {
+    public static PublicMainChapterListItemResponse from(MainChapter chapter) {
+        return new PublicMainChapterListItemResponse(
+                chapter.getMainChapterId(),
+                chapter.getChapterType().name(),
+                chapter.getAssetType(),
+                chapter.getTitle(),
+                chapter.getDescription(),
+                chapter.getDisplayOrder(),
+                chapter.isRequired()
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/learning/dto/response/PublicMainChapterListResponse.java
+++ b/src/main/java/org/firstfolio/learning/dto/response/PublicMainChapterListResponse.java
@@ -1,0 +1,19 @@
+package org.firstfolio.learning.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.firstfolio.curriculum.domain.MainChapter;
+
+import java.util.List;
+
+@Schema(description = "사용자용 공개 대단원 목록")
+public record PublicMainChapterListResponse(
+        List<PublicMainChapterListItemResponse> items
+) {
+    public static PublicMainChapterListResponse from(List<MainChapter> chapters) {
+        return new PublicMainChapterListResponse(
+                chapters.stream()
+                        .map(PublicMainChapterListItemResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/learning/dto/response/PublicSubChapterListItemResponse.java
+++ b/src/main/java/org/firstfolio/learning/dto/response/PublicSubChapterListItemResponse.java
@@ -1,0 +1,24 @@
+package org.firstfolio.learning.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.firstfolio.curriculum.domain.PublicSubChapter;
+
+@Schema(description = "사용자에게 공개되는 소단원 목록 항목")
+public record PublicSubChapterListItemResponse(
+        @Schema(description = "소단원 ID", example = "101") long subChapterId,
+        @Schema(description = "소단원 제목", example = "예금의 이해") String title,
+        @Schema(description = "소단원 설명", example = "예금의 기본 개념") String description,
+        @Schema(description = "표시 순서", example = "1") int displayOrder,
+        @Schema(description = "현재 공개 강좌 콘텐츠 존재 여부", example = "true")
+        boolean contentAvailable
+) {
+    public static PublicSubChapterListItemResponse from(PublicSubChapter chapter) {
+        return new PublicSubChapterListItemResponse(
+                chapter.getSubChapterId(),
+                chapter.getTitle(),
+                chapter.getDescription(),
+                chapter.getDisplayOrder(),
+                chapter.isContentAvailable()
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/learning/dto/response/PublicSubChapterListResponse.java
+++ b/src/main/java/org/firstfolio/learning/dto/response/PublicSubChapterListResponse.java
@@ -1,0 +1,19 @@
+package org.firstfolio.learning.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.firstfolio.curriculum.domain.PublicSubChapter;
+
+import java.util.List;
+
+@Schema(description = "사용자용 공개 소단원 목록")
+public record PublicSubChapterListResponse(
+        List<PublicSubChapterListItemResponse> items
+) {
+    public static PublicSubChapterListResponse from(List<PublicSubChapter> chapters) {
+        return new PublicSubChapterListResponse(
+                chapters.stream()
+                        .map(PublicSubChapterListItemResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/learning/mapper/LearningContinueMapper.java
+++ b/src/main/java/org/firstfolio/learning/mapper/LearningContinueMapper.java
@@ -1,0 +1,13 @@
+package org.firstfolio.learning.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.firstfolio.learning.domain.LearningContinueCandidate;
+
+@Mapper
+public interface LearningContinueMapper {
+
+    LearningContinueCandidate findLatestInProgress(
+            @Param("userId") long userId
+    );
+}

--- a/src/main/java/org/firstfolio/learning/mapper/LearningProgressMapper.java
+++ b/src/main/java/org/firstfolio/learning/mapper/LearningProgressMapper.java
@@ -1,0 +1,26 @@
+package org.firstfolio.learning.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.firstfolio.learning.domain.LearningProgress;
+import org.firstfolio.learning.domain.LearningProgressEvent;
+
+@Mapper
+public interface LearningProgressMapper {
+
+    LearningProgress findByUserIdAndSubChapterId(
+            @Param("userId") long userId,
+            @Param("subChapterId") long subChapterId
+    );
+
+    LearningProgress findByUserIdAndSubChapterIdForUpdate(
+            @Param("userId") long userId,
+            @Param("subChapterId") long subChapterId
+    );
+
+    int insertIfAbsent(LearningProgress progress);
+
+    int updateProgress(LearningProgress progress);
+
+    int insertEvent(LearningProgressEvent event);
+}

--- a/src/main/java/org/firstfolio/learning/mapper/MainChapterLearningMapper.java
+++ b/src/main/java/org/firstfolio/learning/mapper/MainChapterLearningMapper.java
@@ -1,0 +1,30 @@
+package org.firstfolio.learning.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.firstfolio.learning.domain.UserCurriculumItem;
+
+import java.time.LocalDateTime;
+
+@Mapper
+public interface MainChapterLearningMapper {
+
+    UserCurriculumItem findActiveCurriculumItemForUpdate(
+            @Param("userId") long userId,
+            @Param("mainChapterId") long mainChapterId
+    );
+
+    int countActiveSubChapters(
+            @Param("mainChapterId") long mainChapterId
+    );
+
+    int countIncompleteActiveSubChapters(
+            @Param("userId") long userId,
+            @Param("mainChapterId") long mainChapterId
+    );
+
+    int completeCurriculumItemIfIncomplete(
+            @Param("curriculumItemId") long curriculumItemId,
+            @Param("completedAt") LocalDateTime completedAt
+    );
+}

--- a/src/main/java/org/firstfolio/learning/service/LearningContinueService.java
+++ b/src/main/java/org/firstfolio/learning/service/LearningContinueService.java
@@ -1,0 +1,177 @@
+package org.firstfolio.learning.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.firstfolio.content.domain.ContentVersion;
+import org.firstfolio.content.domain.ContentVersionStatus;
+import org.firstfolio.content.domain.StoredContent;
+import org.firstfolio.content.domain.StoredObjectRef;
+import org.firstfolio.content.exception.ContentStorageException;
+import org.firstfolio.content.mapper.ContentVersionMapper;
+import org.firstfolio.content.service.StaticContentStorage;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.learning.domain.LearningContinueCandidate;
+import org.firstfolio.learning.domain.LearningContinueResult;
+import org.firstfolio.learning.mapper.LearningContinueMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+@Service
+public class LearningContinueService {
+
+    private static final String JSON_CONTENT_TYPE = "application/json";
+
+    private final LearningContinueMapper learningContinueMapper;
+    private final ContentVersionMapper contentVersionMapper;
+    private final StaticContentStorage contentStorage;
+    private final ObjectMapper objectMapper;
+
+    public LearningContinueService(
+            LearningContinueMapper learningContinueMapper,
+            ContentVersionMapper contentVersionMapper,
+            StaticContentStorage contentStorage
+    ) {
+        this.learningContinueMapper = learningContinueMapper;
+        this.contentVersionMapper = contentVersionMapper;
+        this.contentStorage = contentStorage;
+        this.objectMapper = new ObjectMapper();
+    }
+
+    @Transactional(readOnly = true)
+    public LearningContinueResult getContinuePosition(long userId) {
+        LearningContinueCandidate candidate = learningContinueMapper
+                .findLatestInProgress(userId);
+        if (candidate == null) {
+            throw new ApiException(ErrorCode.CONTINUE_POSITION_NOT_FOUND);
+        }
+        requireCurrentPublishedPosition(candidate);
+
+        ContentVersion version = contentVersionMapper.findById(
+                candidate.getContentVersionId()
+        );
+        if (version == null
+                || version.getSubChapterId() != candidate.getSubChapterId()
+                || version.getStatus() != ContentVersionStatus.PUBLISHED) {
+            throw unavailable(null);
+        }
+
+        List<String> pageIds = loadPageIds(version);
+        String lastPageId = candidate.getLastPageId();
+        int progressPercent = calculateProgressPercent(pageIds, lastPageId);
+        return new LearningContinueResult(
+                candidate.getCurriculumItemId(),
+                candidate.getMainChapterId(),
+                candidate.getSubChapterId(),
+                candidate.getContentVersionId(),
+                lastPageId,
+                progressPercent,
+                route(candidate.getSubChapterId(), lastPageId)
+        );
+    }
+
+    private void requireCurrentPublishedPosition(
+            LearningContinueCandidate candidate
+    ) {
+        if (!candidate.isMainChapterActive()
+                || !candidate.isSubChapterActive()
+                || !Objects.equals(
+                        candidate.getCurrentContentVersionId(),
+                        candidate.getContentVersionId()
+                )) {
+            throw unavailable(null);
+        }
+    }
+
+    private List<String> loadPageIds(ContentVersion version) {
+        StoredContent stored;
+        try {
+            stored = contentStorage.load(new StoredObjectRef(
+                    version.getStorageObjectKey(),
+                    version.getStorageVersionId()
+            ));
+        } catch (ContentStorageException | IllegalArgumentException exception) {
+            throw unavailable(exception);
+        }
+        if (!isJson(stored.contentType())) {
+            throw unavailable(null);
+        }
+
+        try {
+            JsonNode lesson = objectMapper.readTree(new String(
+                    stored.content(),
+                    StandardCharsets.UTF_8
+            ));
+            if (lesson == null
+                    || !lesson.isObject()
+                    || !Objects.equals(
+                            version.getSchemaVersion(),
+                            lesson.path("schemaVersion").textValue()
+                    )) {
+                throw unavailable(null);
+            }
+
+            JsonNode pages = lesson.path("pages");
+            if (!pages.isArray() || pages.isEmpty()) {
+                throw unavailable(null);
+            }
+            List<String> pageIds = new ArrayList<>();
+            Set<String> uniquePageIds = new HashSet<>();
+            for (JsonNode page : pages) {
+                String pageId = page.path("id").textValue();
+                if (pageId == null
+                        || pageId.isBlank()
+                        || !uniquePageIds.add(pageId)) {
+                    throw unavailable(null);
+                }
+                pageIds.add(pageId);
+            }
+            return List.copyOf(pageIds);
+        } catch (JsonProcessingException exception) {
+            throw unavailable(exception);
+        }
+    }
+
+    private int calculateProgressPercent(
+            List<String> pageIds,
+            String lastPageId
+    ) {
+        if (lastPageId == null) {
+            return 0;
+        }
+        int pageIndex = pageIds.indexOf(lastPageId);
+        if (pageIndex < 0) {
+            throw unavailable(null);
+        }
+        return Math.round((pageIndex + 1) * 100.0f / pageIds.size());
+    }
+
+    private String route(long subChapterId, String lastPageId) {
+        String baseRoute = "/learning/sub-chapters/" + subChapterId;
+        return lastPageId == null
+                ? baseRoute
+                : baseRoute + "?page=" + lastPageId;
+    }
+
+    private boolean isJson(String contentType) {
+        return JSON_CONTENT_TYPE.equalsIgnoreCase(
+                contentType.split(";", 2)[0].trim()
+        );
+    }
+
+    private ApiException unavailable(Throwable cause) {
+        return new ApiException(
+                ErrorCode.CONTENT_UNAVAILABLE,
+                ErrorCode.CONTENT_UNAVAILABLE.getDefaultMessage(),
+                cause
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/learning/service/LearningProgressService.java
+++ b/src/main/java/org/firstfolio/learning/service/LearningProgressService.java
@@ -1,0 +1,333 @@
+package org.firstfolio.learning.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.firstfolio.content.domain.ContentVersion;
+import org.firstfolio.content.domain.PublishedLessonReference;
+import org.firstfolio.content.domain.StoredContent;
+import org.firstfolio.content.domain.StoredObjectRef;
+import org.firstfolio.content.exception.ContentStorageException;
+import org.firstfolio.content.mapper.ContentVersionMapper;
+import org.firstfolio.content.service.StaticContentStorage;
+import org.firstfolio.curriculum.domain.SubChapter;
+import org.firstfolio.curriculum.mapper.SubChapterMapper;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.learning.domain.LearningProgress;
+import org.firstfolio.learning.domain.LearningProgressEvent;
+import org.firstfolio.learning.domain.LearningProgressStatus;
+import org.firstfolio.learning.domain.LearningProgressUpdateCommand;
+import org.firstfolio.learning.domain.LearningProgressUpdateResult;
+import org.firstfolio.learning.mapper.LearningProgressMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Service
+public class LearningProgressService {
+
+    private static final String JSON_CONTENT_TYPE = "application/json";
+
+    private final LearningProgressMapper learningProgressMapper;
+    private final ContentVersionMapper contentVersionMapper;
+    private final SubChapterMapper subChapterMapper;
+    private final StaticContentStorage contentStorage;
+    private final Clock clock;
+    private final ObjectMapper objectMapper;
+
+    public LearningProgressService(
+            LearningProgressMapper learningProgressMapper,
+            ContentVersionMapper contentVersionMapper,
+            SubChapterMapper subChapterMapper,
+            StaticContentStorage contentStorage,
+            Clock clock
+    ) {
+        this.learningProgressMapper = learningProgressMapper;
+        this.contentVersionMapper = contentVersionMapper;
+        this.subChapterMapper = subChapterMapper;
+        this.contentStorage = contentStorage;
+        this.clock = clock;
+        this.objectMapper = new ObjectMapper();
+    }
+
+    @Transactional
+    public LearningProgressUpdateResult save(
+            long userId,
+            long subChapterId,
+            LearningProgressUpdateCommand command
+    ) {
+        requireActiveSubChapter(subChapterId);
+        LearningProgress progress = learningProgressMapper
+                .findByUserIdAndSubChapterIdForUpdate(userId, subChapterId);
+
+        if (progress == null) {
+            progress = createFirstProgress(userId, subChapterId, command);
+            if (progress != null) {
+                return new LearningProgressUpdateResult(progress, true);
+            }
+
+            progress = learningProgressMapper
+                    .findByUserIdAndSubChapterIdForUpdate(userId, subChapterId);
+            if (progress == null) {
+                throw new ApiException(ErrorCode.INTERNAL_ERROR);
+            }
+        }
+
+        return updateExistingProgress(progress, command);
+    }
+
+    @Transactional(readOnly = true)
+    public LearningProgress getStatus(long userId, long subChapterId) {
+        requireActiveSubChapter(subChapterId);
+        LearningProgress progress = learningProgressMapper
+                .findByUserIdAndSubChapterId(userId, subChapterId);
+
+        if (progress != null) {
+            return progress;
+        }
+
+        PublishedLessonReference published = contentVersionMapper
+                .findCurrentPublishedLesson(subChapterId);
+        if (published == null) {
+            throw new ApiException(ErrorCode.CONTENT_NOT_PUBLISHED);
+        }
+
+        LearningProgress notStarted = new LearningProgress();
+        notStarted.setUserId(userId);
+        notStarted.setSubChapterId(subChapterId);
+        notStarted.setContentVersionId(published.getContentVersionId());
+        notStarted.setStatus(LearningProgressStatus.NOT_STARTED);
+        return notStarted;
+    }
+
+    private LearningProgress createFirstProgress(
+            long userId,
+            long subChapterId,
+            LearningProgressUpdateCommand command
+    ) {
+        PublishedLessonReference published = contentVersionMapper
+                .findCurrentPublishedLesson(subChapterId);
+        if (published == null) {
+            throw new ApiException(ErrorCode.CONTENT_NOT_PUBLISHED);
+        }
+        if (published.getContentVersionId() != command.contentVersionId()) {
+            throw new ApiException(ErrorCode.CONTENT_VERSION_MISMATCH);
+        }
+
+        validatePageId(subChapterId, command.contentVersionId(), command.lastPageId());
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        LearningProgress created = new LearningProgress();
+        created.setUserId(userId);
+        created.setSubChapterId(subChapterId);
+        created.setContentVersionId(command.contentVersionId());
+        created.setLastPageId(command.lastPageId());
+        created.setStatus(command.status());
+        created.setStartedAt(now);
+        created.setCompletedAt(command.status() == LearningProgressStatus.COMPLETED
+                ? now : null);
+        created.setUpdatedAt(now);
+
+        if (learningProgressMapper.insertIfAbsent(created) != 1) {
+            return null;
+        }
+
+        LearningProgress stored = learningProgressMapper
+                .findByUserIdAndSubChapterIdForUpdate(userId, subChapterId);
+        if (stored == null) {
+            throw new ApiException(ErrorCode.INTERNAL_ERROR);
+        }
+
+        insertEvent(
+                stored,
+                LearningProgressStatus.NOT_STARTED,
+                null,
+                eventType(command.status()),
+                now
+        );
+        return stored;
+    }
+
+    private LearningProgressUpdateResult updateExistingProgress(
+            LearningProgress progress,
+            LearningProgressUpdateCommand command
+    ) {
+        if (progress.getContentVersionId() != command.contentVersionId()) {
+            throw new ApiException(ErrorCode.CONTENT_VERSION_MISMATCH);
+        }
+
+        String targetPageId = command.lastPageId() == null
+                ? progress.getLastPageId() : command.lastPageId();
+        List<String> pageIds = validatePageId(
+                progress.getSubChapterId(),
+                command.contentVersionId(),
+                targetPageId
+        );
+
+        if (progress.getStatus() == LearningProgressStatus.COMPLETED) {
+            return new LearningProgressUpdateResult(progress, false);
+        }
+
+        if (isBackwardMove(pageIds, progress.getLastPageId(), targetPageId)) {
+            return new LearningProgressUpdateResult(progress, false);
+        }
+
+        boolean changed = progress.getStatus() != command.status()
+                || !Objects.equals(progress.getLastPageId(), targetPageId);
+        if (!changed) {
+            return new LearningProgressUpdateResult(progress, false);
+        }
+
+        LearningProgressStatus previousStatus = progress.getStatus();
+        String previousPageId = progress.getLastPageId();
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        progress.setLastPageId(targetPageId);
+        progress.setStatus(command.status());
+        progress.setUpdatedAt(now);
+        if (command.status() == LearningProgressStatus.COMPLETED) {
+            progress.setCompletedAt(now);
+        }
+
+        if (learningProgressMapper.updateProgress(progress) != 1) {
+            throw new ApiException(ErrorCode.INTERNAL_ERROR);
+        }
+
+        insertEvent(
+                progress,
+                previousStatus,
+                previousPageId,
+                eventType(command.status()),
+                now
+        );
+        return new LearningProgressUpdateResult(progress, true);
+    }
+
+    private List<String> validatePageId(
+            long subChapterId,
+            long contentVersionId,
+            String lastPageId
+    ) {
+        if (lastPageId == null) {
+            return List.of();
+        }
+
+        ContentVersion version = contentVersionMapper.findById(contentVersionId);
+        if (version == null || version.getSubChapterId() != subChapterId) {
+            throw new ApiException(ErrorCode.CONTENT_VERSION_MISMATCH);
+        }
+
+        StoredContent stored;
+        try {
+            stored = contentStorage.load(new StoredObjectRef(
+                    version.getStorageObjectKey(),
+                    version.getStorageVersionId()
+            ));
+        } catch (ContentStorageException | IllegalArgumentException exception) {
+            throw unavailable(exception);
+        }
+
+        if (!isJson(stored.contentType())) {
+            throw unavailable(null);
+        }
+
+        JsonNode lesson;
+        try {
+            lesson = objectMapper.readTree(new String(
+                    stored.content(),
+                    StandardCharsets.UTF_8
+            ));
+        } catch (JsonProcessingException exception) {
+            throw unavailable(exception);
+        }
+
+        if (lesson == null
+                || !lesson.isObject()
+                || !version.getSchemaVersion().equals(
+                        lesson.path("schemaVersion").textValue()
+                )) {
+            throw unavailable(null);
+        }
+
+        List<String> pageIds = new ArrayList<>();
+        for (JsonNode page : lesson.path("pages")) {
+            pageIds.add(page.path("id").textValue());
+        }
+        if (!pageIds.contains(lastPageId)) {
+            throw new ApiException(ErrorCode.INVALID_PAGE_ID);
+        }
+        return pageIds;
+    }
+
+    private boolean isBackwardMove(
+            List<String> pageIds,
+            String previousPageId,
+            String requestedPageId
+    ) {
+        if (previousPageId == null || requestedPageId == null) {
+            return false;
+        }
+
+        int previousIndex = pageIds.indexOf(previousPageId);
+        if (previousIndex < 0) {
+            throw unavailable(null);
+        }
+        return pageIds.indexOf(requestedPageId) < previousIndex;
+    }
+
+    private void insertEvent(
+            LearningProgress progress,
+            LearningProgressStatus previousStatus,
+            String previousPageId,
+            String eventType,
+            LocalDateTime occurredAt
+    ) {
+        LearningProgressEvent event = new LearningProgressEvent();
+        event.setProgressId(progress.getProgressId());
+        event.setUserId(progress.getUserId());
+        event.setSubChapterId(progress.getSubChapterId());
+        event.setContentVersionId(progress.getContentVersionId());
+        event.setEventType(eventType);
+        event.setPreviousStatus(previousStatus);
+        event.setStatus(progress.getStatus());
+        event.setPreviousPageId(previousPageId);
+        event.setLastPageId(progress.getLastPageId());
+        event.setOccurredAt(occurredAt);
+        if (learningProgressMapper.insertEvent(event) != 1) {
+            throw new ApiException(ErrorCode.INTERNAL_ERROR);
+        }
+    }
+
+    private String eventType(LearningProgressStatus status) {
+        return status == LearningProgressStatus.COMPLETED
+                ? "COMPLETED" : "PROGRESS_UPDATED";
+    }
+
+    private boolean isJson(String contentType) {
+        return JSON_CONTENT_TYPE.equalsIgnoreCase(
+                contentType.split(";", 2)[0].trim()
+        );
+    }
+
+    private ApiException unavailable(Throwable cause) {
+        return new ApiException(
+                ErrorCode.CONTENT_UNAVAILABLE,
+                ErrorCode.CONTENT_UNAVAILABLE.getDefaultMessage(),
+                cause
+        );
+    }
+
+    private void requireActiveSubChapter(long subChapterId) {
+        SubChapter subChapter = subChapterMapper.findById(subChapterId);
+        if (subChapter == null || !subChapter.isActive()) {
+            throw new ApiException(ErrorCode.SUB_CHAPTER_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/org/firstfolio/learning/service/MainChapterCompletionService.java
+++ b/src/main/java/org/firstfolio/learning/service/MainChapterCompletionService.java
@@ -1,0 +1,73 @@
+package org.firstfolio.learning.service;
+
+import org.firstfolio.curriculum.domain.ChapterType;
+import org.firstfolio.curriculum.domain.MainChapter;
+import org.firstfolio.curriculum.mapper.MainChapterMapper;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.learning.domain.MainChapterCompletionResult;
+import org.firstfolio.learning.domain.UserCurriculumItem;
+import org.firstfolio.learning.mapper.MainChapterLearningMapper;
+import org.firstfolio.portfolio.service.InitialGrantResult;
+import org.firstfolio.portfolio.service.InitialGrantService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+public class MainChapterCompletionService {
+
+    private final MainChapterLearningMapper learningMapper;
+    private final MainChapterMapper mainChapterMapper;
+    private final InitialGrantService initialGrantService;
+
+    public MainChapterCompletionService(
+            MainChapterLearningMapper learningMapper,
+            MainChapterMapper mainChapterMapper,
+            InitialGrantService initialGrantService
+    ) {
+        this.learningMapper = learningMapper;
+        this.mainChapterMapper = mainChapterMapper;
+        this.initialGrantService = initialGrantService;
+    }
+
+    @Transactional
+    public MainChapterCompletionResult complete(
+            long userId,
+            long mainChapterId,
+            LocalDateTime completedAt
+    ) {
+        if (completedAt == null) {
+            throw new ApiException(ErrorCode.INTERNAL_ERROR);
+        }
+
+        UserCurriculumItem item = learningMapper
+                .findActiveCurriculumItemForUpdate(userId, mainChapterId);
+        MainChapter chapter = mainChapterMapper.findById(mainChapterId);
+        if (item == null || chapter == null || !chapter.isActive()) {
+            throw new ApiException(ErrorCode.QUIZ_NOT_AVAILABLE);
+        }
+
+        boolean completedNow = item.getCompletedAt() == null;
+        if (completedNow && learningMapper.completeCurriculumItemIfIncomplete(
+                item.getCurriculumItemId(),
+                completedAt
+        ) != 1) {
+            throw new ApiException(ErrorCode.INTERNAL_ERROR);
+        }
+
+        InitialGrantResult foundationGrant = null;
+        if (chapter.getChapterType() == ChapterType.FOUNDATION) {
+            foundationGrant = initialGrantService.grantOnFoundationCompleted(
+                    userId,
+                    item.getCurriculumItemId()
+            );
+        }
+        return new MainChapterCompletionResult(
+                chapter.getChapterType(),
+                completedNow,
+                foundationGrant
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/learning/service/PublicChapterQueryService.java
+++ b/src/main/java/org/firstfolio/learning/service/PublicChapterQueryService.java
@@ -1,0 +1,41 @@
+package org.firstfolio.learning.service;
+
+import org.firstfolio.curriculum.domain.MainChapter;
+import org.firstfolio.curriculum.domain.PublicSubChapter;
+import org.firstfolio.curriculum.mapper.MainChapterMapper;
+import org.firstfolio.curriculum.mapper.SubChapterMapper;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class PublicChapterQueryService {
+
+    private final MainChapterMapper mainChapterMapper;
+    private final SubChapterMapper subChapterMapper;
+
+    public PublicChapterQueryService(
+            MainChapterMapper mainChapterMapper,
+            SubChapterMapper subChapterMapper
+    ) {
+        this.mainChapterMapper = mainChapterMapper;
+        this.subChapterMapper = subChapterMapper;
+    }
+
+    @Transactional(readOnly = true)
+    public List<MainChapter> getMainChapters() {
+        return mainChapterMapper.findAll(null, true);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PublicSubChapter> getSubChapters(long mainChapterId) {
+        MainChapter mainChapter = mainChapterMapper.findById(mainChapterId);
+        if (mainChapter == null || !mainChapter.isActive()) {
+            throw new ApiException(ErrorCode.MAIN_CHAPTER_NOT_FOUND);
+        }
+        return subChapterMapper.findPublicByMainChapterId(mainChapterId);
+    }
+}

--- a/src/main/java/org/firstfolio/portfolio/service/InitialGrantResult.java
+++ b/src/main/java/org/firstfolio/portfolio/service/InitialGrantResult.java
@@ -5,8 +5,7 @@ import java.math.BigDecimal;
 /**
  * 초기 모의투자금 지급 결과.
  *
- * <p>API_DOCS {@code POST /quiz-attempts/{attempt_id}/submit} 응답의
- * {@code foundation_grant} 객체에 그대로 대응한다.</p>
+ * <p>대단원 퀴즈 마지막 문항 채점 응답의 {@code foundation_grant} 객체에 대응한다.</p>
  */
 public class InitialGrantResult {
 

--- a/src/main/java/org/firstfolio/portfolio/service/InitialGrantService.java
+++ b/src/main/java/org/firstfolio/portfolio/service/InitialGrantService.java
@@ -22,8 +22,8 @@ import java.time.ZoneOffset;
  *
  * <h3>학습 도메인과의 연결 지점</h3>
  *
- * <p>지급 트리거는 학습 도메인의 {@code POST /quiz-attempts/{attempt_id}/submit}에서 발생한다.
- * 학습 도메인은 이번 작업 범위가 아니므로 <b>이 서비스를 호출하는 쪽만 맞추면 된다.</b></p>
+ * <p>지급 트리거는 대단원 퀴즈의 마지막 문항 답안이 채점되어 포트폴리오 기초
+ * 과정이 완료되는 시점에 발생한다.</p>
  *
  * <pre>
  * // 학습 도메인 (FOUNDATION 대단원 합격 처리 안에서)
@@ -31,7 +31,7 @@ import java.time.ZoneOffset;
  *
  * // 응답 조립
  * response.setFoundationGrant(grant);            // granted / amount / portfolioId
- * response.setNextAction(grant.isGranted() ? "PORTFOLIO" : null);
+ * response.setNextAction("PORTFOLIO_SETUP");
  * </pre>
  *
  * <p>같은 트랜잭션 안에서 호출하면 퀴즈 채점과 지급이 함께 커밋된다. 별도 트랜잭션으로

--- a/src/main/java/org/firstfolio/quiz/controller/AdminQuizQuestionController.java
+++ b/src/main/java/org/firstfolio/quiz/controller/AdminQuizQuestionController.java
@@ -1,0 +1,125 @@
+package org.firstfolio.quiz.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.firstfolio.auth.annotation.CurrentUser;
+import org.firstfolio.auth.domain.AuthenticatedUser;
+import org.firstfolio.common.response.ApiResponse;
+import org.firstfolio.common.web.RequestIdFilter;
+import org.firstfolio.config.OpenApiResponseSchemas;
+import org.firstfolio.quiz.dto.request.QuizQuestionCreateRequest;
+import org.firstfolio.quiz.dto.request.QuizQuestionVersionCreateRequest;
+import org.firstfolio.quiz.dto.response.QuizQuestionCreateResponse;
+import org.firstfolio.quiz.service.QuizQuestionRegistrationService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequestMapping("/api/admin/quiz-questions")
+@Tag(name = "관리자 퀴즈 문항", description = "관리자용 퀴즈 문항 등록·버전 관리 API")
+public class AdminQuizQuestionController {
+
+    private final QuizQuestionRegistrationService registrationService;
+
+    public AdminQuizQuestionController(
+            QuizQuestionRegistrationService registrationService
+    ) {
+        this.registrationService = registrationService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(
+            summary = "신규 퀴즈 문항 등록",
+            description = "JSON Schema와 단원 참조를 검증하고 새 논리 문항의 첫 버전을 "
+                    + "version_no=1, generation_type=HUMAN, DRAFT 상태로 등록합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "201", description = "퀴즈 문항 생성 성공",
+                            content = @io.swagger.v3.oas.annotations.media.Content(
+                                    mediaType = "application/json",
+                                    schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                            implementation = OpenApiResponseSchemas.QuizQuestionCreate.class
+                                    )
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "409", description = "QUESTION_KEY_CONFLICT - 이미 존재하는 논리 키"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "422", description = "QUESTION_VALIDATION_FAILED - 문항 또는 단원 참조 검증 실패"
+                    )
+            }
+    )
+    public ApiResponse<QuizQuestionCreateResponse> createQuestion(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true, description = "퀴즈 문항 JSON Schema에 맞는 신규 문항"
+            )
+            @RequestBody(required = false) QuizQuestionCreateRequest request,
+            @CurrentUser AuthenticatedUser currentUser,
+            HttpServletRequest servletRequest
+    ) {
+        return ApiResponse.of(QuizQuestionCreateResponse.from(
+                registrationService.createQuestion(
+                        request,
+                        currentUser.userId(),
+                        RequestIdFilter.currentRequestId(servletRequest)
+                )
+        ));
+    }
+
+    @PostMapping("/{questionId}/versions")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(
+            summary = "퀴즈 문항 새 버전 등록",
+            description = "기존 문항의 논리 키·사용처·유형·생성 방식을 계승하고 증가한 "
+                    + "version_no의 새 불변 DRAFT 행을 등록합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "201", description = "퀴즈 문항 새 버전 생성 성공",
+                            content = @io.swagger.v3.oas.annotations.media.Content(
+                                    mediaType = "application/json",
+                                    schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                            implementation = OpenApiResponseSchemas.QuizQuestionCreate.class
+                                    )
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "404", description = "QUESTION_NOT_FOUND - 기준 문항을 찾을 수 없음"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "409", description = "QUESTION_VERSION_CONFLICT - 새 버전 번호 충돌"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "422", description = "QUESTION_VALIDATION_FAILED - 새 버전 검증 실패"
+                    )
+            }
+    )
+    public ApiResponse<QuizQuestionCreateResponse> createVersion(
+            @Parameter(description = "기준이 되는 기존 문항 버전 ID", example = "1201", required = true)
+            @PathVariable long questionId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true, description = "새 버전에 저장할 문항 내용"
+            )
+            @RequestBody(required = false) QuizQuestionVersionCreateRequest request,
+            @CurrentUser AuthenticatedUser currentUser,
+            HttpServletRequest servletRequest
+    ) {
+        return ApiResponse.of(QuizQuestionCreateResponse.from(
+                registrationService.createVersion(
+                        questionId,
+                        request,
+                        currentUser.userId(),
+                        RequestIdFilter.currentRequestId(servletRequest)
+                )
+        ));
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/controller/MainChapterQuizAttemptController.java
+++ b/src/main/java/org/firstfolio/quiz/controller/MainChapterQuizAttemptController.java
@@ -1,0 +1,68 @@
+package org.firstfolio.quiz.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.firstfolio.auth.annotation.CurrentUser;
+import org.firstfolio.auth.domain.AuthenticatedUser;
+import org.firstfolio.common.response.ApiResponse;
+import org.firstfolio.config.OpenApiResponseSchemas;
+import org.firstfolio.quiz.dto.response.QuizAttemptStartResponse;
+import org.firstfolio.quiz.service.MainChapterQuizAttemptStartService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/learning/main-chapters/{mainChapterId}/quiz-attempts")
+@Tag(name = "학습 퀴즈", description = "사용자용 학습 퀴즈 응시 API")
+public class MainChapterQuizAttemptController {
+
+    private final MainChapterQuizAttemptStartService startService;
+
+    public MainChapterQuizAttemptController(
+            MainChapterQuizAttemptStartService startService
+    ) {
+        this.startService = startService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(
+            summary = "대단원 퀴즈 응시 시작",
+            description = "대단원에 속한 활성 소단원을 모두 완료한 경우 최신 공개 문항으로 응시를 시작합니다. "
+                    + "진행 중 응시가 있으면 저장된 문항과 순서를 복원하며 정답과 해설은 반환하지 않습니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "201",
+                            description = "대단원 퀴즈 시작 또는 진행 중 응시 복원 성공",
+                            content = @io.swagger.v3.oas.annotations.media.Content(
+                                    mediaType = "application/json",
+                                    schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                            implementation = OpenApiResponseSchemas.QuizAttemptStart.class
+                                    )
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "403",
+                            description = "SUB_CHAPTERS_INCOMPLETE 또는 QUIZ_NOT_AVAILABLE"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "503",
+                            description = "CONTENT_UNAVAILABLE - 저장된 문항 스냅샷 조회 실패"
+                    )
+            }
+    )
+    public ApiResponse<QuizAttemptStartResponse> start(
+            @CurrentUser AuthenticatedUser currentUser,
+            @Parameter(description = "퀴즈를 시작할 대단원 ID", example = "10", required = true)
+            @PathVariable long mainChapterId
+    ) {
+        return ApiResponse.of(QuizAttemptStartResponse.from(
+                startService.start(currentUser.userId(), mainChapterId)
+        ));
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/controller/QuizAnswerController.java
+++ b/src/main/java/org/firstfolio/quiz/controller/QuizAnswerController.java
@@ -32,7 +32,8 @@ public class QuizAnswerController {
             summary = "퀴즈 문항별 답안 제출 및 즉시 채점",
             description = "응시에 고정된 문항 스냅샷으로 단일 답안을 채점하고 정답과 해설을 반환합니다. "
                     + "동일 답안 재요청은 응시 상태와 관계없이 기존 결과를 반환하며 답안 순서는 강제하지 않습니다. "
-                    + "응시 완료와 포인트 지급은 후속 구현에서 마지막 문항 트랜잭션에 연결합니다.",
+                    + "마지막 미응답 문항이면 응시 결과를 확정하고 최초 응시에 한해 정답 수 기반 포인트를 "
+                    + "같은 트랜잭션에서 지급합니다.",
             responses = {
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(
                             responseCode = "200",

--- a/src/main/java/org/firstfolio/quiz/controller/QuizAnswerController.java
+++ b/src/main/java/org/firstfolio/quiz/controller/QuizAnswerController.java
@@ -33,7 +33,8 @@ public class QuizAnswerController {
             description = "응시에 고정된 문항 스냅샷으로 단일 답안을 채점하고 정답과 해설을 반환합니다. "
                     + "동일 답안 재요청은 응시 상태와 관계없이 기존 결과를 반환하며 답안 순서는 강제하지 않습니다. "
                     + "마지막 미응답 문항이면 응시 결과를 확정하고 최초 응시에 한해 정답 수 기반 포인트를 "
-                    + "같은 트랜잭션에서 지급합니다.",
+                    + "같은 트랜잭션에서 지급합니다. 대단원 퀴즈는 별도 합격 점수 없이 모든 문항에 "
+                    + "답하면 대단원 완료까지 함께 처리합니다.",
             responses = {
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(
                             responseCode = "200",

--- a/src/main/java/org/firstfolio/quiz/controller/QuizAnswerController.java
+++ b/src/main/java/org/firstfolio/quiz/controller/QuizAnswerController.java
@@ -1,0 +1,86 @@
+package org.firstfolio.quiz.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.firstfolio.auth.annotation.CurrentUser;
+import org.firstfolio.auth.domain.AuthenticatedUser;
+import org.firstfolio.common.response.ApiResponse;
+import org.firstfolio.config.OpenApiResponseSchemas;
+import org.firstfolio.quiz.dto.request.QuizAnswerSubmitRequest;
+import org.firstfolio.quiz.dto.response.QuizAnswerGradingResponse;
+import org.firstfolio.quiz.service.QuizAnswerGradingService;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/learning/quiz-attempts/{attemptId}/answers/{questionId}")
+@Tag(name = "학습 퀴즈", description = "사용자용 학습 퀴즈 응시 API")
+public class QuizAnswerController {
+
+    private final QuizAnswerGradingService gradingService;
+
+    public QuizAnswerController(QuizAnswerGradingService gradingService) {
+        this.gradingService = gradingService;
+    }
+
+    @PutMapping
+    @Operation(
+            summary = "퀴즈 문항별 답안 제출 및 즉시 채점",
+            description = "응시에 고정된 문항 스냅샷으로 단일 답안을 채점하고 정답과 해설을 반환합니다. "
+                    + "동일 답안 재요청은 응시 상태와 관계없이 기존 결과를 반환하며 답안 순서는 강제하지 않습니다. "
+                    + "응시 완료와 포인트 지급은 후속 구현에서 마지막 문항 트랜잭션에 연결합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            description = "문항 채점 또는 동일 답안 멱등 재조회 성공",
+                            content = @io.swagger.v3.oas.annotations.media.Content(
+                                    mediaType = "application/json",
+                                    schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                            implementation = OpenApiResponseSchemas.QuizAnswerGrading.class
+                                    )
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "403",
+                            description = "QUIZ_ATTEMPT_FORBIDDEN - 본인 소유 응시가 아님"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "404",
+                            description = "QUIZ_ATTEMPT_NOT_FOUND 또는 QUESTION_NOT_IN_ATTEMPT"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "409",
+                            description = "ATTEMPT_ALREADY_GRADED 또는 ANSWER_ALREADY_SUBMITTED"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "422",
+                            description = "INVALID_SELECTED_CHOICE - 선택지 형식 또는 범위 오류"
+                    )
+            }
+    )
+    public ApiResponse<QuizAnswerGradingResponse> grade(
+            @CurrentUser AuthenticatedUser currentUser,
+            @Parameter(description = "퀴즈 응시 ID", example = "3001", required = true)
+            @PathVariable long attemptId,
+            @Parameter(description = "응시에 포함된 문항 버전 ID", example = "1001", required = true)
+            @PathVariable long questionId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    description = "선택한 단일 답안. 예: {\"answer\":{\"key\":\"B\"}}"
+            )
+            @RequestBody(required = false) QuizAnswerSubmitRequest request
+    ) {
+        return ApiResponse.of(QuizAnswerGradingResponse.from(
+                gradingService.grade(
+                        currentUser.userId(),
+                        attemptId,
+                        questionId,
+                        request == null ? null : request.selectedKey()
+                )
+        ));
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/controller/QuizAttemptController.java
+++ b/src/main/java/org/firstfolio/quiz/controller/QuizAttemptController.java
@@ -1,0 +1,69 @@
+package org.firstfolio.quiz.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.firstfolio.auth.annotation.CurrentUser;
+import org.firstfolio.auth.domain.AuthenticatedUser;
+import org.firstfolio.common.response.ApiResponse;
+import org.firstfolio.config.OpenApiResponseSchemas;
+import org.firstfolio.quiz.dto.response.QuizAttemptStartResponse;
+import org.firstfolio.quiz.service.QuizAttemptStartService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/learning/sub-chapters/{subChapterId}/quiz-attempts")
+@Tag(name = "학습 퀴즈", description = "사용자용 학습 퀴즈 응시 API")
+public class QuizAttemptController {
+
+    private final QuizAttemptStartService quizAttemptStartService;
+
+    public QuizAttemptController(QuizAttemptStartService quizAttemptStartService) {
+        this.quizAttemptStartService = quizAttemptStartService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(
+            summary = "소단원 퀴즈 응시 시작",
+            description = "학습을 완료한 콘텐츠 버전의 공개 문항으로 응시와 문항 스냅샷을 생성합니다. "
+                    + "진행 중 응시가 있으면 저장된 문항과 순서를 복원하며 정답과 해설은 반환하지 않습니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "201",
+                            description = "소단원 퀴즈 시작 또는 진행 중 응시 복원 성공",
+                            content = @io.swagger.v3.oas.annotations.media.Content(
+                                    mediaType = "application/json",
+                                    schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                            implementation = OpenApiResponseSchemas.QuizAttemptStart.class
+                                    )
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "403",
+                            description = "QUIZ_NOT_AVAILABLE - 학습 또는 문항 공개 조건 미충족"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "503",
+                            description = "CONTENT_UNAVAILABLE - 콘텐츠 또는 스냅샷 조회 실패"
+                    )
+            }
+    )
+    public ApiResponse<QuizAttemptStartResponse> start(
+            @CurrentUser AuthenticatedUser currentUser,
+            @Parameter(description = "퀴즈를 시작할 소단원 ID", example = "101", required = true)
+            @PathVariable long subChapterId
+    ) {
+        return ApiResponse.of(QuizAttemptStartResponse.from(
+                quizAttemptStartService.start(
+                        currentUser.userId(),
+                        subChapterId
+                )
+        ));
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/domain/QuizAnswer.java
+++ b/src/main/java/org/firstfolio/quiz/domain/QuizAnswer.java
@@ -1,0 +1,88 @@
+package org.firstfolio.quiz.domain;
+
+import java.time.LocalDateTime;
+
+public class QuizAnswer {
+
+    private Long quizAnswerId;
+    private long attemptId;
+    private long questionId;
+    private int displayOrder;
+    private String questionSnapshotJson;
+    private String userAnswerJson;
+    private Boolean correct;
+    private LocalDateTime answeredAt;
+    private LocalDateTime createdAt;
+
+    public Long getQuizAnswerId() {
+        return quizAnswerId;
+    }
+
+    public void setQuizAnswerId(Long quizAnswerId) {
+        this.quizAnswerId = quizAnswerId;
+    }
+
+    public long getAttemptId() {
+        return attemptId;
+    }
+
+    public void setAttemptId(long attemptId) {
+        this.attemptId = attemptId;
+    }
+
+    public long getQuestionId() {
+        return questionId;
+    }
+
+    public void setQuestionId(long questionId) {
+        this.questionId = questionId;
+    }
+
+    public int getDisplayOrder() {
+        return displayOrder;
+    }
+
+    public void setDisplayOrder(int displayOrder) {
+        this.displayOrder = displayOrder;
+    }
+
+    public String getQuestionSnapshotJson() {
+        return questionSnapshotJson;
+    }
+
+    public void setQuestionSnapshotJson(String questionSnapshotJson) {
+        this.questionSnapshotJson = questionSnapshotJson;
+    }
+
+    public String getUserAnswerJson() {
+        return userAnswerJson;
+    }
+
+    public void setUserAnswerJson(String userAnswerJson) {
+        this.userAnswerJson = userAnswerJson;
+    }
+
+    public Boolean getCorrect() {
+        return correct;
+    }
+
+    public void setCorrect(Boolean correct) {
+        this.correct = correct;
+    }
+
+    public LocalDateTime getAnsweredAt() {
+        return answeredAt;
+    }
+
+    public void setAnsweredAt(LocalDateTime answeredAt) {
+        this.answeredAt = answeredAt;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/domain/QuizAnswerGradingResult.java
+++ b/src/main/java/org/firstfolio/quiz/domain/QuizAnswerGradingResult.java
@@ -1,5 +1,6 @@
 package org.firstfolio.quiz.domain;
 
+import org.firstfolio.learning.domain.MainChapterCompletionResult;
 import org.firstfolio.reward.domain.QuizRewardResult;
 
 import java.util.Objects;
@@ -19,6 +20,7 @@ public record QuizAnswerGradingResult(
         Integer correctCount,
         Integer score,
         QuizRewardResult reward,
+        MainChapterCompletionResult mainChapterCompletion,
         String nextAction
 ) {
     public QuizAnswerGradingResult {
@@ -31,6 +33,12 @@ public record QuizAnswerGradingResult(
                 && (correctCount == null || score == null || reward == null)) {
             throw new IllegalArgumentException(
                     "graded result must include score and reward"
+            );
+        }
+        if (attemptStatus != QuizAttemptStatus.GRADED
+                && mainChapterCompletion != null) {
+            throw new IllegalArgumentException(
+                    "in-progress result must not include main chapter completion"
             );
         }
     }

--- a/src/main/java/org/firstfolio/quiz/domain/QuizAnswerGradingResult.java
+++ b/src/main/java/org/firstfolio/quiz/domain/QuizAnswerGradingResult.java
@@ -1,5 +1,7 @@
 package org.firstfolio.quiz.domain;
 
+import org.firstfolio.reward.domain.QuizRewardResult;
+
 import java.util.Objects;
 
 public record QuizAnswerGradingResult(
@@ -13,7 +15,11 @@ public record QuizAnswerGradingResult(
         QuizAttemptStatus attemptStatus,
         int answeredCount,
         int totalCount,
-        boolean allAnswered
+        boolean allAnswered,
+        Integer correctCount,
+        Integer score,
+        QuizRewardResult reward,
+        String nextAction
 ) {
     public QuizAnswerGradingResult {
         Objects.requireNonNull(generationType, "generationType must not be null");
@@ -21,5 +27,11 @@ public record QuizAnswerGradingResult(
         Objects.requireNonNull(correctKey, "correctKey must not be null");
         Objects.requireNonNull(explanation, "explanation must not be null");
         Objects.requireNonNull(attemptStatus, "attemptStatus must not be null");
+        if (attemptStatus == QuizAttemptStatus.GRADED
+                && (correctCount == null || score == null || reward == null)) {
+            throw new IllegalArgumentException(
+                    "graded result must include score and reward"
+            );
+        }
     }
 }

--- a/src/main/java/org/firstfolio/quiz/domain/QuizAnswerGradingResult.java
+++ b/src/main/java/org/firstfolio/quiz/domain/QuizAnswerGradingResult.java
@@ -1,0 +1,25 @@
+package org.firstfolio.quiz.domain;
+
+import java.util.Objects;
+
+public record QuizAnswerGradingResult(
+        long attemptId,
+        long questionId,
+        QuizGenerationType generationType,
+        String selectedKey,
+        boolean correct,
+        String correctKey,
+        String explanation,
+        QuizAttemptStatus attemptStatus,
+        int answeredCount,
+        int totalCount,
+        boolean allAnswered
+) {
+    public QuizAnswerGradingResult {
+        Objects.requireNonNull(generationType, "generationType must not be null");
+        Objects.requireNonNull(selectedKey, "selectedKey must not be null");
+        Objects.requireNonNull(correctKey, "correctKey must not be null");
+        Objects.requireNonNull(explanation, "explanation must not be null");
+        Objects.requireNonNull(attemptStatus, "attemptStatus must not be null");
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/domain/QuizAttempt.java
+++ b/src/main/java/org/firstfolio/quiz/domain/QuizAttempt.java
@@ -15,6 +15,8 @@ public class QuizAttempt {
     private int totalCount;
     private int correctCount;
     private int score;
+    private Long rewardPolicyId;
+    private Long pointTransactionId;
     private LocalDateTime startedAt;
     private LocalDateTime submittedAt;
 
@@ -104,6 +106,22 @@ public class QuizAttempt {
 
     public void setScore(int score) {
         this.score = score;
+    }
+
+    public Long getRewardPolicyId() {
+        return rewardPolicyId;
+    }
+
+    public void setRewardPolicyId(Long rewardPolicyId) {
+        this.rewardPolicyId = rewardPolicyId;
+    }
+
+    public Long getPointTransactionId() {
+        return pointTransactionId;
+    }
+
+    public void setPointTransactionId(Long pointTransactionId) {
+        this.pointTransactionId = pointTransactionId;
     }
 
     public LocalDateTime getStartedAt() {

--- a/src/main/java/org/firstfolio/quiz/domain/QuizAttempt.java
+++ b/src/main/java/org/firstfolio/quiz/domain/QuizAttempt.java
@@ -1,0 +1,124 @@
+package org.firstfolio.quiz.domain;
+
+import java.time.LocalDateTime;
+
+public class QuizAttempt {
+
+    private Long attemptId;
+    private long userId;
+    private QuizType quizType;
+    private Long mainChapterId;
+    private Long subChapterId;
+    private Long contentVersionId;
+    private int attemptNo;
+    private QuizAttemptStatus status;
+    private int totalCount;
+    private int correctCount;
+    private int score;
+    private LocalDateTime startedAt;
+    private LocalDateTime submittedAt;
+
+    public Long getAttemptId() {
+        return attemptId;
+    }
+
+    public void setAttemptId(Long attemptId) {
+        this.attemptId = attemptId;
+    }
+
+    public long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(long userId) {
+        this.userId = userId;
+    }
+
+    public QuizType getQuizType() {
+        return quizType;
+    }
+
+    public void setQuizType(QuizType quizType) {
+        this.quizType = quizType;
+    }
+
+    public Long getMainChapterId() {
+        return mainChapterId;
+    }
+
+    public void setMainChapterId(Long mainChapterId) {
+        this.mainChapterId = mainChapterId;
+    }
+
+    public Long getSubChapterId() {
+        return subChapterId;
+    }
+
+    public void setSubChapterId(Long subChapterId) {
+        this.subChapterId = subChapterId;
+    }
+
+    public Long getContentVersionId() {
+        return contentVersionId;
+    }
+
+    public void setContentVersionId(Long contentVersionId) {
+        this.contentVersionId = contentVersionId;
+    }
+
+    public int getAttemptNo() {
+        return attemptNo;
+    }
+
+    public void setAttemptNo(int attemptNo) {
+        this.attemptNo = attemptNo;
+    }
+
+    public QuizAttemptStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(QuizAttemptStatus status) {
+        this.status = status;
+    }
+
+    public int getTotalCount() {
+        return totalCount;
+    }
+
+    public void setTotalCount(int totalCount) {
+        this.totalCount = totalCount;
+    }
+
+    public int getCorrectCount() {
+        return correctCount;
+    }
+
+    public void setCorrectCount(int correctCount) {
+        this.correctCount = correctCount;
+    }
+
+    public int getScore() {
+        return score;
+    }
+
+    public void setScore(int score) {
+        this.score = score;
+    }
+
+    public LocalDateTime getStartedAt() {
+        return startedAt;
+    }
+
+    public void setStartedAt(LocalDateTime startedAt) {
+        this.startedAt = startedAt;
+    }
+
+    public LocalDateTime getSubmittedAt() {
+        return submittedAt;
+    }
+
+    public void setSubmittedAt(LocalDateTime submittedAt) {
+        this.submittedAt = submittedAt;
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/domain/QuizAttemptQuestion.java
+++ b/src/main/java/org/firstfolio/quiz/domain/QuizAttemptQuestion.java
@@ -1,0 +1,29 @@
+package org.firstfolio.quiz.domain;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.List;
+import java.util.Objects;
+
+public record QuizAttemptQuestion(
+        long questionId,
+        int displayOrder,
+        QuizQuestionType questionType,
+        QuizGenerationType generationType,
+        String prompt,
+        JsonNode scenario,
+        List<QuizChoice> choices
+) {
+    public QuizAttemptQuestion {
+        Objects.requireNonNull(questionType, "questionType must not be null");
+        Objects.requireNonNull(generationType, "generationType must not be null");
+        Objects.requireNonNull(prompt, "prompt must not be null");
+        scenario = scenario == null ? null : scenario.deepCopy();
+        choices = List.copyOf(choices);
+    }
+
+    @Override
+    public JsonNode scenario() {
+        return scenario == null ? null : scenario.deepCopy();
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/domain/QuizAttemptStartResult.java
+++ b/src/main/java/org/firstfolio/quiz/domain/QuizAttemptStartResult.java
@@ -1,0 +1,14 @@
+package org.firstfolio.quiz.domain;
+
+import java.util.List;
+import java.util.Objects;
+
+public record QuizAttemptStartResult(
+        QuizAttempt attempt,
+        List<QuizAttemptQuestion> questions
+) {
+    public QuizAttemptStartResult {
+        Objects.requireNonNull(attempt, "attempt must not be null");
+        questions = List.copyOf(questions);
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/domain/QuizAttemptStatus.java
+++ b/src/main/java/org/firstfolio/quiz/domain/QuizAttemptStatus.java
@@ -1,0 +1,7 @@
+package org.firstfolio.quiz.domain;
+
+public enum QuizAttemptStatus {
+    IN_PROGRESS,
+    SUBMITTED,
+    GRADED
+}

--- a/src/main/java/org/firstfolio/quiz/domain/QuizChoice.java
+++ b/src/main/java/org/firstfolio/quiz/domain/QuizChoice.java
@@ -1,0 +1,11 @@
+package org.firstfolio.quiz.domain;
+
+import java.util.Objects;
+
+public record QuizChoice(String id, String text) {
+
+    public QuizChoice {
+        Objects.requireNonNull(id, "id must not be null");
+        Objects.requireNonNull(text, "text must not be null");
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/domain/QuizDifficulty.java
+++ b/src/main/java/org/firstfolio/quiz/domain/QuizDifficulty.java
@@ -1,0 +1,7 @@
+package org.firstfolio.quiz.domain;
+
+public enum QuizDifficulty {
+    EASY,
+    MEDIUM,
+    HARD
+}

--- a/src/main/java/org/firstfolio/quiz/domain/QuizGenerationType.java
+++ b/src/main/java/org/firstfolio/quiz/domain/QuizGenerationType.java
@@ -1,0 +1,6 @@
+package org.firstfolio.quiz.domain;
+
+public enum QuizGenerationType {
+    HUMAN,
+    AI
+}

--- a/src/main/java/org/firstfolio/quiz/domain/QuizQuestion.java
+++ b/src/main/java/org/firstfolio/quiz/domain/QuizQuestion.java
@@ -1,0 +1,231 @@
+package org.firstfolio.quiz.domain;
+
+import java.time.LocalDateTime;
+
+public class QuizQuestion {
+
+    private Long questionId;
+    private String questionKey;
+    private int versionNo;
+    private QuizUsageType usageType;
+    private Long mainChapterId;
+    private Long subChapterId;
+    private Integer displayOrder;
+    private QuizQuestionType questionType;
+    private QuizDifficulty difficulty;
+    private String prompt;
+    private String scenarioJson;
+    private String optionsJson;
+    private String correctAnswerJson;
+    private String explanation;
+    private QuizGenerationType generationType;
+    private String sourceRefsJson;
+    private QuizQuestionStatus status;
+    private long createdBy;
+    private LocalDateTime publishedAt;
+    private LocalDateTime createdAt;
+
+    public QuizQuestion() {
+    }
+
+    public static QuizQuestion draft(
+            String questionKey,
+            int versionNo,
+            QuizUsageType usageType,
+            Long mainChapterId,
+            Long subChapterId,
+            Integer displayOrder,
+            QuizQuestionType questionType,
+            QuizDifficulty difficulty,
+            String prompt,
+            String scenarioJson,
+            String optionsJson,
+            String correctAnswerJson,
+            String explanation,
+            QuizGenerationType generationType,
+            String sourceRefsJson,
+            long createdBy,
+            LocalDateTime createdAt
+    ) {
+        QuizQuestion question = new QuizQuestion();
+        question.questionKey = questionKey;
+        question.versionNo = versionNo;
+        question.usageType = usageType;
+        question.mainChapterId = mainChapterId;
+        question.subChapterId = subChapterId;
+        question.displayOrder = displayOrder;
+        question.questionType = questionType;
+        question.difficulty = difficulty;
+        question.prompt = prompt;
+        question.scenarioJson = scenarioJson;
+        question.optionsJson = optionsJson;
+        question.correctAnswerJson = correctAnswerJson;
+        question.explanation = explanation;
+        question.generationType = generationType;
+        question.sourceRefsJson = sourceRefsJson;
+        question.status = QuizQuestionStatus.DRAFT;
+        question.createdBy = createdBy;
+        question.createdAt = createdAt;
+        return question;
+    }
+
+    public Long getQuestionId() {
+        return questionId;
+    }
+
+    public void setQuestionId(Long questionId) {
+        this.questionId = questionId;
+    }
+
+    public String getQuestionKey() {
+        return questionKey;
+    }
+
+    public void setQuestionKey(String questionKey) {
+        this.questionKey = questionKey;
+    }
+
+    public int getVersionNo() {
+        return versionNo;
+    }
+
+    public void setVersionNo(int versionNo) {
+        this.versionNo = versionNo;
+    }
+
+    public QuizUsageType getUsageType() {
+        return usageType;
+    }
+
+    public void setUsageType(QuizUsageType usageType) {
+        this.usageType = usageType;
+    }
+
+    public Long getMainChapterId() {
+        return mainChapterId;
+    }
+
+    public void setMainChapterId(Long mainChapterId) {
+        this.mainChapterId = mainChapterId;
+    }
+
+    public Long getSubChapterId() {
+        return subChapterId;
+    }
+
+    public void setSubChapterId(Long subChapterId) {
+        this.subChapterId = subChapterId;
+    }
+
+    public Integer getDisplayOrder() {
+        return displayOrder;
+    }
+
+    public void setDisplayOrder(Integer displayOrder) {
+        this.displayOrder = displayOrder;
+    }
+
+    public QuizQuestionType getQuestionType() {
+        return questionType;
+    }
+
+    public void setQuestionType(QuizQuestionType questionType) {
+        this.questionType = questionType;
+    }
+
+    public QuizDifficulty getDifficulty() {
+        return difficulty;
+    }
+
+    public void setDifficulty(QuizDifficulty difficulty) {
+        this.difficulty = difficulty;
+    }
+
+    public String getPrompt() {
+        return prompt;
+    }
+
+    public void setPrompt(String prompt) {
+        this.prompt = prompt;
+    }
+
+    public String getScenarioJson() {
+        return scenarioJson;
+    }
+
+    public void setScenarioJson(String scenarioJson) {
+        this.scenarioJson = scenarioJson;
+    }
+
+    public String getOptionsJson() {
+        return optionsJson;
+    }
+
+    public void setOptionsJson(String optionsJson) {
+        this.optionsJson = optionsJson;
+    }
+
+    public String getCorrectAnswerJson() {
+        return correctAnswerJson;
+    }
+
+    public void setCorrectAnswerJson(String correctAnswerJson) {
+        this.correctAnswerJson = correctAnswerJson;
+    }
+
+    public String getExplanation() {
+        return explanation;
+    }
+
+    public void setExplanation(String explanation) {
+        this.explanation = explanation;
+    }
+
+    public QuizGenerationType getGenerationType() {
+        return generationType;
+    }
+
+    public void setGenerationType(QuizGenerationType generationType) {
+        this.generationType = generationType;
+    }
+
+    public String getSourceRefsJson() {
+        return sourceRefsJson;
+    }
+
+    public void setSourceRefsJson(String sourceRefsJson) {
+        this.sourceRefsJson = sourceRefsJson;
+    }
+
+    public QuizQuestionStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(QuizQuestionStatus status) {
+        this.status = status;
+    }
+
+    public long getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(long createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public LocalDateTime getPublishedAt() {
+        return publishedAt;
+    }
+
+    public void setPublishedAt(LocalDateTime publishedAt) {
+        this.publishedAt = publishedAt;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/domain/QuizQuestionType.java
+++ b/src/main/java/org/firstfolio/quiz/domain/QuizQuestionType.java
@@ -1,0 +1,7 @@
+package org.firstfolio.quiz.domain;
+
+public enum QuizQuestionType {
+    SINGLE_CHOICE,
+    TRUE_FALSE,
+    SCENARIO
+}

--- a/src/main/java/org/firstfolio/quiz/domain/QuizType.java
+++ b/src/main/java/org/firstfolio/quiz/domain/QuizType.java
@@ -1,0 +1,7 @@
+package org.firstfolio.quiz.domain;
+
+public enum QuizType {
+    LEVEL_TEST,
+    SUB_CHAPTER,
+    MAIN_CHAPTER
+}

--- a/src/main/java/org/firstfolio/quiz/dto/request/QuizAnswerSelectionRequest.java
+++ b/src/main/java/org/firstfolio/quiz/dto/request/QuizAnswerSelectionRequest.java
@@ -1,0 +1,9 @@
+package org.firstfolio.quiz.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "사용자가 선택한 단일 답안")
+public record QuizAnswerSelectionRequest(
+        @Schema(description = "선택지 키", example = "B") String key
+) {
+}

--- a/src/main/java/org/firstfolio/quiz/dto/request/QuizAnswerSubmitRequest.java
+++ b/src/main/java/org/firstfolio/quiz/dto/request/QuizAnswerSubmitRequest.java
@@ -1,0 +1,12 @@
+package org.firstfolio.quiz.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "퀴즈 문항 답안 제출 요청")
+public record QuizAnswerSubmitRequest(
+        @Schema(description = "제출할 단일 답안") QuizAnswerSelectionRequest answer
+) {
+    public String selectedKey() {
+        return answer == null ? null : answer.key();
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/dto/request/QuizQuestionCreateRequest.java
+++ b/src/main/java/org/firstfolio/quiz/dto/request/QuizQuestionCreateRequest.java
@@ -1,0 +1,31 @@
+package org.firstfolio.quiz.dto.request;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "관리자용 신규 퀴즈 문항 등록 요청")
+public record QuizQuestionCreateRequest(
+        @Schema(description = "문항 버전의 논리 키", example = "deposit-basic-001")
+        String questionKey,
+        @Schema(description = "문항 사용처", example = "SUB_CHAPTER")
+        String usageType,
+        @Schema(description = "대단원 ID", nullable = true, example = "2")
+        Long mainChapterId,
+        @Schema(description = "소단원 ID", nullable = true, example = "101")
+        Long subChapterId,
+        @Schema(description = "문항 유형", example = "SINGLE_CHOICE")
+        String questionType,
+        @Schema(description = "난이도", nullable = true, example = "EASY")
+        String difficulty,
+        @Schema(description = "문제 본문")
+        String prompt,
+        @Schema(description = "상황판단형 시나리오", nullable = true)
+        JsonNode scenarioJson,
+        @Schema(description = "선택지 배열")
+        JsonNode optionsJson,
+        @Schema(description = "정답 선택지 키")
+        JsonNode correctAnswerJson,
+        @Schema(description = "채점 후 표시할 해설")
+        String explanation
+) {
+}

--- a/src/main/java/org/firstfolio/quiz/dto/request/QuizQuestionVersionCreateRequest.java
+++ b/src/main/java/org/firstfolio/quiz/dto/request/QuizQuestionVersionCreateRequest.java
@@ -1,0 +1,17 @@
+package org.firstfolio.quiz.dto.request;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "기존 논리 문항의 새 버전 등록 요청")
+public record QuizQuestionVersionCreateRequest(
+        @Schema(description = "새 버전 문제 본문") String prompt,
+        @Schema(description = "상황판단형 시나리오", nullable = true)
+        JsonNode scenarioJson,
+        @Schema(description = "새 선택지 배열") JsonNode optionsJson,
+        @Schema(description = "새 정답 선택지 키") JsonNode correctAnswerJson,
+        @Schema(description = "새 해설") String explanation,
+        @Schema(description = "AI 생성 문항의 새 근거 자료", nullable = true)
+        JsonNode sourceRefsJson
+) {
+}

--- a/src/main/java/org/firstfolio/quiz/dto/response/FoundationGrantResponse.java
+++ b/src/main/java/org/firstfolio/quiz/dto/response/FoundationGrantResponse.java
@@ -1,0 +1,23 @@
+package org.firstfolio.quiz.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.firstfolio.portfolio.service.InitialGrantResult;
+
+import java.math.BigDecimal;
+
+@Schema(description = "포트폴리오 기초 과정 최초 완료 지급 결과")
+public record FoundationGrantResponse(
+        @Schema(description = "초기 모의투자금 지급 완료 여부", example = "true") boolean granted,
+        @Schema(description = "초기 모의투자금", example = "30000000.00") BigDecimal amount,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "생성된 포트폴리오 ID", example = "501", nullable = true) Long portfolioId
+) {
+    public static FoundationGrantResponse from(InitialGrantResult result) {
+        return new FoundationGrantResponse(
+                result.getPortfolioId() != null,
+                result.getAmount(),
+                result.getPortfolioId()
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/dto/response/QuizAnswerAttemptResponse.java
+++ b/src/main/java/org/firstfolio/quiz/dto/response/QuizAnswerAttemptResponse.java
@@ -1,5 +1,6 @@
 package org.firstfolio.quiz.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.firstfolio.quiz.domain.QuizAttemptStatus;
 
@@ -8,6 +9,12 @@ public record QuizAnswerAttemptResponse(
         @Schema(description = "응시 상태", example = "IN_PROGRESS") QuizAttemptStatus status,
         @Schema(description = "답변한 문항 수", example = "1") int answeredCount,
         @Schema(description = "전체 문항 수", example = "3") int totalCount,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "완료 시 최종 정답 수", example = "2", nullable = true)
+        Integer correctCount,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "완료 시 100점 환산 점수", example = "67", nullable = true)
+        Integer score,
         @Schema(description = "응시 완료 여부", example = "false") boolean completed
 ) {
 }

--- a/src/main/java/org/firstfolio/quiz/dto/response/QuizAnswerAttemptResponse.java
+++ b/src/main/java/org/firstfolio/quiz/dto/response/QuizAnswerAttemptResponse.java
@@ -1,0 +1,13 @@
+package org.firstfolio.quiz.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.firstfolio.quiz.domain.QuizAttemptStatus;
+
+@Schema(description = "문항 채점 후 응시 진행 상태")
+public record QuizAnswerAttemptResponse(
+        @Schema(description = "응시 상태", example = "IN_PROGRESS") QuizAttemptStatus status,
+        @Schema(description = "답변한 문항 수", example = "1") int answeredCount,
+        @Schema(description = "전체 문항 수", example = "3") int totalCount,
+        @Schema(description = "응시 완료 여부", example = "false") boolean completed
+) {
+}

--- a/src/main/java/org/firstfolio/quiz/dto/response/QuizAnswerGradingResponse.java
+++ b/src/main/java/org/firstfolio/quiz/dto/response/QuizAnswerGradingResponse.java
@@ -3,6 +3,7 @@ package org.firstfolio.quiz.dto.response;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.firstfolio.quiz.domain.QuizAnswerGradingResult;
+import org.firstfolio.quiz.domain.QuizAttemptStatus;
 import org.firstfolio.quiz.domain.QuizGenerationType;
 
 @Schema(description = "퀴즈 문항 즉시 채점 결과")
@@ -18,6 +19,12 @@ public record QuizAnswerGradingResponse(
         @JsonInclude(JsonInclude.Include.NON_NULL)
         @Schema(description = "마지막 문항 제출 시 포인트 지급 결과", nullable = true)
         QuizRewardResponse reward,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "대단원 퀴즈 완료 여부", nullable = true)
+        Boolean mainChapterCompleted,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "기초 과정 완료 시 초기 모의투자금 지급 결과", nullable = true)
+        FoundationGrantResponse foundationGrant,
         @JsonInclude(JsonInclude.Include.NON_NULL)
         @Schema(description = "퀴즈 완료 후 다음 동작", example = "NEXT_SUB_CHAPTER", nullable = true)
         String nextAction
@@ -42,6 +49,15 @@ public record QuizAnswerGradingResponse(
                 result.reward() == null
                         ? null
                         : QuizRewardResponse.from(result.reward()),
+                result.attemptStatus() != QuizAttemptStatus.GRADED
+                        ? null
+                        : result.mainChapterCompletion() != null,
+                result.mainChapterCompletion() == null
+                                || result.mainChapterCompletion().foundationGrant() == null
+                        ? null
+                        : FoundationGrantResponse.from(
+                                result.mainChapterCompletion().foundationGrant()
+                        ),
                 result.nextAction()
         );
     }

--- a/src/main/java/org/firstfolio/quiz/dto/response/QuizAnswerGradingResponse.java
+++ b/src/main/java/org/firstfolio/quiz/dto/response/QuizAnswerGradingResponse.java
@@ -1,0 +1,35 @@
+package org.firstfolio.quiz.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.firstfolio.quiz.domain.QuizAnswerGradingResult;
+import org.firstfolio.quiz.domain.QuizGenerationType;
+
+@Schema(description = "퀴즈 문항 즉시 채점 결과")
+public record QuizAnswerGradingResponse(
+        @Schema(description = "응시 ID", example = "3001") long attemptId,
+        @Schema(description = "문항 버전 ID", example = "1001") long questionId,
+        @Schema(description = "문항 생성 방식", example = "HUMAN") QuizGenerationType generationType,
+        @Schema(description = "제출한 선택지 키", example = "B") String selectedKey,
+        @Schema(description = "정답 여부", example = "false") boolean isCorrect,
+        @Schema(description = "정답") QuizCorrectAnswerResponse correctAnswer,
+        @Schema(description = "문항 해설") String explanation,
+        @Schema(description = "응시 진행 상태") QuizAnswerAttemptResponse attempt
+) {
+    public static QuizAnswerGradingResponse from(QuizAnswerGradingResult result) {
+        return new QuizAnswerGradingResponse(
+                result.attemptId(),
+                result.questionId(),
+                result.generationType(),
+                result.selectedKey(),
+                result.correct(),
+                new QuizCorrectAnswerResponse(result.correctKey()),
+                result.explanation(),
+                new QuizAnswerAttemptResponse(
+                        result.attemptStatus(),
+                        result.answeredCount(),
+                        result.totalCount(),
+                        result.attemptStatus() == org.firstfolio.quiz.domain.QuizAttemptStatus.GRADED
+                )
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/dto/response/QuizAnswerGradingResponse.java
+++ b/src/main/java/org/firstfolio/quiz/dto/response/QuizAnswerGradingResponse.java
@@ -1,5 +1,6 @@
 package org.firstfolio.quiz.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.firstfolio.quiz.domain.QuizAnswerGradingResult;
 import org.firstfolio.quiz.domain.QuizGenerationType;
@@ -13,7 +14,13 @@ public record QuizAnswerGradingResponse(
         @Schema(description = "정답 여부", example = "false") boolean isCorrect,
         @Schema(description = "정답") QuizCorrectAnswerResponse correctAnswer,
         @Schema(description = "문항 해설") String explanation,
-        @Schema(description = "응시 진행 상태") QuizAnswerAttemptResponse attempt
+        @Schema(description = "응시 진행 상태") QuizAnswerAttemptResponse attempt,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "마지막 문항 제출 시 포인트 지급 결과", nullable = true)
+        QuizRewardResponse reward,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "퀴즈 완료 후 다음 동작", example = "NEXT_SUB_CHAPTER", nullable = true)
+        String nextAction
 ) {
     public static QuizAnswerGradingResponse from(QuizAnswerGradingResult result) {
         return new QuizAnswerGradingResponse(
@@ -28,8 +35,14 @@ public record QuizAnswerGradingResponse(
                         result.attemptStatus(),
                         result.answeredCount(),
                         result.totalCount(),
+                        result.correctCount(),
+                        result.score(),
                         result.attemptStatus() == org.firstfolio.quiz.domain.QuizAttemptStatus.GRADED
-                )
+                ),
+                result.reward() == null
+                        ? null
+                        : QuizRewardResponse.from(result.reward()),
+                result.nextAction()
         );
     }
 }

--- a/src/main/java/org/firstfolio/quiz/dto/response/QuizAttemptQuestionResponse.java
+++ b/src/main/java/org/firstfolio/quiz/dto/response/QuizAttemptQuestionResponse.java
@@ -1,0 +1,42 @@
+package org.firstfolio.quiz.dto.response;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.firstfolio.quiz.domain.QuizAttemptQuestion;
+import org.firstfolio.quiz.domain.QuizGenerationType;
+import org.firstfolio.quiz.domain.QuizQuestionType;
+
+import java.util.List;
+
+@Schema(description = "응시에 고정된 퀴즈 문항. 정답과 해설은 포함하지 않습니다.")
+public record QuizAttemptQuestionResponse(
+        @Schema(description = "출제된 문항 버전 ID", example = "1001") long questionId,
+        @Schema(description = "응시 내 표시 순서", example = "1") int displayOrder,
+        @Schema(description = "문항 유형", example = "SINGLE_CHOICE") QuizQuestionType questionType,
+        @Schema(description = "문항 생성 방식", example = "HUMAN") QuizGenerationType generationType,
+        @Schema(description = "문제 본문", example = "예금에 대한 설명으로 올바른 것은?") String prompt,
+        @Schema(description = "시나리오 문항 정보. 일반 문항은 null", nullable = true) JsonNode scenario,
+        @Schema(description = "선택지 목록") List<QuizChoiceResponse> choices
+) {
+    public QuizAttemptQuestionResponse {
+        scenario = scenario == null ? null : scenario.deepCopy();
+        choices = List.copyOf(choices);
+    }
+
+    public static QuizAttemptQuestionResponse from(QuizAttemptQuestion question) {
+        return new QuizAttemptQuestionResponse(
+                question.questionId(),
+                question.displayOrder(),
+                question.questionType(),
+                question.generationType(),
+                question.prompt(),
+                question.scenario(),
+                question.choices().stream().map(QuizChoiceResponse::from).toList()
+        );
+    }
+
+    @Override
+    public JsonNode scenario() {
+        return scenario == null ? null : scenario.deepCopy();
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/dto/response/QuizAttemptStartResponse.java
+++ b/src/main/java/org/firstfolio/quiz/dto/response/QuizAttemptStartResponse.java
@@ -1,0 +1,39 @@
+package org.firstfolio.quiz.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.firstfolio.quiz.domain.QuizAttempt;
+import org.firstfolio.quiz.domain.QuizAttemptStartResult;
+import org.firstfolio.quiz.domain.QuizAttemptStatus;
+import org.firstfolio.quiz.domain.QuizType;
+
+import java.util.List;
+
+@Schema(description = "소단원 퀴즈 응시 시작 결과")
+public record QuizAttemptStartResponse(
+        @Schema(description = "응시 ID", example = "3001") long attemptId,
+        @Schema(description = "퀴즈 유형", example = "SUB_CHAPTER") QuizType quizType,
+        @Schema(description = "소단원 ID", example = "101") long subChapterId,
+        @Schema(description = "학습한 강좌 콘텐츠 버전 ID", example = "301") long contentVersionId,
+        @Schema(description = "응시 상태", example = "IN_PROGRESS") QuizAttemptStatus status,
+        @Schema(description = "문항 수", example = "3") int questionCount,
+        @Schema(description = "정답·해설을 제외한 출제 문항") List<QuizAttemptQuestionResponse> questions
+) {
+    public QuizAttemptStartResponse {
+        questions = List.copyOf(questions);
+    }
+
+    public static QuizAttemptStartResponse from(QuizAttemptStartResult result) {
+        QuizAttempt attempt = result.attempt();
+        return new QuizAttemptStartResponse(
+                attempt.getAttemptId(),
+                attempt.getQuizType(),
+                attempt.getSubChapterId(),
+                attempt.getContentVersionId(),
+                attempt.getStatus(),
+                result.questions().size(),
+                result.questions().stream()
+                        .map(QuizAttemptQuestionResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/dto/response/QuizAttemptStartResponse.java
+++ b/src/main/java/org/firstfolio/quiz/dto/response/QuizAttemptStartResponse.java
@@ -1,5 +1,6 @@
 package org.firstfolio.quiz.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.firstfolio.quiz.domain.QuizAttempt;
 import org.firstfolio.quiz.domain.QuizAttemptStartResult;
@@ -8,12 +9,16 @@ import org.firstfolio.quiz.domain.QuizType;
 
 import java.util.List;
 
-@Schema(description = "소단원 퀴즈 응시 시작 결과")
+@Schema(description = "학습 퀴즈 응시 시작 결과")
 public record QuizAttemptStartResponse(
         @Schema(description = "응시 ID", example = "3001") long attemptId,
         @Schema(description = "퀴즈 유형", example = "SUB_CHAPTER") QuizType quizType,
-        @Schema(description = "소단원 ID", example = "101") long subChapterId,
-        @Schema(description = "학습한 강좌 콘텐츠 버전 ID", example = "301") long contentVersionId,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "대단원 ID", example = "10", nullable = true) Long mainChapterId,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "소단원 ID", example = "101", nullable = true) Long subChapterId,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "학습한 강좌 콘텐츠 버전 ID", example = "301", nullable = true) Long contentVersionId,
         @Schema(description = "응시 상태", example = "IN_PROGRESS") QuizAttemptStatus status,
         @Schema(description = "문항 수", example = "3") int questionCount,
         @Schema(description = "정답·해설을 제외한 출제 문항") List<QuizAttemptQuestionResponse> questions
@@ -27,6 +32,7 @@ public record QuizAttemptStartResponse(
         return new QuizAttemptStartResponse(
                 attempt.getAttemptId(),
                 attempt.getQuizType(),
+                attempt.getMainChapterId(),
                 attempt.getSubChapterId(),
                 attempt.getContentVersionId(),
                 attempt.getStatus(),

--- a/src/main/java/org/firstfolio/quiz/dto/response/QuizChoiceResponse.java
+++ b/src/main/java/org/firstfolio/quiz/dto/response/QuizChoiceResponse.java
@@ -1,0 +1,14 @@
+package org.firstfolio.quiz.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.firstfolio.quiz.domain.QuizChoice;
+
+@Schema(description = "사용자에게 노출하는 퀴즈 선택지")
+public record QuizChoiceResponse(
+        @Schema(description = "선택지 식별자", example = "A") String id,
+        @Schema(description = "선택지 문구", example = "예금은 약정 조건에 따라 이자를 받을 수 있다.") String text
+) {
+    public static QuizChoiceResponse from(QuizChoice choice) {
+        return new QuizChoiceResponse(choice.id(), choice.text());
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/dto/response/QuizCorrectAnswerResponse.java
+++ b/src/main/java/org/firstfolio/quiz/dto/response/QuizCorrectAnswerResponse.java
@@ -1,0 +1,9 @@
+package org.firstfolio.quiz.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "정답 선택지")
+public record QuizCorrectAnswerResponse(
+        @Schema(description = "정답 선택지 키", example = "C") String key
+) {
+}

--- a/src/main/java/org/firstfolio/quiz/dto/response/QuizQuestionCreateResponse.java
+++ b/src/main/java/org/firstfolio/quiz/dto/response/QuizQuestionCreateResponse.java
@@ -1,0 +1,27 @@
+package org.firstfolio.quiz.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.firstfolio.quiz.domain.QuizGenerationType;
+import org.firstfolio.quiz.domain.QuizQuestion;
+import org.firstfolio.quiz.domain.QuizQuestionStatus;
+
+@Schema(description = "퀴즈 문항 버전 생성 결과")
+public record QuizQuestionCreateResponse(
+        @Schema(description = "생성된 문항 버전 ID", example = "1201") long questionId,
+        @Schema(description = "논리 문항 키", example = "deposit-basic-001") String questionKey,
+        @Schema(description = "문항 버전 번호", example = "1") int versionNo,
+        @Schema(description = "생성 방식", example = "HUMAN")
+        QuizGenerationType generationType,
+        @Schema(description = "버전 상태", example = "DRAFT") QuizQuestionStatus status
+) {
+
+    public static QuizQuestionCreateResponse from(QuizQuestion question) {
+        return new QuizQuestionCreateResponse(
+                question.getQuestionId(),
+                question.getQuestionKey(),
+                question.getVersionNo(),
+                question.getGenerationType(),
+                question.getStatus()
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/dto/response/QuizRewardResponse.java
+++ b/src/main/java/org/firstfolio/quiz/dto/response/QuizRewardResponse.java
@@ -1,0 +1,18 @@
+package org.firstfolio.quiz.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.firstfolio.reward.domain.QuizRewardResult;
+
+@Schema(description = "퀴즈 완료 포인트 지급 결과")
+public record QuizRewardResponse(
+        @Schema(description = "지급 포인트", example = "200") int points,
+        @Schema(description = "포인트 원장 ID", example = "7001", nullable = true)
+        Long pointTransactionId
+) {
+    public static QuizRewardResponse from(QuizRewardResult result) {
+        return new QuizRewardResponse(
+                result.points(),
+                result.pointTransactionId()
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/mapper/QuizAttemptMapper.java
+++ b/src/main/java/org/firstfolio/quiz/mapper/QuizAttemptMapper.java
@@ -33,9 +33,13 @@ public interface QuizAttemptMapper {
 
     int countAnsweredByAttemptId(@Param("attemptId") long attemptId);
 
+    int countCorrectByAttemptId(@Param("attemptId") long attemptId);
+
     int insertAttempt(QuizAttempt attempt);
 
     int insertAnswer(QuizAnswer answer);
 
     int gradeAnswerIfUnanswered(QuizAnswer answer);
+
+    int completeAttemptIfInProgress(QuizAttempt attempt);
 }

--- a/src/main/java/org/firstfolio/quiz/mapper/QuizAttemptMapper.java
+++ b/src/main/java/org/firstfolio/quiz/mapper/QuizAttemptMapper.java
@@ -10,6 +10,8 @@ import java.util.List;
 @Mapper
 public interface QuizAttemptMapper {
 
+    QuizAttempt findByIdForUpdate(@Param("attemptId") long attemptId);
+
     QuizAttempt findInProgressByUserIdAndSubChapterIdForUpdate(
             @Param("userId") long userId,
             @Param("subChapterId") long subChapterId
@@ -24,7 +26,16 @@ public interface QuizAttemptMapper {
             @Param("attemptId") long attemptId
     );
 
+    QuizAnswer findAnswerByAttemptIdAndQuestionIdForUpdate(
+            @Param("attemptId") long attemptId,
+            @Param("questionId") long questionId
+    );
+
+    int countAnsweredByAttemptId(@Param("attemptId") long attemptId);
+
     int insertAttempt(QuizAttempt attempt);
 
     int insertAnswer(QuizAnswer answer);
+
+    int gradeAnswerIfUnanswered(QuizAnswer answer);
 }

--- a/src/main/java/org/firstfolio/quiz/mapper/QuizAttemptMapper.java
+++ b/src/main/java/org/firstfolio/quiz/mapper/QuizAttemptMapper.java
@@ -17,9 +17,19 @@ public interface QuizAttemptMapper {
             @Param("subChapterId") long subChapterId
     );
 
+    QuizAttempt findInProgressByUserIdAndMainChapterIdForUpdate(
+            @Param("userId") long userId,
+            @Param("mainChapterId") long mainChapterId
+    );
+
     Integer findMaxAttemptNoByUserIdAndSubChapterId(
             @Param("userId") long userId,
             @Param("subChapterId") long subChapterId
+    );
+
+    Integer findMaxAttemptNoByUserIdAndMainChapterId(
+            @Param("userId") long userId,
+            @Param("mainChapterId") long mainChapterId
     );
 
     List<QuizAnswer> findAnswersByAttemptId(

--- a/src/main/java/org/firstfolio/quiz/mapper/QuizAttemptMapper.java
+++ b/src/main/java/org/firstfolio/quiz/mapper/QuizAttemptMapper.java
@@ -1,0 +1,30 @@
+package org.firstfolio.quiz.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.firstfolio.quiz.domain.QuizAnswer;
+import org.firstfolio.quiz.domain.QuizAttempt;
+
+import java.util.List;
+
+@Mapper
+public interface QuizAttemptMapper {
+
+    QuizAttempt findInProgressByUserIdAndSubChapterIdForUpdate(
+            @Param("userId") long userId,
+            @Param("subChapterId") long subChapterId
+    );
+
+    Integer findMaxAttemptNoByUserIdAndSubChapterId(
+            @Param("userId") long userId,
+            @Param("subChapterId") long subChapterId
+    );
+
+    List<QuizAnswer> findAnswersByAttemptId(
+            @Param("attemptId") long attemptId
+    );
+
+    int insertAttempt(QuizAttempt attempt);
+
+    int insertAnswer(QuizAnswer answer);
+}

--- a/src/main/java/org/firstfolio/quiz/mapper/QuizQuestionMapper.java
+++ b/src/main/java/org/firstfolio/quiz/mapper/QuizQuestionMapper.java
@@ -2,6 +2,7 @@ package org.firstfolio.quiz.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.firstfolio.quiz.domain.QuizQuestion;
 import org.firstfolio.quiz.domain.QuizQuestionReference;
 
 import java.util.List;
@@ -9,7 +10,17 @@ import java.util.List;
 @Mapper
 public interface QuizQuestionMapper {
 
+    QuizQuestion findById(@Param("questionId") long questionId);
+
+    QuizQuestion findLatestByQuestionKeyForUpdate(
+            @Param("questionKey") String questionKey
+    );
+
+    int countByQuestionKey(@Param("questionKey") String questionKey);
+
     List<QuizQuestionReference> findReferencesByIds(
             @Param("questionIds") List<Long> questionIds
     );
+
+    int insert(QuizQuestion question);
 }

--- a/src/main/java/org/firstfolio/quiz/mapper/QuizQuestionMapper.java
+++ b/src/main/java/org/firstfolio/quiz/mapper/QuizQuestionMapper.java
@@ -22,5 +22,9 @@ public interface QuizQuestionMapper {
             @Param("questionIds") List<Long> questionIds
     );
 
+    List<QuizQuestion> findAllByIds(
+            @Param("questionIds") List<Long> questionIds
+    );
+
     int insert(QuizQuestion question);
 }

--- a/src/main/java/org/firstfolio/quiz/mapper/QuizQuestionMapper.java
+++ b/src/main/java/org/firstfolio/quiz/mapper/QuizQuestionMapper.java
@@ -26,5 +26,9 @@ public interface QuizQuestionMapper {
             @Param("questionIds") List<Long> questionIds
     );
 
+    List<QuizQuestion> findLatestPublishedByMainChapterId(
+            @Param("mainChapterId") long mainChapterId
+    );
+
     int insert(QuizQuestion question);
 }

--- a/src/main/java/org/firstfolio/quiz/service/MainChapterQuizAttemptStartService.java
+++ b/src/main/java/org/firstfolio/quiz/service/MainChapterQuizAttemptStartService.java
@@ -1,0 +1,177 @@
+package org.firstfolio.quiz.service;
+
+import org.firstfolio.curriculum.domain.MainChapter;
+import org.firstfolio.curriculum.mapper.MainChapterMapper;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.learning.domain.UserCurriculumItem;
+import org.firstfolio.learning.mapper.MainChapterLearningMapper;
+import org.firstfolio.quiz.domain.QuizAnswer;
+import org.firstfolio.quiz.domain.QuizAttempt;
+import org.firstfolio.quiz.domain.QuizAttemptQuestion;
+import org.firstfolio.quiz.domain.QuizAttemptStartResult;
+import org.firstfolio.quiz.domain.QuizAttemptStatus;
+import org.firstfolio.quiz.domain.QuizQuestion;
+import org.firstfolio.quiz.domain.QuizType;
+import org.firstfolio.quiz.mapper.QuizAttemptMapper;
+import org.firstfolio.quiz.mapper.QuizQuestionMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class MainChapterQuizAttemptStartService {
+
+    private final QuizAttemptMapper quizAttemptMapper;
+    private final QuizQuestionMapper quizQuestionMapper;
+    private final MainChapterLearningMapper learningMapper;
+    private final MainChapterMapper mainChapterMapper;
+    private final Clock clock;
+    private final QuizQuestionSnapshotCodec snapshotCodec;
+
+    public MainChapterQuizAttemptStartService(
+            QuizAttemptMapper quizAttemptMapper,
+            QuizQuestionMapper quizQuestionMapper,
+            MainChapterLearningMapper learningMapper,
+            MainChapterMapper mainChapterMapper,
+            Clock clock
+    ) {
+        this.quizAttemptMapper = quizAttemptMapper;
+        this.quizQuestionMapper = quizQuestionMapper;
+        this.learningMapper = learningMapper;
+        this.mainChapterMapper = mainChapterMapper;
+        this.clock = clock;
+        this.snapshotCodec = new QuizQuestionSnapshotCodec();
+    }
+
+    @Transactional
+    public QuizAttemptStartResult start(long userId, long mainChapterId) {
+        QuizAttempt inProgress = quizAttemptMapper
+                .findInProgressByUserIdAndMainChapterIdForUpdate(
+                        userId,
+                        mainChapterId
+                );
+        requireAvailableMainChapter(userId, mainChapterId);
+
+        if (inProgress != null) {
+            return restore(inProgress);
+        }
+
+        // 존재하지 않는 응시 행은 잠글 수 없으므로 커리큘럼 행을 잠근 뒤 한 번 더
+        // 확인해 동시 시작 요청이 진행 중 응시를 중복 생성하지 않게 한다.
+        inProgress = quizAttemptMapper
+                .findInProgressByUserIdAndMainChapterIdForUpdate(
+                        userId,
+                        mainChapterId
+                );
+        if (inProgress != null) {
+            return restore(inProgress);
+        }
+
+        requireAllSubChaptersCompleted(userId, mainChapterId);
+        List<QuizQuestion> questions = quizQuestionMapper
+                .findLatestPublishedByMainChapterId(mainChapterId);
+        if (questions.isEmpty()) {
+            throw new ApiException(ErrorCode.QUIZ_NOT_AVAILABLE);
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        QuizAttempt attempt = createAttempt(
+                userId,
+                mainChapterId,
+                questions.size(),
+                now
+        );
+
+        List<QuizAttemptQuestion> views = new ArrayList<>();
+        for (int index = 0; index < questions.size(); index++) {
+            QuizQuestion question = questions.get(index);
+            QuizAnswer answer = new QuizAnswer();
+            answer.setAttemptId(attempt.getAttemptId());
+            answer.setQuestionId(question.getQuestionId());
+            answer.setDisplayOrder(index + 1);
+            answer.setQuestionSnapshotJson(
+                    snapshotCodec.createSnapshot(question)
+            );
+            answer.setCreatedAt(now);
+
+            if (quizAttemptMapper.insertAnswer(answer) != 1) {
+                throw new ApiException(ErrorCode.INTERNAL_ERROR);
+            }
+            views.add(snapshotCodec.toQuestionView(answer));
+        }
+
+        return new QuizAttemptStartResult(attempt, views);
+    }
+
+    private void requireAvailableMainChapter(long userId, long mainChapterId) {
+        UserCurriculumItem item = learningMapper
+                .findActiveCurriculumItemForUpdate(userId, mainChapterId);
+        MainChapter mainChapter = mainChapterMapper.findById(mainChapterId);
+        if (item == null || mainChapter == null || !mainChapter.isActive()) {
+            throw new ApiException(ErrorCode.QUIZ_NOT_AVAILABLE);
+        }
+    }
+
+    private void requireAllSubChaptersCompleted(
+            long userId,
+            long mainChapterId
+    ) {
+        if (learningMapper.countActiveSubChapters(mainChapterId) <= 0) {
+            throw new ApiException(ErrorCode.QUIZ_NOT_AVAILABLE);
+        }
+        if (learningMapper.countIncompleteActiveSubChapters(
+                userId,
+                mainChapterId
+        ) > 0) {
+            throw new ApiException(ErrorCode.SUB_CHAPTERS_INCOMPLETE);
+        }
+    }
+
+    private QuizAttemptStartResult restore(QuizAttempt attempt) {
+        List<QuizAnswer> answers = quizAttemptMapper.findAnswersByAttemptId(
+                attempt.getAttemptId()
+        );
+        if (answers.size() != attempt.getTotalCount()) {
+            throw new ApiException(ErrorCode.CONTENT_UNAVAILABLE);
+        }
+        return new QuizAttemptStartResult(
+                attempt,
+                answers.stream().map(snapshotCodec::toQuestionView).toList()
+        );
+    }
+
+    private QuizAttempt createAttempt(
+            long userId,
+            long mainChapterId,
+            int totalCount,
+            LocalDateTime startedAt
+    ) {
+        Integer maxAttemptNo = quizAttemptMapper
+                .findMaxAttemptNoByUserIdAndMainChapterId(
+                        userId,
+                        mainChapterId
+                );
+
+        QuizAttempt attempt = new QuizAttempt();
+        attempt.setUserId(userId);
+        attempt.setQuizType(QuizType.MAIN_CHAPTER);
+        attempt.setMainChapterId(mainChapterId);
+        attempt.setAttemptNo(maxAttemptNo == null ? 1 : maxAttemptNo + 1);
+        attempt.setStatus(QuizAttemptStatus.IN_PROGRESS);
+        attempt.setTotalCount(totalCount);
+        attempt.setCorrectCount(0);
+        attempt.setScore(0);
+        attempt.setStartedAt(startedAt);
+
+        if (quizAttemptMapper.insertAttempt(attempt) != 1
+                || attempt.getAttemptId() == null) {
+            throw new ApiException(ErrorCode.INTERNAL_ERROR);
+        }
+        return attempt;
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/service/QuizAnswerGradingService.java
+++ b/src/main/java/org/firstfolio/quiz/service/QuizAnswerGradingService.java
@@ -12,6 +12,8 @@ import org.firstfolio.quiz.domain.QuizAttempt;
 import org.firstfolio.quiz.domain.QuizAttemptStatus;
 import org.firstfolio.quiz.domain.QuizGenerationType;
 import org.firstfolio.quiz.mapper.QuizAttemptMapper;
+import org.firstfolio.reward.domain.QuizRewardResult;
+import org.firstfolio.reward.service.QuizRewardService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,14 +29,17 @@ public class QuizAnswerGradingService {
 
     private final QuizAttemptMapper quizAttemptMapper;
     private final Clock clock;
+    private final QuizRewardService quizRewardService;
     private final ObjectMapper objectMapper;
 
     public QuizAnswerGradingService(
             QuizAttemptMapper quizAttemptMapper,
-            Clock clock
+            Clock clock,
+            QuizRewardService quizRewardService
     ) {
         this.quizAttemptMapper = quizAttemptMapper;
         this.clock = clock;
+        this.quizRewardService = quizRewardService;
         this.objectMapper = new ObjectMapper();
     }
 
@@ -90,7 +95,67 @@ public class QuizAnswerGradingService {
         if (quizAttemptMapper.gradeAnswerIfUnanswered(answer) != 1) {
             throw new ApiException(ErrorCode.INTERNAL_ERROR);
         }
-        return result(attempt, answer, snapshot, selectedKey);
+        return completeAndResult(
+                attempt,
+                answer,
+                snapshot,
+                selectedKey
+        );
+    }
+
+    private QuizAnswerGradingResult completeAndResult(
+            QuizAttempt attempt,
+            QuizAnswer answer,
+            QuestionSnapshot snapshot,
+            String selectedKey
+    ) {
+        int answeredCount = answeredCount(attempt);
+        if (answeredCount < attempt.getTotalCount()) {
+            return result(
+                    attempt,
+                    answer,
+                    snapshot,
+                    selectedKey,
+                    answeredCount,
+                    null
+            );
+        }
+
+        int correctCount = quizAttemptMapper.countCorrectByAttemptId(
+                attempt.getAttemptId()
+        );
+        if (correctCount < 0 || correctCount > attempt.getTotalCount()) {
+            throw new ApiException(ErrorCode.INTERNAL_ERROR);
+        }
+
+        LocalDateTime completedAt = answer.getAnsweredAt();
+        QuizRewardResult reward = quizRewardService
+                .grantForCompletedAttempt(
+                        attempt.getUserId(),
+                        attempt.getAttemptId(),
+                        attempt.getAttemptNo(),
+                        correctCount,
+                        completedAt
+                );
+
+        attempt.setStatus(QuizAttemptStatus.GRADED);
+        attempt.setCorrectCount(correctCount);
+        attempt.setScore(score(correctCount, attempt.getTotalCount()));
+        attempt.setRewardPolicyId(reward.policyId());
+        attempt.setPointTransactionId(reward.pointTransactionId());
+        attempt.setSubmittedAt(completedAt);
+
+        if (quizAttemptMapper.completeAttemptIfInProgress(attempt) != 1) {
+            throw new ApiException(ErrorCode.INTERNAL_ERROR);
+        }
+        return result(
+                attempt,
+                answer,
+                snapshot,
+                selectedKey,
+                answeredCount,
+                reward
+        );
     }
 
     private QuizAnswerGradingResult result(
@@ -99,16 +164,38 @@ public class QuizAnswerGradingService {
             QuestionSnapshot snapshot,
             String selectedKey
     ) {
+        int answeredCount = answeredCount(attempt);
+        QuizRewardResult reward = attempt.getStatus() == QuizAttemptStatus.GRADED
+                ? quizRewardService.restore(
+                        attempt.getUserId(),
+                        attempt.getAttemptId(),
+                        attempt.getRewardPolicyId(),
+                        attempt.getPointTransactionId()
+                )
+                : null;
+        return result(
+                attempt,
+                answer,
+                snapshot,
+                selectedKey,
+                answeredCount,
+                reward
+        );
+    }
+
+    private QuizAnswerGradingResult result(
+            QuizAttempt attempt,
+            QuizAnswer answer,
+            QuestionSnapshot snapshot,
+            String selectedKey,
+            int answeredCount,
+            QuizRewardResult reward
+    ) {
         if (answer.getCorrect() == null) {
             throw new ApiException(ErrorCode.INTERNAL_ERROR);
         }
 
-        int answeredCount = quizAttemptMapper.countAnsweredByAttemptId(
-                attempt.getAttemptId()
-        );
-        if (answeredCount < 0 || answeredCount > attempt.getTotalCount()) {
-            throw new ApiException(ErrorCode.INTERNAL_ERROR);
-        }
+        boolean completed = attempt.getStatus() == QuizAttemptStatus.GRADED;
 
         return new QuizAnswerGradingResult(
                 attempt.getAttemptId(),
@@ -121,8 +208,31 @@ public class QuizAnswerGradingService {
                 attempt.getStatus(),
                 answeredCount,
                 attempt.getTotalCount(),
-                answeredCount == attempt.getTotalCount()
+                answeredCount == attempt.getTotalCount(),
+                completed ? attempt.getCorrectCount() : null,
+                completed ? attempt.getScore() : null,
+                reward,
+                completed && attempt.getQuizType() == org.firstfolio.quiz.domain.QuizType.SUB_CHAPTER
+                        ? "NEXT_SUB_CHAPTER"
+                        : null
         );
+    }
+
+    private int answeredCount(QuizAttempt attempt) {
+        int answeredCount = quizAttemptMapper.countAnsweredByAttemptId(
+                attempt.getAttemptId()
+        );
+        if (answeredCount < 0 || answeredCount > attempt.getTotalCount()) {
+            throw new ApiException(ErrorCode.INTERNAL_ERROR);
+        }
+        return answeredCount;
+    }
+
+    private int score(int correctCount, int totalCount) {
+        if (totalCount <= 0) {
+            throw new ApiException(ErrorCode.INTERNAL_ERROR);
+        }
+        return Math.round(correctCount * 100.0f / totalCount);
     }
 
     private String normalizeSelectedKey(String selectedKey) {

--- a/src/main/java/org/firstfolio/quiz/service/QuizAnswerGradingService.java
+++ b/src/main/java/org/firstfolio/quiz/service/QuizAnswerGradingService.java
@@ -1,0 +1,221 @@
+package org.firstfolio.quiz.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.quiz.domain.QuizAnswer;
+import org.firstfolio.quiz.domain.QuizAnswerGradingResult;
+import org.firstfolio.quiz.domain.QuizAttempt;
+import org.firstfolio.quiz.domain.QuizAttemptStatus;
+import org.firstfolio.quiz.domain.QuizGenerationType;
+import org.firstfolio.quiz.mapper.QuizAttemptMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+@Service
+public class QuizAnswerGradingService {
+
+    private static final int MAX_CHOICE_KEY_LENGTH = 50;
+
+    private final QuizAttemptMapper quizAttemptMapper;
+    private final Clock clock;
+    private final ObjectMapper objectMapper;
+
+    public QuizAnswerGradingService(
+            QuizAttemptMapper quizAttemptMapper,
+            Clock clock
+    ) {
+        this.quizAttemptMapper = quizAttemptMapper;
+        this.clock = clock;
+        this.objectMapper = new ObjectMapper();
+    }
+
+    @Transactional
+    public QuizAnswerGradingResult grade(
+            long userId,
+            long attemptId,
+            long questionId,
+            String requestedKey
+    ) {
+        QuizAttempt attempt = quizAttemptMapper.findByIdForUpdate(attemptId);
+        if (attempt == null) {
+            throw new ApiException(ErrorCode.QUIZ_ATTEMPT_NOT_FOUND);
+        }
+        if (attempt.getUserId() != userId) {
+            throw new ApiException(ErrorCode.QUIZ_ATTEMPT_FORBIDDEN);
+        }
+
+        QuizAnswer answer = quizAttemptMapper
+                .findAnswerByAttemptIdAndQuestionIdForUpdate(
+                        attemptId,
+                        questionId
+                );
+        if (answer == null) {
+            throw new ApiException(ErrorCode.QUESTION_NOT_IN_ATTEMPT);
+        }
+
+        String selectedKey = normalizeSelectedKey(requestedKey);
+        QuestionSnapshot snapshot = parseSnapshot(
+                answer.getQuestionSnapshotJson()
+        );
+
+        if (answer.getUserAnswerJson() != null) {
+            String existingKey = parseUserAnswer(answer.getUserAnswerJson());
+            if (!existingKey.equals(selectedKey)) {
+                throw new ApiException(ErrorCode.ANSWER_ALREADY_SUBMITTED);
+            }
+            return result(attempt, answer, snapshot, existingKey);
+        }
+
+        if (attempt.getStatus() != QuizAttemptStatus.IN_PROGRESS) {
+            throw new ApiException(ErrorCode.ATTEMPT_ALREADY_GRADED);
+        }
+        if (!snapshot.optionKeys().contains(selectedKey)) {
+            throw new ApiException(ErrorCode.INVALID_SELECTED_CHOICE);
+        }
+
+        boolean correct = snapshot.correctKey().equals(selectedKey);
+        answer.setUserAnswerJson(toUserAnswerJson(selectedKey));
+        answer.setCorrect(correct);
+        answer.setAnsweredAt(LocalDateTime.now(clock));
+
+        if (quizAttemptMapper.gradeAnswerIfUnanswered(answer) != 1) {
+            throw new ApiException(ErrorCode.INTERNAL_ERROR);
+        }
+        return result(attempt, answer, snapshot, selectedKey);
+    }
+
+    private QuizAnswerGradingResult result(
+            QuizAttempt attempt,
+            QuizAnswer answer,
+            QuestionSnapshot snapshot,
+            String selectedKey
+    ) {
+        if (answer.getCorrect() == null) {
+            throw new ApiException(ErrorCode.INTERNAL_ERROR);
+        }
+
+        int answeredCount = quizAttemptMapper.countAnsweredByAttemptId(
+                attempt.getAttemptId()
+        );
+        if (answeredCount < 0 || answeredCount > attempt.getTotalCount()) {
+            throw new ApiException(ErrorCode.INTERNAL_ERROR);
+        }
+
+        return new QuizAnswerGradingResult(
+                attempt.getAttemptId(),
+                answer.getQuestionId(),
+                snapshot.generationType(),
+                selectedKey,
+                answer.getCorrect(),
+                snapshot.correctKey(),
+                snapshot.explanation(),
+                attempt.getStatus(),
+                answeredCount,
+                attempt.getTotalCount(),
+                answeredCount == attempt.getTotalCount()
+        );
+    }
+
+    private String normalizeSelectedKey(String selectedKey) {
+        if (selectedKey == null) {
+            throw new ApiException(ErrorCode.INVALID_SELECTED_CHOICE);
+        }
+
+        String normalized = selectedKey.strip();
+        if (normalized.isEmpty() || normalized.length() > MAX_CHOICE_KEY_LENGTH) {
+            throw new ApiException(ErrorCode.INVALID_SELECTED_CHOICE);
+        }
+        return normalized;
+    }
+
+    private QuestionSnapshot parseSnapshot(String snapshotJson) {
+        try {
+            JsonNode snapshot = objectMapper.readTree(snapshotJson);
+            QuizGenerationType generationType = QuizGenerationType.valueOf(
+                    requiredText(snapshot, "generation_type")
+            );
+
+            JsonNode options = snapshot.path("options_json");
+            if (!options.isArray() || options.isEmpty()) {
+                throw internalError(null);
+            }
+            Set<String> optionKeys = new HashSet<>();
+            for (JsonNode option : options) {
+                if (!optionKeys.add(requiredText(option, "key"))) {
+                    throw internalError(null);
+                }
+            }
+
+            String correctKey = requiredText(
+                    snapshot.path("correct_answer_json"),
+                    "key"
+            );
+            if (!optionKeys.contains(correctKey)) {
+                throw internalError(null);
+            }
+
+            return new QuestionSnapshot(
+                    generationType,
+                    Set.copyOf(optionKeys),
+                    correctKey,
+                    requiredText(snapshot, "explanation")
+            );
+        } catch (JsonProcessingException | IllegalArgumentException exception) {
+            throw internalError(exception);
+        }
+    }
+
+    private String parseUserAnswer(String userAnswerJson) {
+        try {
+            return requiredText(objectMapper.readTree(userAnswerJson), "key");
+        } catch (JsonProcessingException exception) {
+            throw internalError(exception);
+        }
+    }
+
+    private String toUserAnswerJson(String selectedKey) {
+        ObjectNode answer = objectMapper.createObjectNode();
+        answer.put("key", selectedKey);
+        try {
+            return objectMapper.writeValueAsString(answer);
+        } catch (JsonProcessingException exception) {
+            throw internalError(exception);
+        }
+    }
+
+    private String requiredText(JsonNode node, String fieldName) {
+        if (node == null) {
+            throw internalError(null);
+        }
+        String value = node.path(fieldName).textValue();
+        if (value == null || value.isBlank()) {
+            throw internalError(null);
+        }
+        return value;
+    }
+
+    private ApiException internalError(Throwable cause) {
+        return new ApiException(
+                ErrorCode.INTERNAL_ERROR,
+                ErrorCode.INTERNAL_ERROR.getDefaultMessage(),
+                cause
+        );
+    }
+
+    private record QuestionSnapshot(
+            QuizGenerationType generationType,
+            Set<String> optionKeys,
+            String correctKey,
+            String explanation
+    ) {
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/service/QuizAnswerGradingService.java
+++ b/src/main/java/org/firstfolio/quiz/service/QuizAnswerGradingService.java
@@ -4,13 +4,17 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.firstfolio.curriculum.domain.ChapterType;
 import org.firstfolio.exception.ApiException;
 import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.learning.domain.MainChapterCompletionResult;
+import org.firstfolio.learning.service.MainChapterCompletionService;
 import org.firstfolio.quiz.domain.QuizAnswer;
 import org.firstfolio.quiz.domain.QuizAnswerGradingResult;
 import org.firstfolio.quiz.domain.QuizAttempt;
 import org.firstfolio.quiz.domain.QuizAttemptStatus;
 import org.firstfolio.quiz.domain.QuizGenerationType;
+import org.firstfolio.quiz.domain.QuizType;
 import org.firstfolio.quiz.mapper.QuizAttemptMapper;
 import org.firstfolio.reward.domain.QuizRewardResult;
 import org.firstfolio.reward.service.QuizRewardService;
@@ -30,16 +34,19 @@ public class QuizAnswerGradingService {
     private final QuizAttemptMapper quizAttemptMapper;
     private final Clock clock;
     private final QuizRewardService quizRewardService;
+    private final MainChapterCompletionService mainChapterCompletionService;
     private final ObjectMapper objectMapper;
 
     public QuizAnswerGradingService(
             QuizAttemptMapper quizAttemptMapper,
             Clock clock,
-            QuizRewardService quizRewardService
+            QuizRewardService quizRewardService,
+            MainChapterCompletionService mainChapterCompletionService
     ) {
         this.quizAttemptMapper = quizAttemptMapper;
         this.clock = clock;
         this.quizRewardService = quizRewardService;
+        this.mainChapterCompletionService = mainChapterCompletionService;
         this.objectMapper = new ObjectMapper();
     }
 
@@ -117,6 +124,7 @@ public class QuizAnswerGradingService {
                     snapshot,
                     selectedKey,
                     answeredCount,
+                    null,
                     null
             );
         }
@@ -137,6 +145,8 @@ public class QuizAnswerGradingService {
                         correctCount,
                         completedAt
                 );
+        MainChapterCompletionResult mainChapterCompletion =
+                completeMainChapter(attempt, completedAt);
 
         attempt.setStatus(QuizAttemptStatus.GRADED);
         attempt.setCorrectCount(correctCount);
@@ -154,7 +164,8 @@ public class QuizAnswerGradingService {
                 snapshot,
                 selectedKey,
                 answeredCount,
-                reward
+                reward,
+                mainChapterCompletion
         );
     }
 
@@ -173,13 +184,21 @@ public class QuizAnswerGradingService {
                         attempt.getPointTransactionId()
                 )
                 : null;
+        MainChapterCompletionResult mainChapterCompletion =
+                attempt.getStatus() == QuizAttemptStatus.GRADED
+                        ? completeMainChapter(
+                                attempt,
+                                requireSubmittedAt(attempt)
+                        )
+                        : null;
         return result(
                 attempt,
                 answer,
                 snapshot,
                 selectedKey,
                 answeredCount,
-                reward
+                reward,
+                mainChapterCompletion
         );
     }
 
@@ -189,7 +208,8 @@ public class QuizAnswerGradingService {
             QuestionSnapshot snapshot,
             String selectedKey,
             int answeredCount,
-            QuizRewardResult reward
+            QuizRewardResult reward,
+            MainChapterCompletionResult mainChapterCompletion
     ) {
         if (answer.getCorrect() == null) {
             throw new ApiException(ErrorCode.INTERNAL_ERROR);
@@ -212,10 +232,54 @@ public class QuizAnswerGradingService {
                 completed ? attempt.getCorrectCount() : null,
                 completed ? attempt.getScore() : null,
                 reward,
-                completed && attempt.getQuizType() == org.firstfolio.quiz.domain.QuizType.SUB_CHAPTER
-                        ? "NEXT_SUB_CHAPTER"
-                        : null
+                mainChapterCompletion,
+                nextAction(attempt, mainChapterCompletion)
         );
+    }
+
+    private MainChapterCompletionResult completeMainChapter(
+            QuizAttempt attempt,
+            LocalDateTime completedAt
+    ) {
+        if (attempt.getQuizType() != QuizType.MAIN_CHAPTER) {
+            return null;
+        }
+        if (attempt.getMainChapterId() == null) {
+            throw new ApiException(ErrorCode.INTERNAL_ERROR);
+        }
+        return mainChapterCompletionService.complete(
+                attempt.getUserId(),
+                attempt.getMainChapterId(),
+                completedAt
+        );
+    }
+
+    private LocalDateTime requireSubmittedAt(QuizAttempt attempt) {
+        if (attempt.getSubmittedAt() == null) {
+            throw new ApiException(ErrorCode.INTERNAL_ERROR);
+        }
+        return attempt.getSubmittedAt();
+    }
+
+    private String nextAction(
+            QuizAttempt attempt,
+            MainChapterCompletionResult mainChapterCompletion
+    ) {
+        if (attempt.getStatus() != QuizAttemptStatus.GRADED) {
+            return null;
+        }
+        if (attempt.getQuizType() == QuizType.SUB_CHAPTER) {
+            return "NEXT_SUB_CHAPTER";
+        }
+        if (attempt.getQuizType() == QuizType.MAIN_CHAPTER) {
+            if (mainChapterCompletion == null) {
+                throw new ApiException(ErrorCode.INTERNAL_ERROR);
+            }
+            return mainChapterCompletion.chapterType() == ChapterType.FOUNDATION
+                    ? "PORTFOLIO_SETUP"
+                    : "NEXT_MAIN_CHAPTER";
+        }
+        throw new ApiException(ErrorCode.INTERNAL_ERROR);
     }
 
     private int answeredCount(QuizAttempt attempt) {

--- a/src/main/java/org/firstfolio/quiz/service/QuizAttemptStartService.java
+++ b/src/main/java/org/firstfolio/quiz/service/QuizAttemptStartService.java
@@ -3,7 +3,6 @@ package org.firstfolio.quiz.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.firstfolio.content.domain.ContentVersion;
 import org.firstfolio.content.domain.StoredContent;
 import org.firstfolio.content.domain.StoredObjectRef;
@@ -22,11 +21,8 @@ import org.firstfolio.quiz.domain.QuizAttempt;
 import org.firstfolio.quiz.domain.QuizAttemptQuestion;
 import org.firstfolio.quiz.domain.QuizAttemptStartResult;
 import org.firstfolio.quiz.domain.QuizAttemptStatus;
-import org.firstfolio.quiz.domain.QuizChoice;
-import org.firstfolio.quiz.domain.QuizGenerationType;
 import org.firstfolio.quiz.domain.QuizQuestion;
 import org.firstfolio.quiz.domain.QuizQuestionStatus;
-import org.firstfolio.quiz.domain.QuizQuestionType;
 import org.firstfolio.quiz.domain.QuizType;
 import org.firstfolio.quiz.domain.QuizUsageType;
 import org.firstfolio.quiz.mapper.QuizAttemptMapper;
@@ -56,6 +52,7 @@ public class QuizAttemptStartService {
     private final StaticContentStorage contentStorage;
     private final Clock clock;
     private final ObjectMapper objectMapper;
+    private final QuizQuestionSnapshotCodec snapshotCodec;
 
     public QuizAttemptStartService(
             QuizAttemptMapper quizAttemptMapper,
@@ -74,6 +71,7 @@ public class QuizAttemptStartService {
         this.contentStorage = contentStorage;
         this.clock = clock;
         this.objectMapper = new ObjectMapper();
+        this.snapshotCodec = new QuizQuestionSnapshotCodec();
     }
 
     @Transactional
@@ -114,7 +112,7 @@ public class QuizAttemptStartService {
             long questionId = questionIds.get(index);
             int displayOrder = index + 1;
             QuizQuestion question = questionById.get(questionId);
-            String snapshot = createSnapshot(question);
+            String snapshot = snapshotCodec.createSnapshot(question);
 
             QuizAnswer answer = new QuizAnswer();
             answer.setAttemptId(attempt.getAttemptId());
@@ -126,7 +124,7 @@ public class QuizAttemptStartService {
                 throw new ApiException(ErrorCode.INTERNAL_ERROR);
             }
 
-            views.add(toQuestionView(answer));
+            views.add(snapshotCodec.toQuestionView(answer));
         }
 
         return new QuizAttemptStartResult(attempt, views);
@@ -154,7 +152,7 @@ public class QuizAttemptStartService {
         }
 
         List<QuizAttemptQuestion> questions = answers.stream()
-                .map(this::toQuestionView)
+                .map(snapshotCodec::toQuestionView)
                 .toList();
         return new QuizAttemptStartResult(attempt, questions);
     }
@@ -263,99 +261,6 @@ public class QuizAttemptStartService {
             throw new ApiException(ErrorCode.INTERNAL_ERROR);
         }
         return attempt;
-    }
-
-    private String createSnapshot(QuizQuestion question) {
-        ObjectNode snapshot = objectMapper.createObjectNode();
-        snapshot.put("question_type", question.getQuestionType().name());
-        snapshot.put("generation_type", question.getGenerationType().name());
-        snapshot.put("prompt", question.getPrompt());
-        snapshot.set("scenario_json", parseNullableJson(question.getScenarioJson()));
-        snapshot.set("options_json", parseRequiredJson(question.getOptionsJson()));
-        snapshot.set(
-                "correct_answer_json",
-                parseRequiredJson(question.getCorrectAnswerJson())
-        );
-        snapshot.put("explanation", question.getExplanation());
-
-        try {
-            return objectMapper.writeValueAsString(snapshot);
-        } catch (JsonProcessingException exception) {
-            throw unavailable(exception);
-        }
-    }
-
-    private QuizAttemptQuestion toQuestionView(QuizAnswer answer) {
-        try {
-            JsonNode snapshot = objectMapper.readTree(
-                    answer.getQuestionSnapshotJson()
-            );
-            QuizQuestionType questionType = QuizQuestionType.valueOf(
-                    requiredText(snapshot, "question_type")
-            );
-            QuizGenerationType generationType = QuizGenerationType.valueOf(
-                    requiredText(snapshot, "generation_type")
-            );
-            String prompt = requiredText(snapshot, "prompt");
-            JsonNode scenario = snapshot.get("scenario_json");
-            if (scenario == null || scenario.isMissingNode()) {
-                throw unavailable(null);
-            }
-            if (scenario.isNull()) {
-                scenario = null;
-            }
-
-            JsonNode options = snapshot.path("options_json");
-            if (!options.isArray() || options.isEmpty()) {
-                throw unavailable(null);
-            }
-            List<QuizChoice> choices = new ArrayList<>();
-            for (JsonNode option : options) {
-                choices.add(new QuizChoice(
-                        requiredText(option, "key"),
-                        requiredText(option, "label")
-                ));
-            }
-
-            return new QuizAttemptQuestion(
-                    answer.getQuestionId(),
-                    answer.getDisplayOrder(),
-                    questionType,
-                    generationType,
-                    prompt,
-                    scenario,
-                    choices
-            );
-        } catch (JsonProcessingException | IllegalArgumentException exception) {
-            throw unavailable(exception);
-        }
-    }
-
-    private JsonNode parseNullableJson(String json) {
-        return json == null ? objectMapper.nullNode() : parseRequiredJson(json);
-    }
-
-    private JsonNode parseRequiredJson(String json) {
-        if (json == null) {
-            throw unavailable(null);
-        }
-        try {
-            JsonNode parsed = objectMapper.readTree(json);
-            if (parsed == null) {
-                throw unavailable(null);
-            }
-            return parsed;
-        } catch (JsonProcessingException exception) {
-            throw unavailable(exception);
-        }
-    }
-
-    private String requiredText(JsonNode node, String fieldName) {
-        String value = node.path(fieldName).textValue();
-        if (value == null || value.isBlank()) {
-            throw unavailable(null);
-        }
-        return value;
     }
 
     private Map<Long, QuizQuestion> indexQuestions(List<QuizQuestion> questions) {

--- a/src/main/java/org/firstfolio/quiz/service/QuizAttemptStartService.java
+++ b/src/main/java/org/firstfolio/quiz/service/QuizAttemptStartService.java
@@ -1,0 +1,389 @@
+package org.firstfolio.quiz.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.firstfolio.content.domain.ContentVersion;
+import org.firstfolio.content.domain.StoredContent;
+import org.firstfolio.content.domain.StoredObjectRef;
+import org.firstfolio.content.exception.ContentStorageException;
+import org.firstfolio.content.mapper.ContentVersionMapper;
+import org.firstfolio.content.service.StaticContentStorage;
+import org.firstfolio.curriculum.domain.SubChapter;
+import org.firstfolio.curriculum.mapper.SubChapterMapper;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.learning.domain.LearningProgress;
+import org.firstfolio.learning.domain.LearningProgressStatus;
+import org.firstfolio.learning.mapper.LearningProgressMapper;
+import org.firstfolio.quiz.domain.QuizAnswer;
+import org.firstfolio.quiz.domain.QuizAttempt;
+import org.firstfolio.quiz.domain.QuizAttemptQuestion;
+import org.firstfolio.quiz.domain.QuizAttemptStartResult;
+import org.firstfolio.quiz.domain.QuizAttemptStatus;
+import org.firstfolio.quiz.domain.QuizChoice;
+import org.firstfolio.quiz.domain.QuizGenerationType;
+import org.firstfolio.quiz.domain.QuizQuestion;
+import org.firstfolio.quiz.domain.QuizQuestionStatus;
+import org.firstfolio.quiz.domain.QuizQuestionType;
+import org.firstfolio.quiz.domain.QuizType;
+import org.firstfolio.quiz.domain.QuizUsageType;
+import org.firstfolio.quiz.mapper.QuizAttemptMapper;
+import org.firstfolio.quiz.mapper.QuizQuestionMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+@Service
+public class QuizAttemptStartService {
+
+    private static final String JSON_CONTENT_TYPE = "application/json";
+
+    private final QuizAttemptMapper quizAttemptMapper;
+    private final QuizQuestionMapper quizQuestionMapper;
+    private final LearningProgressMapper learningProgressMapper;
+    private final ContentVersionMapper contentVersionMapper;
+    private final SubChapterMapper subChapterMapper;
+    private final StaticContentStorage contentStorage;
+    private final Clock clock;
+    private final ObjectMapper objectMapper;
+
+    public QuizAttemptStartService(
+            QuizAttemptMapper quizAttemptMapper,
+            QuizQuestionMapper quizQuestionMapper,
+            LearningProgressMapper learningProgressMapper,
+            ContentVersionMapper contentVersionMapper,
+            SubChapterMapper subChapterMapper,
+            StaticContentStorage contentStorage,
+            Clock clock
+    ) {
+        this.quizAttemptMapper = quizAttemptMapper;
+        this.quizQuestionMapper = quizQuestionMapper;
+        this.learningProgressMapper = learningProgressMapper;
+        this.contentVersionMapper = contentVersionMapper;
+        this.subChapterMapper = subChapterMapper;
+        this.contentStorage = contentStorage;
+        this.clock = clock;
+        this.objectMapper = new ObjectMapper();
+    }
+
+    @Transactional
+    public QuizAttemptStartResult start(long userId, long subChapterId) {
+        requireActiveSubChapter(subChapterId);
+        LearningProgress progress = requireCompletedProgress(userId, subChapterId);
+
+        QuizAttempt inProgress = quizAttemptMapper
+                .findInProgressByUserIdAndSubChapterIdForUpdate(
+                        userId,
+                        subChapterId
+                );
+        if (inProgress != null) {
+            return restore(inProgress);
+        }
+
+        List<Long> questionIds = loadQuestionIds(
+                subChapterId,
+                progress.getContentVersionId()
+        );
+        List<QuizQuestion> questions = requireAvailableQuestions(
+                subChapterId,
+                questionIds
+        );
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        QuizAttempt attempt = createAttempt(
+                userId,
+                subChapterId,
+                progress.getContentVersionId(),
+                questionIds.size(),
+                now
+        );
+
+        Map<Long, QuizQuestion> questionById = indexQuestions(questions);
+        List<QuizAttemptQuestion> views = new ArrayList<>();
+        for (int index = 0; index < questionIds.size(); index++) {
+            long questionId = questionIds.get(index);
+            int displayOrder = index + 1;
+            QuizQuestion question = questionById.get(questionId);
+            String snapshot = createSnapshot(question);
+
+            QuizAnswer answer = new QuizAnswer();
+            answer.setAttemptId(attempt.getAttemptId());
+            answer.setQuestionId(questionId);
+            answer.setDisplayOrder(displayOrder);
+            answer.setQuestionSnapshotJson(snapshot);
+            answer.setCreatedAt(now);
+            if (quizAttemptMapper.insertAnswer(answer) != 1) {
+                throw new ApiException(ErrorCode.INTERNAL_ERROR);
+            }
+
+            views.add(toQuestionView(answer));
+        }
+
+        return new QuizAttemptStartResult(attempt, views);
+    }
+
+    private LearningProgress requireCompletedProgress(
+            long userId,
+            long subChapterId
+    ) {
+        LearningProgress progress = learningProgressMapper
+                .findByUserIdAndSubChapterIdForUpdate(userId, subChapterId);
+        if (progress == null
+                || progress.getStatus() != LearningProgressStatus.COMPLETED) {
+            throw new ApiException(ErrorCode.QUIZ_NOT_AVAILABLE);
+        }
+        return progress;
+    }
+
+    private QuizAttemptStartResult restore(QuizAttempt attempt) {
+        List<QuizAnswer> answers = quizAttemptMapper.findAnswersByAttemptId(
+                attempt.getAttemptId()
+        );
+        if (answers.size() != attempt.getTotalCount()) {
+            throw unavailable(null);
+        }
+
+        List<QuizAttemptQuestion> questions = answers.stream()
+                .map(this::toQuestionView)
+                .toList();
+        return new QuizAttemptStartResult(attempt, questions);
+    }
+
+    private List<Long> loadQuestionIds(
+            long subChapterId,
+            long contentVersionId
+    ) {
+        ContentVersion version = contentVersionMapper.findById(contentVersionId);
+        if (version == null || version.getSubChapterId() != subChapterId) {
+            throw new ApiException(ErrorCode.QUIZ_NOT_AVAILABLE);
+        }
+
+        StoredContent stored;
+        try {
+            stored = contentStorage.load(new StoredObjectRef(
+                    version.getStorageObjectKey(),
+                    version.getStorageVersionId()
+            ));
+        } catch (ContentStorageException | IllegalArgumentException exception) {
+            throw unavailable(exception);
+        }
+        if (!isJson(stored.contentType())) {
+            throw unavailable(null);
+        }
+
+        try {
+            JsonNode lesson = objectMapper.readTree(new String(
+                    stored.content(),
+                    StandardCharsets.UTF_8
+            ));
+            if (lesson == null
+                    || !lesson.isObject()
+                    || !Objects.equals(
+                            version.getSchemaVersion(),
+                            lesson.path("schemaVersion").textValue()
+                    )) {
+                throw unavailable(null);
+            }
+
+            JsonNode questionIdsNode = lesson.path("subChapterQuiz")
+                    .path("questionIds");
+            if (!questionIdsNode.isArray() || questionIdsNode.isEmpty()) {
+                throw unavailable(null);
+            }
+
+            List<Long> questionIds = new ArrayList<>();
+            for (JsonNode questionId : questionIdsNode) {
+                if (!questionId.canConvertToLong() || questionId.longValue() <= 0) {
+                    throw unavailable(null);
+                }
+                questionIds.add(questionId.longValue());
+            }
+            if (questionIds.stream().distinct().count() != questionIds.size()) {
+                throw unavailable(null);
+            }
+            return List.copyOf(questionIds);
+        } catch (JsonProcessingException exception) {
+            throw unavailable(exception);
+        }
+    }
+
+    private List<QuizQuestion> requireAvailableQuestions(
+            long subChapterId,
+            List<Long> questionIds
+    ) {
+        List<QuizQuestion> questions = quizQuestionMapper.findAllByIds(questionIds);
+        Map<Long, QuizQuestion> questionById = indexQuestions(questions);
+
+        for (Long questionId : questionIds) {
+            QuizQuestion question = questionById.get(questionId);
+            if (question == null
+                    || question.getUsageType() != QuizUsageType.SUB_CHAPTER
+                    || !Objects.equals(question.getSubChapterId(), subChapterId)
+                    || question.getStatus() != QuizQuestionStatus.PUBLISHED) {
+                throw new ApiException(ErrorCode.QUIZ_NOT_AVAILABLE);
+            }
+        }
+        return questions;
+    }
+
+    private QuizAttempt createAttempt(
+            long userId,
+            long subChapterId,
+            long contentVersionId,
+            int totalCount,
+            LocalDateTime startedAt
+    ) {
+        Integer maxAttemptNo = quizAttemptMapper
+                .findMaxAttemptNoByUserIdAndSubChapterId(userId, subChapterId);
+
+        QuizAttempt attempt = new QuizAttempt();
+        attempt.setUserId(userId);
+        attempt.setQuizType(QuizType.SUB_CHAPTER);
+        attempt.setSubChapterId(subChapterId);
+        attempt.setContentVersionId(contentVersionId);
+        attempt.setAttemptNo(maxAttemptNo == null ? 1 : maxAttemptNo + 1);
+        attempt.setStatus(QuizAttemptStatus.IN_PROGRESS);
+        attempt.setTotalCount(totalCount);
+        attempt.setCorrectCount(0);
+        attempt.setScore(0);
+        attempt.setStartedAt(startedAt);
+
+        if (quizAttemptMapper.insertAttempt(attempt) != 1
+                || attempt.getAttemptId() == null) {
+            throw new ApiException(ErrorCode.INTERNAL_ERROR);
+        }
+        return attempt;
+    }
+
+    private String createSnapshot(QuizQuestion question) {
+        ObjectNode snapshot = objectMapper.createObjectNode();
+        snapshot.put("question_type", question.getQuestionType().name());
+        snapshot.put("generation_type", question.getGenerationType().name());
+        snapshot.put("prompt", question.getPrompt());
+        snapshot.set("scenario_json", parseNullableJson(question.getScenarioJson()));
+        snapshot.set("options_json", parseRequiredJson(question.getOptionsJson()));
+        snapshot.set(
+                "correct_answer_json",
+                parseRequiredJson(question.getCorrectAnswerJson())
+        );
+        snapshot.put("explanation", question.getExplanation());
+
+        try {
+            return objectMapper.writeValueAsString(snapshot);
+        } catch (JsonProcessingException exception) {
+            throw unavailable(exception);
+        }
+    }
+
+    private QuizAttemptQuestion toQuestionView(QuizAnswer answer) {
+        try {
+            JsonNode snapshot = objectMapper.readTree(
+                    answer.getQuestionSnapshotJson()
+            );
+            QuizQuestionType questionType = QuizQuestionType.valueOf(
+                    requiredText(snapshot, "question_type")
+            );
+            QuizGenerationType generationType = QuizGenerationType.valueOf(
+                    requiredText(snapshot, "generation_type")
+            );
+            String prompt = requiredText(snapshot, "prompt");
+            JsonNode scenario = snapshot.get("scenario_json");
+            if (scenario == null || scenario.isMissingNode()) {
+                throw unavailable(null);
+            }
+            if (scenario.isNull()) {
+                scenario = null;
+            }
+
+            JsonNode options = snapshot.path("options_json");
+            if (!options.isArray() || options.isEmpty()) {
+                throw unavailable(null);
+            }
+            List<QuizChoice> choices = new ArrayList<>();
+            for (JsonNode option : options) {
+                choices.add(new QuizChoice(
+                        requiredText(option, "key"),
+                        requiredText(option, "label")
+                ));
+            }
+
+            return new QuizAttemptQuestion(
+                    answer.getQuestionId(),
+                    answer.getDisplayOrder(),
+                    questionType,
+                    generationType,
+                    prompt,
+                    scenario,
+                    choices
+            );
+        } catch (JsonProcessingException | IllegalArgumentException exception) {
+            throw unavailable(exception);
+        }
+    }
+
+    private JsonNode parseNullableJson(String json) {
+        return json == null ? objectMapper.nullNode() : parseRequiredJson(json);
+    }
+
+    private JsonNode parseRequiredJson(String json) {
+        if (json == null) {
+            throw unavailable(null);
+        }
+        try {
+            JsonNode parsed = objectMapper.readTree(json);
+            if (parsed == null) {
+                throw unavailable(null);
+            }
+            return parsed;
+        } catch (JsonProcessingException exception) {
+            throw unavailable(exception);
+        }
+    }
+
+    private String requiredText(JsonNode node, String fieldName) {
+        String value = node.path(fieldName).textValue();
+        if (value == null || value.isBlank()) {
+            throw unavailable(null);
+        }
+        return value;
+    }
+
+    private Map<Long, QuizQuestion> indexQuestions(List<QuizQuestion> questions) {
+        Map<Long, QuizQuestion> questionById = new HashMap<>();
+        for (QuizQuestion question : questions) {
+            questionById.put(question.getQuestionId(), question);
+        }
+        return questionById;
+    }
+
+    private boolean isJson(String contentType) {
+        return JSON_CONTENT_TYPE.equalsIgnoreCase(
+                contentType.split(";", 2)[0].trim()
+        );
+    }
+
+    private void requireActiveSubChapter(long subChapterId) {
+        SubChapter subChapter = subChapterMapper.findById(subChapterId);
+        if (subChapter == null || !subChapter.isActive()) {
+            throw new ApiException(ErrorCode.QUIZ_NOT_AVAILABLE);
+        }
+    }
+
+    private ApiException unavailable(Throwable cause) {
+        return new ApiException(
+                ErrorCode.CONTENT_UNAVAILABLE,
+                ErrorCode.CONTENT_UNAVAILABLE.getDefaultMessage(),
+                cause
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/service/QuizQuestionRegistrationService.java
+++ b/src/main/java/org/firstfolio/quiz/service/QuizQuestionRegistrationService.java
@@ -1,0 +1,407 @@
+package org.firstfolio.quiz.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.firstfolio.common.json.ApiObjectMapperFactory;
+import org.firstfolio.curriculum.domain.ChapterType;
+import org.firstfolio.curriculum.domain.MainChapter;
+import org.firstfolio.curriculum.domain.SubChapter;
+import org.firstfolio.curriculum.mapper.AdminAuditLogMapper;
+import org.firstfolio.curriculum.mapper.MainChapterMapper;
+import org.firstfolio.curriculum.mapper.SubChapterMapper;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.quiz.domain.QuizDifficulty;
+import org.firstfolio.quiz.domain.QuizGenerationType;
+import org.firstfolio.quiz.domain.QuizQuestion;
+import org.firstfolio.quiz.domain.QuizQuestionType;
+import org.firstfolio.quiz.domain.QuizUsageType;
+import org.firstfolio.quiz.dto.request.QuizQuestionCreateRequest;
+import org.firstfolio.quiz.dto.request.QuizQuestionVersionCreateRequest;
+import org.firstfolio.quiz.mapper.QuizQuestionMapper;
+import org.firstfolio.quiz.validation.QuizQuestionSchemaValidator;
+import org.firstfolio.quiz.validation.QuizQuestionValidationError;
+import org.firstfolio.quiz.validation.QuizQuestionValidationResult;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Service
+public class QuizQuestionRegistrationService {
+
+    private static final String AUDIT_ENTITY_TYPE = "QUIZ_QUESTION";
+
+    private final QuizQuestionSchemaValidator schemaValidator;
+    private final QuizQuestionMapper questionMapper;
+    private final MainChapterMapper mainChapterMapper;
+    private final SubChapterMapper subChapterMapper;
+    private final AdminAuditLogMapper auditLogMapper;
+    private final Clock clock;
+    private final ObjectMapper objectMapper;
+
+    public QuizQuestionRegistrationService(
+            QuizQuestionSchemaValidator schemaValidator,
+            QuizQuestionMapper questionMapper,
+            MainChapterMapper mainChapterMapper,
+            SubChapterMapper subChapterMapper,
+            AdminAuditLogMapper auditLogMapper,
+            Clock clock
+    ) {
+        this.schemaValidator = schemaValidator;
+        this.questionMapper = questionMapper;
+        this.mainChapterMapper = mainChapterMapper;
+        this.subChapterMapper = subChapterMapper;
+        this.auditLogMapper = auditLogMapper;
+        this.clock = clock;
+        this.objectMapper = ApiObjectMapperFactory.create();
+    }
+
+    @Transactional
+    public QuizQuestion createQuestion(
+            QuizQuestionCreateRequest request,
+            long actorUserId,
+            String requestId
+    ) {
+        if (request == null) {
+            throw new ApiException(ErrorCode.INVALID_REQUEST);
+        }
+
+        ObjectNode candidate = firstVersionCandidate(request);
+        requireValidQuestion(candidate);
+
+        if (questionMapper.countByQuestionKey(request.questionKey()) > 0) {
+            throw new ApiException(ErrorCode.QUESTION_KEY_CONFLICT);
+        }
+
+        QuizUsageType usageType = QuizUsageType.valueOf(request.usageType());
+        QuizQuestionType questionType = QuizQuestionType.valueOf(request.questionType());
+        QuizDifficulty difficulty = request.difficulty() == null
+                ? null
+                : QuizDifficulty.valueOf(request.difficulty());
+        QuestionScope scope = resolveAndValidateScope(
+                usageType,
+                request.mainChapterId(),
+                request.subChapterId()
+        );
+        LocalDateTime now = LocalDateTime.now(clock);
+        QuizQuestion question = QuizQuestion.draft(
+                request.questionKey(),
+                1,
+                usageType,
+                scope.mainChapterId(),
+                scope.subChapterId(),
+                null,
+                questionType,
+                difficulty,
+                request.prompt(),
+                jsonOrNull(request.scenarioJson()),
+                request.optionsJson().toString(),
+                request.correctAnswerJson().toString(),
+                request.explanation(),
+                QuizGenerationType.HUMAN,
+                null,
+                actorUserId,
+                now
+        );
+
+        insertQuestion(
+                question,
+                actorUserId,
+                requestId,
+                now,
+                ErrorCode.QUESTION_KEY_CONFLICT
+        );
+        return question;
+    }
+
+    @Transactional
+    public QuizQuestion createVersion(
+            long questionId,
+            QuizQuestionVersionCreateRequest request,
+            long actorUserId,
+            String requestId
+    ) {
+        if (request == null) {
+            throw new ApiException(ErrorCode.INVALID_REQUEST);
+        }
+
+        QuizQuestion base = questionMapper.findById(questionId);
+        if (base == null) {
+            throw new ApiException(ErrorCode.QUESTION_NOT_FOUND);
+        }
+
+        QuizQuestion latest = questionMapper.findLatestByQuestionKeyForUpdate(
+                base.getQuestionKey()
+        );
+        if (latest == null) {
+            throw new IllegalStateException("퀴즈 문항의 최신 버전을 찾을 수 없습니다.");
+        }
+
+        ObjectNode candidate = nextVersionCandidate(base, request);
+        requireValidQuestion(candidate);
+
+        int versionNo;
+        try {
+            versionNo = Math.addExact(latest.getVersionNo(), 1);
+        } catch (ArithmeticException exception) {
+            throw new ApiException(
+                    ErrorCode.QUESTION_VERSION_CONFLICT,
+                    ErrorCode.QUESTION_VERSION_CONFLICT.getDefaultMessage(),
+                    exception
+            );
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        QuizQuestion question = QuizQuestion.draft(
+                base.getQuestionKey(),
+                versionNo,
+                base.getUsageType(),
+                base.getMainChapterId(),
+                base.getSubChapterId(),
+                base.getDisplayOrder(),
+                base.getQuestionType(),
+                base.getDifficulty(),
+                request.prompt(),
+                jsonOrNull(request.scenarioJson()),
+                request.optionsJson().toString(),
+                request.correctAnswerJson().toString(),
+                request.explanation(),
+                base.getGenerationType(),
+                jsonOrNull(request.sourceRefsJson()),
+                actorUserId,
+                now
+        );
+
+        insertQuestion(
+                question,
+                actorUserId,
+                requestId,
+                now,
+                ErrorCode.QUESTION_VERSION_CONFLICT
+        );
+        return question;
+    }
+
+    private ObjectNode firstVersionCandidate(QuizQuestionCreateRequest request) {
+        ObjectNode candidate = objectMapper.createObjectNode();
+        putText(candidate, "question_key", request.questionKey());
+        putText(candidate, "usage_type", request.usageType());
+        putLong(candidate, "main_chapter_id", request.mainChapterId());
+        putLong(candidate, "sub_chapter_id", request.subChapterId());
+        putText(candidate, "question_type", request.questionType());
+        putText(candidate, "difficulty", request.difficulty());
+        putText(candidate, "prompt", request.prompt());
+        setNode(candidate, "scenario_json", request.scenarioJson());
+        setNode(candidate, "options_json", request.optionsJson());
+        setNode(candidate, "correct_answer_json", request.correctAnswerJson());
+        putText(candidate, "explanation", request.explanation());
+        candidate.put("generation_type", QuizGenerationType.HUMAN.name());
+        candidate.putNull("source_refs_json");
+        return candidate;
+    }
+
+    private ObjectNode nextVersionCandidate(
+            QuizQuestion base,
+            QuizQuestionVersionCreateRequest request
+    ) {
+        ObjectNode candidate = objectMapper.createObjectNode();
+        candidate.put("question_key", base.getQuestionKey());
+        candidate.put("usage_type", base.getUsageType().name());
+        putLong(candidate, "main_chapter_id", base.getMainChapterId());
+        putLong(candidate, "sub_chapter_id", base.getSubChapterId());
+        candidate.put("question_type", base.getQuestionType().name());
+        putEnum(candidate, "difficulty", base.getDifficulty());
+        putText(candidate, "prompt", request.prompt());
+        setNode(candidate, "scenario_json", request.scenarioJson());
+        setNode(candidate, "options_json", request.optionsJson());
+        setNode(candidate, "correct_answer_json", request.correctAnswerJson());
+        putText(candidate, "explanation", request.explanation());
+        candidate.put("generation_type", base.getGenerationType().name());
+        setNode(candidate, "source_refs_json", request.sourceRefsJson());
+        return candidate;
+    }
+
+    private QuestionScope resolveAndValidateScope(
+            QuizUsageType usageType,
+            Long mainChapterId,
+            Long subChapterId
+    ) {
+        Long resolvedMainChapterId = mainChapterId;
+
+        if (subChapterId != null) {
+            SubChapter subChapter = subChapterMapper.findById(subChapterId);
+            if (subChapter == null) {
+                throw validationFailure(
+                        "/sub_chapter_id",
+                        "참조한 소단원을 찾을 수 없습니다: " + subChapterId
+                );
+            }
+            if (mainChapterId != null
+                    && mainChapterId.longValue() != subChapter.getMainChapterId()) {
+                throw validationFailure(
+                        "/main_chapter_id",
+                        "대단원과 소단원의 소속 관계가 일치하지 않습니다."
+                );
+            }
+            if (resolvedMainChapterId == null) {
+                resolvedMainChapterId = subChapter.getMainChapterId();
+            }
+        }
+
+        MainChapter mainChapter = null;
+        if (resolvedMainChapterId != null) {
+            mainChapter = mainChapterMapper.findById(resolvedMainChapterId);
+            if (mainChapter == null) {
+                throw validationFailure(
+                        "/main_chapter_id",
+                        "참조한 대단원을 찾을 수 없습니다: " + resolvedMainChapterId
+                );
+            }
+        }
+
+        if (usageType == QuizUsageType.LEVEL_TEST
+                && (mainChapter == null
+                || mainChapter.getChapterType() != ChapterType.ASSET)) {
+            throw validationFailure(
+                    "/main_chapter_id",
+                    "레벨 테스트는 ASSET 대단원만 참조할 수 있습니다."
+            );
+        }
+        return new QuestionScope(resolvedMainChapterId, subChapterId);
+    }
+
+    private void requireValidQuestion(ObjectNode candidate) {
+        QuizQuestionValidationResult result = schemaValidator.validate(
+                candidate.toString().getBytes(StandardCharsets.UTF_8)
+        );
+        if (result.isValid()) {
+            return;
+        }
+
+        QuizQuestionValidationError firstError = result.errors().get(0);
+        throw validationFailure(firstError.path(), firstError.message());
+    }
+
+    private ApiException validationFailure(String path, String message) {
+        String location = path == null || path.isBlank() ? "" : " (" + path + ")";
+        return new ApiException(
+                ErrorCode.QUESTION_VALIDATION_FAILED,
+                ErrorCode.QUESTION_VALIDATION_FAILED.getDefaultMessage()
+                        + location + " " + message
+        );
+    }
+
+    private void insertQuestion(
+            QuizQuestion question,
+            long actorUserId,
+            String requestId,
+            LocalDateTime now,
+            ErrorCode conflictCode
+    ) {
+        try {
+            questionMapper.insert(question);
+            auditLogMapper.insert(
+                    actorUserId,
+                    "CREATE",
+                    AUDIT_ENTITY_TYPE,
+                    question.getQuestionId(),
+                    null,
+                    snapshot(question),
+                    requestId,
+                    now
+            );
+        } catch (DuplicateKeyException exception) {
+            throw new ApiException(
+                    conflictCode,
+                    conflictCode.getDefaultMessage(),
+                    exception
+            );
+        }
+    }
+
+    private String snapshot(QuizQuestion question) {
+        Map<String, Object> snapshot = new LinkedHashMap<>();
+        snapshot.put("question_id", question.getQuestionId());
+        snapshot.put("question_key", question.getQuestionKey());
+        snapshot.put("version_no", question.getVersionNo());
+        snapshot.put("usage_type", question.getUsageType());
+        snapshot.put("main_chapter_id", question.getMainChapterId());
+        snapshot.put("sub_chapter_id", question.getSubChapterId());
+        snapshot.put("question_type", question.getQuestionType());
+        snapshot.put("difficulty", question.getDifficulty());
+        snapshot.put("prompt", question.getPrompt());
+        snapshot.put("scenario_json", parseStoredJson(question.getScenarioJson()));
+        snapshot.put("options_json", parseStoredJson(question.getOptionsJson()));
+        snapshot.put("correct_answer_json", parseStoredJson(question.getCorrectAnswerJson()));
+        snapshot.put("explanation", question.getExplanation());
+        snapshot.put("generation_type", question.getGenerationType());
+        snapshot.put("source_refs_json", parseStoredJson(question.getSourceRefsJson()));
+        snapshot.put("status", question.getStatus());
+        snapshot.put("created_by", question.getCreatedBy());
+        snapshot.put("created_at", question.getCreatedAt());
+
+        try {
+            return objectMapper.writeValueAsString(snapshot);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("퀴즈 문항 감사 이력을 직렬화할 수 없습니다.", exception);
+        }
+    }
+
+    private JsonNode parseStoredJson(String json) {
+        if (json == null) {
+            return null;
+        }
+        try {
+            return objectMapper.readTree(json);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("퀴즈 문항 JSON을 감사 이력으로 변환할 수 없습니다.", exception);
+        }
+    }
+
+    private String jsonOrNull(JsonNode value) {
+        return value == null || value.isNull() ? null : value.toString();
+    }
+
+    private void putText(ObjectNode target, String field, String value) {
+        if (value == null) {
+            target.putNull(field);
+        } else {
+            target.put(field, value);
+        }
+    }
+
+    private void putLong(ObjectNode target, String field, Long value) {
+        if (value == null) {
+            target.putNull(field);
+        } else {
+            target.put(field, value);
+        }
+    }
+
+    private void putEnum(ObjectNode target, String field, Enum<?> value) {
+        if (value == null) {
+            target.putNull(field);
+        } else {
+            target.put(field, value.name());
+        }
+    }
+
+    private void setNode(ObjectNode target, String field, JsonNode value) {
+        if (value == null) {
+            target.putNull(field);
+        } else {
+            target.set(field, value);
+        }
+    }
+
+    private record QuestionScope(Long mainChapterId, Long subChapterId) {
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/service/QuizQuestionSnapshotCodec.java
+++ b/src/main/java/org/firstfolio/quiz/service/QuizQuestionSnapshotCodec.java
@@ -1,0 +1,123 @@
+package org.firstfolio.quiz.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.quiz.domain.QuizAnswer;
+import org.firstfolio.quiz.domain.QuizAttemptQuestion;
+import org.firstfolio.quiz.domain.QuizChoice;
+import org.firstfolio.quiz.domain.QuizGenerationType;
+import org.firstfolio.quiz.domain.QuizQuestion;
+import org.firstfolio.quiz.domain.QuizQuestionType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+final class QuizQuestionSnapshotCodec {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    String createSnapshot(QuizQuestion question) {
+        ObjectNode snapshot = objectMapper.createObjectNode();
+        snapshot.put("question_type", question.getQuestionType().name());
+        snapshot.put("generation_type", question.getGenerationType().name());
+        snapshot.put("prompt", question.getPrompt());
+        snapshot.set("scenario_json", parseNullableJson(question.getScenarioJson()));
+        snapshot.set("options_json", parseRequiredJson(question.getOptionsJson()));
+        snapshot.set(
+                "correct_answer_json",
+                parseRequiredJson(question.getCorrectAnswerJson())
+        );
+        snapshot.put("explanation", question.getExplanation());
+
+        try {
+            return objectMapper.writeValueAsString(snapshot);
+        } catch (JsonProcessingException exception) {
+            throw unavailable(exception);
+        }
+    }
+
+    QuizAttemptQuestion toQuestionView(QuizAnswer answer) {
+        try {
+            JsonNode snapshot = objectMapper.readTree(
+                    answer.getQuestionSnapshotJson()
+            );
+            QuizQuestionType questionType = QuizQuestionType.valueOf(
+                    requiredText(snapshot, "question_type")
+            );
+            QuizGenerationType generationType = QuizGenerationType.valueOf(
+                    requiredText(snapshot, "generation_type")
+            );
+            String prompt = requiredText(snapshot, "prompt");
+            JsonNode scenario = snapshot.get("scenario_json");
+            if (scenario == null || scenario.isMissingNode()) {
+                throw unavailable(null);
+            }
+            if (scenario.isNull()) {
+                scenario = null;
+            }
+
+            JsonNode options = snapshot.path("options_json");
+            if (!options.isArray() || options.isEmpty()) {
+                throw unavailable(null);
+            }
+            List<QuizChoice> choices = new ArrayList<>();
+            for (JsonNode option : options) {
+                choices.add(new QuizChoice(
+                        requiredText(option, "key"),
+                        requiredText(option, "label")
+                ));
+            }
+
+            return new QuizAttemptQuestion(
+                    answer.getQuestionId(),
+                    answer.getDisplayOrder(),
+                    questionType,
+                    generationType,
+                    prompt,
+                    scenario,
+                    choices
+            );
+        } catch (JsonProcessingException | IllegalArgumentException exception) {
+            throw unavailable(exception);
+        }
+    }
+
+    private JsonNode parseNullableJson(String json) {
+        return json == null ? objectMapper.nullNode() : parseRequiredJson(json);
+    }
+
+    private JsonNode parseRequiredJson(String json) {
+        if (json == null) {
+            throw unavailable(null);
+        }
+        try {
+            JsonNode parsed = objectMapper.readTree(json);
+            if (parsed == null) {
+                throw unavailable(null);
+            }
+            return parsed;
+        } catch (JsonProcessingException exception) {
+            throw unavailable(exception);
+        }
+    }
+
+    private String requiredText(JsonNode node, String fieldName) {
+        String value = node.path(fieldName).textValue();
+        if (value == null || value.isBlank()) {
+            throw unavailable(null);
+        }
+        return value;
+    }
+
+    private ApiException unavailable(Throwable cause) {
+        return new ApiException(
+                ErrorCode.CONTENT_UNAVAILABLE,
+                ErrorCode.CONTENT_UNAVAILABLE.getDefaultMessage(),
+                cause
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/validation/QuizQuestionSchemaValidator.java
+++ b/src/main/java/org/firstfolio/quiz/validation/QuizQuestionSchemaValidator.java
@@ -1,0 +1,150 @@
+package org.firstfolio.quiz.validation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.Error;
+import com.networknt.schema.InputFormat;
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.dialect.Dialects;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 퀴즈 문항 원본 JSON의 구조와 JSON 내부 일관성을 검증한다.
+ *
+ * <p>대단원·소단원 존재 여부와 AI 근거 콘텐츠 ID 존재 여부 같은 DB 연계 규칙은
+ * 이 검증기의 범위가 아니다.</p>
+ */
+@Component
+public final class QuizQuestionSchemaValidator {
+
+    private static final String SCHEMA_RESOURCE =
+            "schemas/quiz/1.0/quiz-question.schema.json";
+
+    private final ObjectMapper objectMapper;
+    private final Schema schema;
+
+    public QuizQuestionSchemaValidator() {
+        this(new ObjectMapper());
+    }
+
+    QuizQuestionSchemaValidator(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper.copy()
+                .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
+        this.schema = loadSchema();
+    }
+
+    public QuizQuestionValidationResult validate(byte[] content) {
+        if (content == null || content.length == 0) {
+            return invalidJson("퀴즈 문항 JSON이 비어 있습니다.");
+        }
+
+        JsonNode root;
+        try {
+            root = objectMapper.readTree(content);
+        } catch (JsonProcessingException exception) {
+            return invalidJson("올바른 JSON 형식이 아닙니다.");
+        } catch (IOException exception) {
+            return invalidJson("퀴즈 문항 JSON을 읽을 수 없습니다.");
+        }
+
+        if (root == null) {
+            return invalidJson("퀴즈 문항 JSON이 비어 있습니다.");
+        }
+
+        List<QuizQuestionValidationError> errors = new ArrayList<>();
+        for (Error error : schema.validate(root.toString(), InputFormat.JSON)) {
+            errors.add(new QuizQuestionValidationError(
+                    QuizQuestionValidationErrorCode.SCHEMA_VIOLATION,
+                    error.getInstanceLocation().toString(),
+                    error.getMessage()
+            ));
+        }
+
+        if (errors.isEmpty()) {
+            errors.addAll(validateOptionKeys(root));
+        }
+
+        errors.sort(Comparator
+                .comparing(QuizQuestionValidationError::path)
+                .thenComparing(error -> error.code().name())
+                .thenComparing(QuizQuestionValidationError::message));
+
+        return errors.isEmpty()
+                ? QuizQuestionValidationResult.valid()
+                : new QuizQuestionValidationResult(errors);
+    }
+
+    private List<QuizQuestionValidationError> validateOptionKeys(JsonNode root) {
+        JsonNode options = root.path("options_json");
+        Set<String> seenKeys = new HashSet<>();
+        Map<String, Integer> firstIndexes = new HashMap<>();
+        List<QuizQuestionValidationError> errors = new ArrayList<>();
+
+        for (int index = 0; index < options.size(); index++) {
+            String key = options.get(index).path("key").textValue();
+            if (seenKeys.add(key)) {
+                firstIndexes.put(key, index);
+                continue;
+            }
+
+            errors.add(new QuizQuestionValidationError(
+                    QuizQuestionValidationErrorCode.DUPLICATE_OPTION_KEY,
+                    "/options_json/" + index + "/key",
+                    "선택지 key '" + key + "'가 /options_json/"
+                            + firstIndexes.get(key) + "/key와 중복됩니다."
+            ));
+        }
+
+        String correctKey = root.path("correct_answer_json").path("key").textValue();
+        if (!seenKeys.contains(correctKey)) {
+            errors.add(new QuizQuestionValidationError(
+                    QuizQuestionValidationErrorCode.CORRECT_OPTION_NOT_FOUND,
+                    "/correct_answer_json/key",
+                    "정답 key '" + correctKey + "'가 options_json에 존재하지 않습니다."
+            ));
+        }
+        return errors;
+    }
+
+    private Schema loadSchema() {
+        ClassLoader classLoader = QuizQuestionSchemaValidator.class.getClassLoader();
+        try (InputStream inputStream = classLoader.getResourceAsStream(SCHEMA_RESOURCE)) {
+            if (inputStream == null) {
+                throw new IllegalStateException(
+                        "퀴즈 문항 JSON Schema를 찾을 수 없습니다: " + SCHEMA_RESOURCE
+                );
+            }
+
+            String schemaData = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+            SchemaRegistry registry = SchemaRegistry.withDialect(Dialects.getDraft202012());
+            return registry.getSchema(schemaData, InputFormat.JSON);
+        } catch (IOException exception) {
+            throw new IllegalStateException(
+                    "퀴즈 문항 JSON Schema를 읽을 수 없습니다: " + SCHEMA_RESOURCE,
+                    exception
+            );
+        }
+    }
+
+    private QuizQuestionValidationResult invalidJson(String message) {
+        return QuizQuestionValidationResult.invalid(new QuizQuestionValidationError(
+                QuizQuestionValidationErrorCode.INVALID_JSON,
+                "",
+                message
+        ));
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/validation/QuizQuestionValidationError.java
+++ b/src/main/java/org/firstfolio/quiz/validation/QuizQuestionValidationError.java
@@ -1,0 +1,16 @@
+package org.firstfolio.quiz.validation;
+
+import java.util.Objects;
+
+public record QuizQuestionValidationError(
+        QuizQuestionValidationErrorCode code,
+        String path,
+        String message
+) {
+
+    public QuizQuestionValidationError {
+        Objects.requireNonNull(code, "code must not be null");
+        Objects.requireNonNull(path, "path must not be null");
+        Objects.requireNonNull(message, "message must not be null");
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/validation/QuizQuestionValidationErrorCode.java
+++ b/src/main/java/org/firstfolio/quiz/validation/QuizQuestionValidationErrorCode.java
@@ -1,0 +1,8 @@
+package org.firstfolio.quiz.validation;
+
+public enum QuizQuestionValidationErrorCode {
+    INVALID_JSON,
+    SCHEMA_VIOLATION,
+    DUPLICATE_OPTION_KEY,
+    CORRECT_OPTION_NOT_FOUND
+}

--- a/src/main/java/org/firstfolio/quiz/validation/QuizQuestionValidationResult.java
+++ b/src/main/java/org/firstfolio/quiz/validation/QuizQuestionValidationResult.java
@@ -1,0 +1,24 @@
+package org.firstfolio.quiz.validation;
+
+import java.util.List;
+import java.util.Objects;
+
+public record QuizQuestionValidationResult(List<QuizQuestionValidationError> errors) {
+
+    public QuizQuestionValidationResult {
+        Objects.requireNonNull(errors, "errors must not be null");
+        errors = List.copyOf(errors);
+    }
+
+    public static QuizQuestionValidationResult valid() {
+        return new QuizQuestionValidationResult(List.of());
+    }
+
+    public static QuizQuestionValidationResult invalid(QuizQuestionValidationError error) {
+        return new QuizQuestionValidationResult(List.of(error));
+    }
+
+    public boolean isValid() {
+        return errors.isEmpty();
+    }
+}

--- a/src/main/java/org/firstfolio/reward/domain/PointTransaction.java
+++ b/src/main/java/org/firstfolio/reward/domain/PointTransaction.java
@@ -1,0 +1,97 @@
+package org.firstfolio.reward.domain;
+
+import java.time.LocalDateTime;
+
+public class PointTransaction {
+
+    private Long pointTransactionId;
+    private long userId;
+    private String transactionType;
+    private int amount;
+    private String reasonType;
+    private Long reasonId;
+    private int balanceAfter;
+    private String idempotencyKey;
+    private LocalDateTime occurredAt;
+    private LocalDateTime createdAt;
+
+    public Long getPointTransactionId() {
+        return pointTransactionId;
+    }
+
+    public void setPointTransactionId(Long pointTransactionId) {
+        this.pointTransactionId = pointTransactionId;
+    }
+
+    public long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(long userId) {
+        this.userId = userId;
+    }
+
+    public String getTransactionType() {
+        return transactionType;
+    }
+
+    public void setTransactionType(String transactionType) {
+        this.transactionType = transactionType;
+    }
+
+    public int getAmount() {
+        return amount;
+    }
+
+    public void setAmount(int amount) {
+        this.amount = amount;
+    }
+
+    public String getReasonType() {
+        return reasonType;
+    }
+
+    public void setReasonType(String reasonType) {
+        this.reasonType = reasonType;
+    }
+
+    public Long getReasonId() {
+        return reasonId;
+    }
+
+    public void setReasonId(Long reasonId) {
+        this.reasonId = reasonId;
+    }
+
+    public int getBalanceAfter() {
+        return balanceAfter;
+    }
+
+    public void setBalanceAfter(int balanceAfter) {
+        this.balanceAfter = balanceAfter;
+    }
+
+    public String getIdempotencyKey() {
+        return idempotencyKey;
+    }
+
+    public void setIdempotencyKey(String idempotencyKey) {
+        this.idempotencyKey = idempotencyKey;
+    }
+
+    public LocalDateTime getOccurredAt() {
+        return occurredAt;
+    }
+
+    public void setOccurredAt(LocalDateTime occurredAt) {
+        this.occurredAt = occurredAt;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/org/firstfolio/reward/domain/QuizRewardResult.java
+++ b/src/main/java/org/firstfolio/reward/domain/QuizRewardResult.java
@@ -1,0 +1,18 @@
+package org.firstfolio.reward.domain;
+
+public record QuizRewardResult(
+        long policyId,
+        int points,
+        Long pointTransactionId
+) {
+    public QuizRewardResult {
+        if (policyId <= 0 || points < 0) {
+            throw new IllegalArgumentException("invalid quiz reward result");
+        }
+        if (points > 0 && pointTransactionId == null) {
+            throw new IllegalArgumentException(
+                    "positive reward must include point transaction"
+            );
+        }
+    }
+}

--- a/src/main/java/org/firstfolio/reward/domain/RewardPolicy.java
+++ b/src/main/java/org/firstfolio/reward/domain/RewardPolicy.java
@@ -1,0 +1,41 @@
+package org.firstfolio.reward.domain;
+
+public class RewardPolicy {
+
+    private long policyId;
+    private String policyKey;
+    private int versionNo;
+    private String configJson;
+
+    public long getPolicyId() {
+        return policyId;
+    }
+
+    public void setPolicyId(long policyId) {
+        this.policyId = policyId;
+    }
+
+    public String getPolicyKey() {
+        return policyKey;
+    }
+
+    public void setPolicyKey(String policyKey) {
+        this.policyKey = policyKey;
+    }
+
+    public int getVersionNo() {
+        return versionNo;
+    }
+
+    public void setVersionNo(int versionNo) {
+        this.versionNo = versionNo;
+    }
+
+    public String getConfigJson() {
+        return configJson;
+    }
+
+    public void setConfigJson(String configJson) {
+        this.configJson = configJson;
+    }
+}

--- a/src/main/java/org/firstfolio/reward/mapper/QuizRewardMapper.java
+++ b/src/main/java/org/firstfolio/reward/mapper/QuizRewardMapper.java
@@ -1,0 +1,31 @@
+package org.firstfolio.reward.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.firstfolio.reward.domain.PointTransaction;
+import org.firstfolio.reward.domain.RewardPolicy;
+
+import java.time.LocalDateTime;
+
+@Mapper
+public interface QuizRewardMapper {
+
+    RewardPolicy findActivePolicyAt(
+            @Param("policyKey") String policyKey,
+            @Param("effectiveAt") LocalDateTime effectiveAt
+    );
+
+    PointTransaction findTransactionById(
+            @Param("pointTransactionId") long pointTransactionId
+    );
+
+    int increasePointBalance(
+            @Param("userId") long userId,
+            @Param("amount") int amount,
+            @Param("updatedAt") LocalDateTime updatedAt
+    );
+
+    Integer findPointBalance(@Param("userId") long userId);
+
+    int insertTransaction(PointTransaction transaction);
+}

--- a/src/main/java/org/firstfolio/reward/service/QuizRewardService.java
+++ b/src/main/java/org/firstfolio/reward/service/QuizRewardService.java
@@ -1,0 +1,157 @@
+package org.firstfolio.reward.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.reward.domain.PointTransaction;
+import org.firstfolio.reward.domain.QuizRewardResult;
+import org.firstfolio.reward.domain.RewardPolicy;
+import org.firstfolio.reward.mapper.QuizRewardMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+public class QuizRewardService {
+
+    private static final String POLICY_KEY = "QUIZ_REWARD";
+    private static final String TRANSACTION_TYPE = "EARN";
+    private static final String REASON_TYPE = "QUIZ";
+    private static final String IDEMPOTENCY_PREFIX = "quiz-reward:";
+
+    private final QuizRewardMapper quizRewardMapper;
+    private final ObjectMapper objectMapper;
+
+    public QuizRewardService(QuizRewardMapper quizRewardMapper) {
+        this.quizRewardMapper = quizRewardMapper;
+        this.objectMapper = new ObjectMapper();
+    }
+
+    @Transactional
+    public QuizRewardResult grantForCompletedAttempt(
+            long userId,
+            long attemptId,
+            int attemptNo,
+            int correctCount,
+            LocalDateTime completedAt
+    ) {
+        RewardPolicy policy = quizRewardMapper.findActivePolicyAt(
+                POLICY_KEY,
+                completedAt
+        );
+        if (policy == null) {
+            throw internalError(null);
+        }
+
+        int pointsPerCorrect = pointsPerCorrect(policy.getConfigJson());
+        int points = attemptNo == 1
+                ? multiplyPoints(correctCount, pointsPerCorrect)
+                : 0;
+        if (points == 0) {
+            return new QuizRewardResult(policy.getPolicyId(), 0, null);
+        }
+
+        if (quizRewardMapper.increasePointBalance(
+                userId,
+                points,
+                completedAt
+        ) != 1) {
+            throw internalError(null);
+        }
+        Integer balanceAfter = quizRewardMapper.findPointBalance(userId);
+        if (balanceAfter == null || balanceAfter < points) {
+            throw internalError(null);
+        }
+
+        PointTransaction transaction = new PointTransaction();
+        transaction.setUserId(userId);
+        transaction.setTransactionType(TRANSACTION_TYPE);
+        transaction.setAmount(points);
+        transaction.setReasonType(REASON_TYPE);
+        transaction.setReasonId(attemptId);
+        transaction.setBalanceAfter(balanceAfter);
+        transaction.setIdempotencyKey(IDEMPOTENCY_PREFIX + attemptId);
+        transaction.setOccurredAt(completedAt);
+        transaction.setCreatedAt(completedAt);
+
+        if (quizRewardMapper.insertTransaction(transaction) != 1
+                || transaction.getPointTransactionId() == null) {
+            throw internalError(null);
+        }
+        return new QuizRewardResult(
+                policy.getPolicyId(),
+                points,
+                transaction.getPointTransactionId()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public QuizRewardResult restore(
+            long userId,
+            long attemptId,
+            Long policyId,
+            Long pointTransactionId
+    ) {
+        if (policyId == null) {
+            throw internalError(null);
+        }
+        if (pointTransactionId == null) {
+            return new QuizRewardResult(policyId, 0, null);
+        }
+
+        PointTransaction transaction = quizRewardMapper
+                .findTransactionById(pointTransactionId);
+        if (transaction == null
+                || transaction.getUserId() != userId
+                || !TRANSACTION_TYPE.equals(transaction.getTransactionType())
+                || !REASON_TYPE.equals(transaction.getReasonType())
+                || transaction.getReasonId() == null
+                || transaction.getReasonId() != attemptId
+                || transaction.getAmount() <= 0) {
+            throw internalError(null);
+        }
+        return new QuizRewardResult(
+                policyId,
+                transaction.getAmount(),
+                transaction.getPointTransactionId()
+        );
+    }
+
+    private int pointsPerCorrect(String configJson) {
+        try {
+            JsonNode value = objectMapper
+                    .readTree(configJson)
+                    .path("points_per_correct");
+            if (!value.isIntegralNumber()
+                    || !value.canConvertToInt()
+                    || value.intValue() < 0) {
+                throw internalError(null);
+            }
+            return value.intValue();
+        } catch (JsonProcessingException exception) {
+            throw internalError(exception);
+        }
+    }
+
+    private int multiplyPoints(int correctCount, int pointsPerCorrect) {
+        if (correctCount < 0) {
+            throw internalError(null);
+        }
+        try {
+            return Math.multiplyExact(correctCount, pointsPerCorrect);
+        } catch (ArithmeticException exception) {
+            throw internalError(exception);
+        }
+    }
+
+    private ApiException internalError(Throwable cause) {
+        return new ApiException(
+                ErrorCode.INTERNAL_ERROR,
+                ErrorCode.INTERNAL_ERROR.getDefaultMessage(),
+                cause
+        );
+    }
+}

--- a/src/main/resources/mappers/curriculum/SubChapterMapper.xml
+++ b/src/main/resources/mappers/curriculum/SubChapterMapper.xml
@@ -18,6 +18,36 @@
         <result property="updatedAt" column="updated_at" />
     </resultMap>
 
+    <resultMap id="publicSubChapterResultMap"
+               type="org.firstfolio.curriculum.domain.PublicSubChapter">
+        <id property="subChapterId" column="sub_chapter_id" />
+        <result property="mainChapterId" column="main_chapter_id" />
+        <result property="title" column="title" />
+        <result property="description" column="description" />
+        <result property="displayOrder" column="display_order" />
+        <result property="contentAvailable" column="content_available" />
+    </resultMap>
+
+    <select id="findPublicByMainChapterId"
+            resultMap="publicSubChapterResultMap">
+        SELECT
+            sc.sub_chapter_id,
+            sc.main_chapter_id,
+            sc.title,
+            sc.description,
+            sc.display_order,
+            CASE WHEN cv.content_version_id IS NULL THEN FALSE ELSE TRUE END
+                AS content_available
+        FROM sub_chapters sc
+        LEFT JOIN content_versions cv
+            ON cv.content_version_id = sc.current_content_version_id
+           AND cv.sub_chapter_id = sc.sub_chapter_id
+           AND cv.status = 'PUBLISHED'
+        WHERE sc.main_chapter_id = #{mainChapterId}
+          AND sc.is_active = TRUE
+        ORDER BY sc.display_order, sc.sub_chapter_id
+    </select>
+
     <sql id="subChapterColumns">
         sub_chapter_id,
         main_chapter_id,

--- a/src/main/resources/mappers/learning/LearningContinueMapper.xml
+++ b/src/main/resources/mappers/learning/LearningContinueMapper.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.firstfolio.learning.mapper.LearningContinueMapper">
+
+    <resultMap id="learningContinueCandidateResultMap"
+               type="org.firstfolio.learning.domain.LearningContinueCandidate">
+        <id property="curriculumItemId" column="curriculum_item_id" />
+        <result property="mainChapterId" column="main_chapter_id" />
+        <result property="mainChapterActive" column="main_chapter_active" />
+        <result property="subChapterId" column="sub_chapter_id" />
+        <result property="subChapterActive" column="sub_chapter_active" />
+        <result property="currentContentVersionId" column="current_content_version_id" />
+        <result property="contentVersionId" column="content_version_id" />
+        <result property="lastPageId" column="last_page_id" />
+        <result property="updatedAt" column="updated_at" />
+    </resultMap>
+
+    <select id="findLatestInProgress"
+            resultMap="learningContinueCandidateResultMap">
+        SELECT
+            curriculum.curriculum_item_id,
+            curriculum.main_chapter_id,
+            main.is_active AS main_chapter_active,
+            sub.sub_chapter_id,
+            sub.is_active AS sub_chapter_active,
+            sub.current_content_version_id,
+            progress.content_version_id,
+            progress.last_page_id,
+            progress.updated_at
+        FROM user_learning_progress progress
+        INNER JOIN sub_chapters sub
+            ON sub.sub_chapter_id = progress.sub_chapter_id
+        INNER JOIN main_chapters main
+            ON main.main_chapter_id = sub.main_chapter_id
+        INNER JOIN user_curriculum_items curriculum
+            ON curriculum.user_id = progress.user_id
+           AND curriculum.main_chapter_id = sub.main_chapter_id
+           AND curriculum.status = 'ACTIVE'
+           AND curriculum.completed_at IS NULL
+        WHERE progress.user_id = #{userId}
+          AND progress.status = 'IN_PROGRESS'
+        ORDER BY progress.updated_at DESC, progress.progress_id DESC
+        LIMIT 1
+    </select>
+
+</mapper>

--- a/src/main/resources/mappers/learning/LearningProgressMapper.xml
+++ b/src/main/resources/mappers/learning/LearningProgressMapper.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.firstfolio.learning.mapper.LearningProgressMapper">
+
+    <resultMap id="learningProgressResultMap"
+               type="org.firstfolio.learning.domain.LearningProgress">
+        <id property="progressId" column="progress_id" />
+        <result property="userId" column="user_id" />
+        <result property="subChapterId" column="sub_chapter_id" />
+        <result property="contentVersionId" column="content_version_id" />
+        <result property="lastPageId" column="last_page_id" />
+        <result property="status" column="status" />
+        <result property="startedAt" column="started_at" />
+        <result property="completedAt" column="completed_at" />
+        <result property="updatedAt" column="updated_at" />
+    </resultMap>
+
+    <select id="findByUserIdAndSubChapterId"
+            resultMap="learningProgressResultMap">
+        SELECT
+            progress_id,
+            user_id,
+            sub_chapter_id,
+            content_version_id,
+            last_page_id,
+            status,
+            started_at,
+            completed_at,
+            updated_at
+        FROM user_learning_progress
+        WHERE user_id = #{userId}
+          AND sub_chapter_id = #{subChapterId}
+    </select>
+
+    <select id="findByUserIdAndSubChapterIdForUpdate"
+            resultMap="learningProgressResultMap">
+        SELECT
+            progress_id,
+            user_id,
+            sub_chapter_id,
+            content_version_id,
+            last_page_id,
+            status,
+            started_at,
+            completed_at,
+            updated_at
+        FROM user_learning_progress
+        WHERE user_id = #{userId}
+          AND sub_chapter_id = #{subChapterId}
+        FOR UPDATE
+    </select>
+
+    <insert id="insertIfAbsent"
+            parameterType="org.firstfolio.learning.domain.LearningProgress"
+            useGeneratedKeys="true"
+            keyProperty="progressId"
+            keyColumn="progress_id">
+        INSERT IGNORE INTO user_learning_progress (
+            user_id,
+            sub_chapter_id,
+            content_version_id,
+            last_page_id,
+            status,
+            started_at,
+            completed_at,
+            updated_at
+        ) VALUES (
+            #{userId},
+            #{subChapterId},
+            #{contentVersionId},
+            #{lastPageId,jdbcType=VARCHAR},
+            #{status},
+            #{startedAt},
+            #{completedAt,jdbcType=TIMESTAMP},
+            #{updatedAt}
+        )
+    </insert>
+
+    <update id="updateProgress"
+            parameterType="org.firstfolio.learning.domain.LearningProgress">
+        UPDATE user_learning_progress
+        SET last_page_id = #{lastPageId,jdbcType=VARCHAR},
+            status = #{status},
+            completed_at = #{completedAt,jdbcType=TIMESTAMP},
+            updated_at = #{updatedAt}
+        WHERE progress_id = #{progressId}
+          AND status != 'COMPLETED'
+    </update>
+
+    <insert id="insertEvent"
+            parameterType="org.firstfolio.learning.domain.LearningProgressEvent"
+            useGeneratedKeys="true"
+            keyProperty="progressEventId"
+            keyColumn="progress_event_id">
+        INSERT INTO user_learning_progress_events (
+            progress_id,
+            user_id,
+            sub_chapter_id,
+            content_version_id,
+            event_type,
+            previous_status,
+            status,
+            previous_page_id,
+            last_page_id,
+            occurred_at
+        ) VALUES (
+            #{progressId},
+            #{userId},
+            #{subChapterId},
+            #{contentVersionId},
+            #{eventType},
+            #{previousStatus,jdbcType=VARCHAR},
+            #{status},
+            #{previousPageId,jdbcType=VARCHAR},
+            #{lastPageId,jdbcType=VARCHAR},
+            #{occurredAt}
+        )
+    </insert>
+
+</mapper>

--- a/src/main/resources/mappers/learning/MainChapterLearningMapper.xml
+++ b/src/main/resources/mappers/learning/MainChapterLearningMapper.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.firstfolio.learning.mapper.MainChapterLearningMapper">
+
+    <resultMap id="curriculumItemResultMap"
+               type="org.firstfolio.learning.domain.UserCurriculumItem">
+        <id property="curriculumItemId" column="curriculum_item_id" />
+        <result property="userId" column="user_id" />
+        <result property="mainChapterId" column="main_chapter_id" />
+        <result property="status" column="status" />
+        <result property="completedAt" column="completed_at" />
+    </resultMap>
+
+    <select id="findActiveCurriculumItemForUpdate"
+            resultMap="curriculumItemResultMap">
+        SELECT
+            curriculum_item_id,
+            user_id,
+            main_chapter_id,
+            status,
+            completed_at
+        FROM user_curriculum_items
+        WHERE user_id = #{userId}
+          AND main_chapter_id = #{mainChapterId}
+          AND status = 'ACTIVE'
+        FOR UPDATE
+    </select>
+
+    <select id="countActiveSubChapters" resultType="int">
+        SELECT COUNT(*)
+        FROM sub_chapters
+        WHERE main_chapter_id = #{mainChapterId}
+          AND is_active = TRUE
+    </select>
+
+    <select id="countIncompleteActiveSubChapters" resultType="int">
+        SELECT COUNT(*)
+        FROM sub_chapters sub
+        WHERE sub.main_chapter_id = #{mainChapterId}
+          AND sub.is_active = TRUE
+          AND NOT EXISTS (
+              SELECT 1
+              FROM user_learning_progress progress
+              WHERE progress.user_id = #{userId}
+                AND progress.sub_chapter_id = sub.sub_chapter_id
+                AND progress.status = 'COMPLETED'
+          )
+    </select>
+
+    <update id="completeCurriculumItemIfIncomplete">
+        UPDATE user_curriculum_items
+        SET completed_at = #{completedAt}
+        WHERE curriculum_item_id = #{curriculumItemId}
+          AND status = 'ACTIVE'
+          AND completed_at IS NULL
+    </update>
+
+</mapper>

--- a/src/main/resources/mappers/quiz/QuizAttemptMapper.xml
+++ b/src/main/resources/mappers/quiz/QuizAttemptMapper.xml
@@ -75,6 +75,19 @@
         FOR UPDATE
     </select>
 
+    <select id="findInProgressByUserIdAndMainChapterIdForUpdate"
+            resultMap="quizAttemptResultMap">
+        SELECT <include refid="quizAttemptColumns" />
+        FROM quiz_attempts
+        WHERE user_id = #{userId}
+          AND quiz_type = 'MAIN_CHAPTER'
+          AND main_chapter_id = #{mainChapterId}
+          AND status = 'IN_PROGRESS'
+        ORDER BY attempt_no DESC
+        LIMIT 1
+        FOR UPDATE
+    </select>
+
     <select id="findMaxAttemptNoByUserIdAndSubChapterId"
             resultType="java.lang.Integer">
         SELECT MAX(attempt_no)
@@ -82,6 +95,15 @@
         WHERE user_id = #{userId}
           AND quiz_type = 'SUB_CHAPTER'
           AND sub_chapter_id = #{subChapterId}
+    </select>
+
+    <select id="findMaxAttemptNoByUserIdAndMainChapterId"
+            resultType="java.lang.Integer">
+        SELECT MAX(attempt_no)
+        FROM quiz_attempts
+        WHERE user_id = #{userId}
+          AND quiz_type = 'MAIN_CHAPTER'
+          AND main_chapter_id = #{mainChapterId}
     </select>
 
     <select id="findAnswersByAttemptId" resultMap="quizAnswerResultMap">

--- a/src/main/resources/mappers/quiz/QuizAttemptMapper.xml
+++ b/src/main/resources/mappers/quiz/QuizAttemptMapper.xml
@@ -51,6 +51,13 @@
         submitted_at
     </sql>
 
+    <select id="findByIdForUpdate" resultMap="quizAttemptResultMap">
+        SELECT <include refid="quizAttemptColumns" />
+        FROM quiz_attempts
+        WHERE attempt_id = #{attemptId}
+        FOR UPDATE
+    </select>
+
     <select id="findInProgressByUserIdAndSubChapterIdForUpdate"
             resultMap="quizAttemptResultMap">
         SELECT <include refid="quizAttemptColumns" />
@@ -87,6 +94,31 @@
         FROM quiz_answers
         WHERE attempt_id = #{attemptId}
         ORDER BY display_order ASC
+    </select>
+
+    <select id="findAnswerByAttemptIdAndQuestionIdForUpdate"
+            resultMap="quizAnswerResultMap">
+        SELECT
+            quiz_answer_id,
+            attempt_id,
+            question_id,
+            display_order,
+            question_snapshot_json,
+            user_answer_json,
+            is_correct,
+            answered_at,
+            created_at
+        FROM quiz_answers
+        WHERE attempt_id = #{attemptId}
+          AND question_id = #{questionId}
+        FOR UPDATE
+    </select>
+
+    <select id="countAnsweredByAttemptId" resultType="int">
+        SELECT COUNT(*)
+        FROM quiz_answers
+        WHERE attempt_id = #{attemptId}
+          AND user_answer_json IS NOT NULL
     </select>
 
     <insert id="insertAttempt"
@@ -148,5 +180,15 @@
             #{createdAt}
         )
     </insert>
+
+    <update id="gradeAnswerIfUnanswered"
+            parameterType="org.firstfolio.quiz.domain.QuizAnswer">
+        UPDATE quiz_answers
+        SET user_answer_json = #{userAnswerJson},
+            is_correct = #{correct},
+            answered_at = #{answeredAt}
+        WHERE quiz_answer_id = #{quizAnswerId}
+          AND user_answer_json IS NULL
+    </update>
 
 </mapper>

--- a/src/main/resources/mappers/quiz/QuizAttemptMapper.xml
+++ b/src/main/resources/mappers/quiz/QuizAttemptMapper.xml
@@ -18,6 +18,8 @@
         <result property="totalCount" column="total_count" />
         <result property="correctCount" column="correct_count" />
         <result property="score" column="score" />
+        <result property="rewardPolicyId" column="reward_policy_id" />
+        <result property="pointTransactionId" column="point_transaction_id" />
         <result property="startedAt" column="started_at" />
         <result property="submittedAt" column="submitted_at" />
     </resultMap>
@@ -47,6 +49,8 @@
         total_count,
         correct_count,
         score,
+        reward_policy_id,
+        point_transaction_id,
         started_at,
         submitted_at
     </sql>
@@ -121,6 +125,13 @@
           AND user_answer_json IS NOT NULL
     </select>
 
+    <select id="countCorrectByAttemptId" resultType="int">
+        SELECT COUNT(*)
+        FROM quiz_answers
+        WHERE attempt_id = #{attemptId}
+          AND is_correct = TRUE
+    </select>
+
     <insert id="insertAttempt"
             parameterType="org.firstfolio.quiz.domain.QuizAttempt"
             useGeneratedKeys="true"
@@ -189,6 +200,19 @@
             answered_at = #{answeredAt}
         WHERE quiz_answer_id = #{quizAnswerId}
           AND user_answer_json IS NULL
+    </update>
+
+    <update id="completeAttemptIfInProgress"
+            parameterType="org.firstfolio.quiz.domain.QuizAttempt">
+        UPDATE quiz_attempts
+        SET status = #{status},
+            correct_count = #{correctCount},
+            score = #{score},
+            reward_policy_id = #{rewardPolicyId},
+            point_transaction_id = #{pointTransactionId,jdbcType=BIGINT},
+            submitted_at = #{submittedAt}
+        WHERE attempt_id = #{attemptId}
+          AND status = 'IN_PROGRESS'
     </update>
 
 </mapper>

--- a/src/main/resources/mappers/quiz/QuizAttemptMapper.xml
+++ b/src/main/resources/mappers/quiz/QuizAttemptMapper.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.firstfolio.quiz.mapper.QuizAttemptMapper">
+
+    <resultMap id="quizAttemptResultMap"
+               type="org.firstfolio.quiz.domain.QuizAttempt">
+        <id property="attemptId" column="attempt_id" />
+        <result property="userId" column="user_id" />
+        <result property="quizType" column="quiz_type" />
+        <result property="mainChapterId" column="main_chapter_id" />
+        <result property="subChapterId" column="sub_chapter_id" />
+        <result property="contentVersionId" column="content_version_id" />
+        <result property="attemptNo" column="attempt_no" />
+        <result property="status" column="status" />
+        <result property="totalCount" column="total_count" />
+        <result property="correctCount" column="correct_count" />
+        <result property="score" column="score" />
+        <result property="startedAt" column="started_at" />
+        <result property="submittedAt" column="submitted_at" />
+    </resultMap>
+
+    <resultMap id="quizAnswerResultMap"
+               type="org.firstfolio.quiz.domain.QuizAnswer">
+        <id property="quizAnswerId" column="quiz_answer_id" />
+        <result property="attemptId" column="attempt_id" />
+        <result property="questionId" column="question_id" />
+        <result property="displayOrder" column="display_order" />
+        <result property="questionSnapshotJson" column="question_snapshot_json" />
+        <result property="userAnswerJson" column="user_answer_json" />
+        <result property="correct" column="is_correct" />
+        <result property="answeredAt" column="answered_at" />
+        <result property="createdAt" column="created_at" />
+    </resultMap>
+
+    <sql id="quizAttemptColumns">
+        attempt_id,
+        user_id,
+        quiz_type,
+        main_chapter_id,
+        sub_chapter_id,
+        content_version_id,
+        attempt_no,
+        status,
+        total_count,
+        correct_count,
+        score,
+        started_at,
+        submitted_at
+    </sql>
+
+    <select id="findInProgressByUserIdAndSubChapterIdForUpdate"
+            resultMap="quizAttemptResultMap">
+        SELECT <include refid="quizAttemptColumns" />
+        FROM quiz_attempts
+        WHERE user_id = #{userId}
+          AND quiz_type = 'SUB_CHAPTER'
+          AND sub_chapter_id = #{subChapterId}
+          AND status = 'IN_PROGRESS'
+        ORDER BY attempt_no DESC
+        LIMIT 1
+        FOR UPDATE
+    </select>
+
+    <select id="findMaxAttemptNoByUserIdAndSubChapterId"
+            resultType="java.lang.Integer">
+        SELECT MAX(attempt_no)
+        FROM quiz_attempts
+        WHERE user_id = #{userId}
+          AND quiz_type = 'SUB_CHAPTER'
+          AND sub_chapter_id = #{subChapterId}
+    </select>
+
+    <select id="findAnswersByAttemptId" resultMap="quizAnswerResultMap">
+        SELECT
+            quiz_answer_id,
+            attempt_id,
+            question_id,
+            display_order,
+            question_snapshot_json,
+            user_answer_json,
+            is_correct,
+            answered_at,
+            created_at
+        FROM quiz_answers
+        WHERE attempt_id = #{attemptId}
+        ORDER BY display_order ASC
+    </select>
+
+    <insert id="insertAttempt"
+            parameterType="org.firstfolio.quiz.domain.QuizAttempt"
+            useGeneratedKeys="true"
+            keyProperty="attemptId"
+            keyColumn="attempt_id">
+        INSERT INTO quiz_attempts (
+            user_id,
+            quiz_type,
+            main_chapter_id,
+            sub_chapter_id,
+            content_version_id,
+            attempt_no,
+            status,
+            total_count,
+            correct_count,
+            score,
+            started_at,
+            submitted_at
+        ) VALUES (
+            #{userId},
+            #{quizType},
+            #{mainChapterId,jdbcType=BIGINT},
+            #{subChapterId,jdbcType=BIGINT},
+            #{contentVersionId,jdbcType=BIGINT},
+            #{attemptNo},
+            #{status},
+            #{totalCount},
+            #{correctCount},
+            #{score},
+            #{startedAt},
+            #{submittedAt,jdbcType=TIMESTAMP}
+        )
+    </insert>
+
+    <insert id="insertAnswer"
+            parameterType="org.firstfolio.quiz.domain.QuizAnswer"
+            useGeneratedKeys="true"
+            keyProperty="quizAnswerId"
+            keyColumn="quiz_answer_id">
+        INSERT INTO quiz_answers (
+            attempt_id,
+            question_id,
+            display_order,
+            question_snapshot_json,
+            user_answer_json,
+            is_correct,
+            answered_at,
+            created_at
+        ) VALUES (
+            #{attemptId},
+            #{questionId},
+            #{displayOrder},
+            #{questionSnapshotJson},
+            #{userAnswerJson,jdbcType=VARCHAR},
+            #{correct,jdbcType=BOOLEAN},
+            #{answeredAt,jdbcType=TIMESTAMP},
+            #{createdAt}
+        )
+    </insert>
+
+</mapper>

--- a/src/main/resources/mappers/quiz/QuizQuestionMapper.xml
+++ b/src/main/resources/mappers/quiz/QuizQuestionMapper.xml
@@ -5,6 +5,30 @@
 
 <mapper namespace="org.firstfolio.quiz.mapper.QuizQuestionMapper">
 
+    <resultMap id="questionResultMap"
+               type="org.firstfolio.quiz.domain.QuizQuestion">
+        <id property="questionId" column="question_id" />
+        <result property="questionKey" column="question_key" />
+        <result property="versionNo" column="version_no" />
+        <result property="usageType" column="usage_type" />
+        <result property="mainChapterId" column="main_chapter_id" />
+        <result property="subChapterId" column="sub_chapter_id" />
+        <result property="displayOrder" column="display_order" />
+        <result property="questionType" column="question_type" />
+        <result property="difficulty" column="difficulty" />
+        <result property="prompt" column="prompt" />
+        <result property="scenarioJson" column="scenario_json" />
+        <result property="optionsJson" column="options_json" />
+        <result property="correctAnswerJson" column="correct_answer_json" />
+        <result property="explanation" column="explanation" />
+        <result property="generationType" column="generation_type" />
+        <result property="sourceRefsJson" column="source_refs_json" />
+        <result property="status" column="status" />
+        <result property="createdBy" column="created_by" />
+        <result property="publishedAt" column="published_at" />
+        <result property="createdAt" column="created_at" />
+    </resultMap>
+
     <resultMap id="questionReferenceResultMap"
                type="org.firstfolio.quiz.domain.QuizQuestionReference">
         <id property="questionId" column="question_id" />
@@ -12,6 +36,51 @@
         <result property="subChapterId" column="sub_chapter_id" />
         <result property="status" column="status" />
     </resultMap>
+
+    <sql id="questionColumns">
+        question_id,
+        question_key,
+        version_no,
+        usage_type,
+        main_chapter_id,
+        sub_chapter_id,
+        display_order,
+        question_type,
+        difficulty,
+        prompt,
+        scenario_json,
+        options_json,
+        correct_answer_json,
+        explanation,
+        generation_type,
+        source_refs_json,
+        status,
+        created_by,
+        published_at,
+        created_at
+    </sql>
+
+    <select id="findById" resultMap="questionResultMap">
+        SELECT <include refid="questionColumns" />
+        FROM quiz_questions
+        WHERE question_id = #{questionId}
+    </select>
+
+    <select id="findLatestByQuestionKeyForUpdate"
+            resultMap="questionResultMap">
+        SELECT <include refid="questionColumns" />
+        FROM quiz_questions
+        WHERE question_key = #{questionKey}
+        ORDER BY version_no DESC
+        LIMIT 1
+        FOR UPDATE
+    </select>
+
+    <select id="countByQuestionKey" resultType="int">
+        SELECT COUNT(*)
+        FROM quiz_questions
+        WHERE question_key = #{questionKey}
+    </select>
 
     <select id="findReferencesByIds" resultMap="questionReferenceResultMap">
         SELECT question_id,
@@ -28,5 +97,53 @@
             #{questionId}
         </foreach>
     </select>
+
+    <insert id="insert"
+            parameterType="org.firstfolio.quiz.domain.QuizQuestion"
+            useGeneratedKeys="true"
+            keyProperty="questionId"
+            keyColumn="question_id">
+        INSERT INTO quiz_questions (
+            question_key,
+            version_no,
+            usage_type,
+            main_chapter_id,
+            sub_chapter_id,
+            display_order,
+            question_type,
+            difficulty,
+            prompt,
+            scenario_json,
+            options_json,
+            correct_answer_json,
+            explanation,
+            generation_type,
+            source_refs_json,
+            status,
+            created_by,
+            published_at,
+            created_at
+        ) VALUES (
+            #{questionKey},
+            #{versionNo},
+            #{usageType},
+            #{mainChapterId,jdbcType=BIGINT},
+            #{subChapterId,jdbcType=BIGINT},
+            #{displayOrder,jdbcType=INTEGER},
+            #{questionType},
+            #{difficulty,jdbcType=VARCHAR},
+            #{prompt},
+            #{scenarioJson,jdbcType=VARCHAR},
+            #{optionsJson,jdbcType=VARCHAR},
+            #{correctAnswerJson,jdbcType=VARCHAR},
+            #{explanation},
+            #{generationType},
+            #{sourceRefsJson,jdbcType=VARCHAR},
+            #{status},
+            #{createdBy},
+            #{publishedAt,jdbcType=TIMESTAMP},
+            #{createdAt}
+        )
+    </insert>
 
 </mapper>

--- a/src/main/resources/mappers/quiz/QuizQuestionMapper.xml
+++ b/src/main/resources/mappers/quiz/QuizQuestionMapper.xml
@@ -98,6 +98,19 @@
         </foreach>
     </select>
 
+    <select id="findAllByIds" resultMap="questionResultMap">
+        SELECT <include refid="questionColumns" />
+        FROM quiz_questions
+        WHERE question_id IN
+        <foreach collection="questionIds"
+                 item="questionId"
+                 open="("
+                 separator=","
+                 close=")">
+            #{questionId}
+        </foreach>
+    </select>
+
     <insert id="insert"
             parameterType="org.firstfolio.quiz.domain.QuizQuestion"
             useGeneratedKeys="true"

--- a/src/main/resources/mappers/quiz/QuizQuestionMapper.xml
+++ b/src/main/resources/mappers/quiz/QuizQuestionMapper.xml
@@ -111,6 +111,24 @@
         </foreach>
     </select>
 
+    <select id="findLatestPublishedByMainChapterId"
+            resultMap="questionResultMap">
+        SELECT <include refid="questionColumns" />
+        FROM quiz_questions question
+        WHERE question.usage_type = 'MAIN_CHAPTER'
+          AND question.main_chapter_id = #{mainChapterId}
+          AND question.status = 'PUBLISHED'
+          AND question.display_order IS NOT NULL
+          AND NOT EXISTS (
+              SELECT 1
+              FROM quiz_questions newer
+              WHERE newer.question_key = question.question_key
+                AND newer.status = 'PUBLISHED'
+                AND newer.version_no &gt; question.version_no
+          )
+        ORDER BY question.display_order, question.question_id
+    </select>
+
     <insert id="insert"
             parameterType="org.firstfolio.quiz.domain.QuizQuestion"
             useGeneratedKeys="true"

--- a/src/main/resources/mappers/reward/QuizRewardMapper.xml
+++ b/src/main/resources/mappers/reward/QuizRewardMapper.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.firstfolio.reward.mapper.QuizRewardMapper">
+
+    <resultMap id="rewardPolicyResultMap"
+               type="org.firstfolio.reward.domain.RewardPolicy">
+        <id property="policyId" column="policy_id" />
+        <result property="policyKey" column="policy_key" />
+        <result property="versionNo" column="version_no" />
+        <result property="configJson" column="config_json" />
+    </resultMap>
+
+    <resultMap id="pointTransactionResultMap"
+               type="org.firstfolio.reward.domain.PointTransaction">
+        <id property="pointTransactionId" column="point_transaction_id" />
+        <result property="userId" column="user_id" />
+        <result property="transactionType" column="transaction_type" />
+        <result property="amount" column="amount" />
+        <result property="reasonType" column="reason_type" />
+        <result property="reasonId" column="reason_id" />
+        <result property="balanceAfter" column="balance_after" />
+        <result property="idempotencyKey" column="idempotency_key" />
+        <result property="occurredAt" column="occurred_at" />
+        <result property="createdAt" column="created_at" />
+    </resultMap>
+
+    <select id="findActivePolicyAt" resultMap="rewardPolicyResultMap">
+        SELECT policy_id, policy_key, version_no, config_json
+        FROM system_policies
+        WHERE policy_key = #{policyKey}
+          AND is_active = TRUE
+          AND effective_from &lt;= #{effectiveAt}
+          AND (effective_to IS NULL OR effective_to &gt; #{effectiveAt})
+        ORDER BY version_no DESC
+        LIMIT 1
+        FOR SHARE
+    </select>
+
+    <select id="findTransactionById" resultMap="pointTransactionResultMap">
+        SELECT
+            point_transaction_id,
+            user_id,
+            transaction_type,
+            amount,
+            reason_type,
+            reason_id,
+            balance_after,
+            idempotency_key,
+            occurred_at,
+            created_at
+        FROM point_transactions
+        WHERE point_transaction_id = #{pointTransactionId}
+    </select>
+
+    <update id="increasePointBalance">
+        UPDATE users
+        SET point_balance = point_balance + #{amount},
+            updated_at = #{updatedAt}
+        WHERE user_id = #{userId}
+    </update>
+
+    <select id="findPointBalance" resultType="java.lang.Integer">
+        SELECT point_balance
+        FROM users
+        WHERE user_id = #{userId}
+    </select>
+
+    <insert id="insertTransaction"
+            parameterType="org.firstfolio.reward.domain.PointTransaction"
+            useGeneratedKeys="true"
+            keyProperty="pointTransactionId"
+            keyColumn="point_transaction_id">
+        INSERT INTO point_transactions (
+            user_id,
+            transaction_type,
+            amount,
+            reason_type,
+            reason_id,
+            balance_after,
+            idempotency_key,
+            occurred_at,
+            created_at
+        ) VALUES (
+            #{userId},
+            #{transactionType},
+            #{amount},
+            #{reasonType},
+            #{reasonId},
+            #{balanceAfter},
+            #{idempotencyKey},
+            #{occurredAt},
+            #{createdAt}
+        )
+    </insert>
+
+</mapper>

--- a/src/main/resources/schemas/quiz/1.0/quiz-question.schema.json
+++ b/src/main/resources/schemas/quiz/1.0/quiz-question.schema.json
@@ -1,0 +1,484 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://firstfolio.org/schemas/quiz/1.0/quiz-question.schema.json",
+  "title": "FirstFolio quiz question schema 1.0",
+  "type": "object",
+  "required": [
+    "question_key",
+    "usage_type",
+    "main_chapter_id",
+    "sub_chapter_id",
+    "question_type",
+    "difficulty",
+    "prompt",
+    "scenario_json",
+    "options_json",
+    "correct_answer_json",
+    "explanation",
+    "generation_type",
+    "source_refs_json"
+  ],
+  "properties": {
+    "question_key": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 100,
+      "pattern": "\\S"
+    },
+    "usage_type": {
+      "enum": [
+        "LEVEL_TEST",
+        "SUB_CHAPTER",
+        "MAIN_CHAPTER",
+        "DAILY_GENERAL",
+        "DAILY_NEWS"
+      ]
+    },
+    "main_chapter_id": {
+      "$ref": "#/$defs/nullablePositiveId"
+    },
+    "sub_chapter_id": {
+      "$ref": "#/$defs/nullablePositiveId"
+    },
+    "question_type": {
+      "enum": [
+        "SINGLE_CHOICE",
+        "TRUE_FALSE",
+        "SCENARIO"
+      ]
+    },
+    "difficulty": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "EASY",
+        "MEDIUM",
+        "HARD",
+        null
+      ]
+    },
+    "prompt": {
+      "$ref": "#/$defs/nonBlankText"
+    },
+    "scenario_json": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/scenario"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "options_json": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "$ref": "#/$defs/option"
+      }
+    },
+    "correct_answer_json": {
+      "$ref": "#/$defs/correctAnswer"
+    },
+    "explanation": {
+      "$ref": "#/$defs/nonBlankText"
+    },
+    "generation_type": {
+      "enum": [
+        "HUMAN",
+        "AI"
+      ]
+    },
+    "source_refs_json": {
+      "oneOf": [
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/sourceRef"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "usage_type": {
+            "const": "SUB_CHAPTER"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "sub_chapter_id": {
+            "$ref": "#/$defs/positiveId"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "usage_type": {
+            "enum": [
+              "LEVEL_TEST",
+              "MAIN_CHAPTER"
+            ]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "main_chapter_id": {
+            "$ref": "#/$defs/positiveId"
+          },
+          "sub_chapter_id": {
+            "type": "null"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "question_type": {
+            "const": "SCENARIO"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "scenario_json": {
+            "$ref": "#/$defs/scenario"
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "scenario_json": {
+            "type": "null"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "question_type": {
+            "const": "TRUE_FALSE"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "options_json": {
+            "minItems": 2,
+            "maxItems": 2,
+            "allOf": [
+              {
+                "contains": {
+                  "properties": {
+                    "key": {
+                      "const": "O"
+                    }
+                  },
+                  "required": [
+                    "key"
+                  ]
+                },
+                "minContains": 1,
+                "maxContains": 1
+              },
+              {
+                "contains": {
+                  "properties": {
+                    "key": {
+                      "const": "X"
+                    }
+                  },
+                  "required": [
+                    "key"
+                  ]
+                },
+                "minContains": 1,
+                "maxContains": 1
+              }
+            ]
+          },
+          "correct_answer_json": {
+            "properties": {
+              "key": {
+                "enum": [
+                  "O",
+                  "X"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "generation_type": {
+            "const": "AI"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "source_refs_json": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/$defs/sourceRef"
+            }
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "source_refs_json": {
+            "type": "null"
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "positiveId": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 9223372036854775807
+    },
+    "nullablePositiveId": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/positiveId"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "nonBlankText": {
+      "type": "string",
+      "pattern": "\\S",
+      "not": {
+        "pattern": "<\\s*(?:/?\\s*[A-Za-z][^>]*|!--[\\s\\S]*--\\s*)>"
+      }
+    },
+    "nullableNonBlankText": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/nonBlankText"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "option": {
+      "type": "object",
+      "required": [
+        "key",
+        "label"
+      ],
+      "properties": {
+        "key": {
+          "type": "string",
+          "pattern": "\\S",
+          "maxLength": 50
+        },
+        "label": {
+          "$ref": "#/$defs/nonBlankText"
+        },
+        "description": {
+          "$ref": "#/$defs/nullableNonBlankText"
+        }
+      },
+      "additionalProperties": false
+    },
+    "correctAnswer": {
+      "type": "object",
+      "required": [
+        "key"
+      ],
+      "properties": {
+        "key": {
+          "type": "string",
+          "pattern": "\\S",
+          "maxLength": 50
+        }
+      },
+      "additionalProperties": false
+    },
+    "scenario": {
+      "type": "object",
+      "required": [
+        "title",
+        "narrative",
+        "persona",
+        "requirements",
+        "market",
+        "constraints"
+      ],
+      "properties": {
+        "title": {
+          "$ref": "#/$defs/nonBlankText"
+        },
+        "narrative": {
+          "$ref": "#/$defs/nonBlankText"
+        },
+        "persona": {
+          "$ref": "#/$defs/persona"
+        },
+        "requirements": {
+          "$ref": "#/$defs/requirements"
+        },
+        "market": {
+          "$ref": "#/$defs/market"
+        },
+        "constraints": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/nonBlankText"
+          }
+        },
+        "paper_title": {
+          "$ref": "#/$defs/nullableNonBlankText"
+        }
+      },
+      "additionalProperties": false
+    },
+    "persona": {
+      "type": "object",
+      "required": [
+        "name",
+        "age",
+        "job"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/nonBlankText"
+        },
+        "age": {
+          "$ref": "#/$defs/nonBlankText"
+        },
+        "job": {
+          "$ref": "#/$defs/nonBlankText"
+        }
+      },
+      "additionalProperties": false
+    },
+    "requirements": {
+      "type": "object",
+      "required": [
+        "assets",
+        "risk",
+        "goal"
+      ],
+      "properties": {
+        "assets": {
+          "$ref": "#/$defs/nonBlankText"
+        },
+        "risk": {
+          "$ref": "#/$defs/nonBlankText"
+        },
+        "goal": {
+          "$ref": "#/$defs/nonBlankText"
+        }
+      },
+      "additionalProperties": false
+    },
+    "market": {
+      "type": "object",
+      "required": [
+        "title",
+        "reference_at",
+        "bullets"
+      ],
+      "properties": {
+        "title": {
+          "$ref": "#/$defs/nonBlankText"
+        },
+        "reference_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "bullets": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/nonBlankText"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "sourceRef": {
+      "type": "object",
+      "required": [
+        "title",
+        "reference_at"
+      ],
+      "properties": {
+        "knowledge_content_id": {
+          "$ref": "#/$defs/nullablePositiveId"
+        },
+        "title": {
+          "$ref": "#/$defs/nonBlankText"
+        },
+        "publisher": {
+          "$ref": "#/$defs/nullableNonBlankText"
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        },
+        "reference_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "required": [
+            "knowledge_content_id"
+          ],
+          "properties": {
+            "knowledge_content_id": {
+              "$ref": "#/$defs/positiveId"
+            }
+          }
+        },
+        {
+          "required": [
+            "url"
+          ],
+          "properties": {
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/test/java/org/firstfolio/config/OpenApiConfigTest.java
+++ b/src/test/java/org/firstfolio/config/OpenApiConfigTest.java
@@ -5,8 +5,10 @@ import org.firstfolio.auth.controller.AuthController;
 import org.firstfolio.auth.domain.AuthenticatedUser;
 import org.firstfolio.auth.service.AuthUseCase;
 import org.firstfolio.learning.controller.LessonContentController;
+import org.firstfolio.learning.controller.LearningProgressController;
 import org.firstfolio.learning.controller.PublicChapterController;
 import org.firstfolio.learning.service.LessonContentQueryService;
+import org.firstfolio.learning.service.LearningProgressService;
 import org.firstfolio.learning.service.PublicChapterQueryService;
 import org.firstfolio.portfolio.controller.PortfolioController;
 import org.firstfolio.portfolio.service.PortfolioQueryService;
@@ -132,6 +134,18 @@ class OpenApiConfigTest {
                         "$.paths['/api/learning/main-chapters/{mainChapterId}/sub-chapters'].get.responses['404'].content['application/json'].schema['$ref']"
                 ).value("#/components/schemas/ErrorResponse"))
                 .andExpect(jsonPath(
+                        "$.paths['/api/learning/sub-chapters/{subChapterId}/progress'].put.responses['200'].content['application/json'].schema['$ref']"
+                ).value("#/components/schemas/LearningProgressUpdateApiResponse"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/learning/sub-chapters/{subChapterId}/progress'].post"
+                ).doesNotExist())
+                .andExpect(jsonPath(
+                        "$.paths['/api/learning/sub-chapters/{subChapterId}/progress'].get.responses['200'].content['application/json'].schema['$ref']"
+                ).value("#/components/schemas/LearningProgressApiResponse"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/learning/sub-chapters/{subChapterId}/progress'].get.responses['404'].content['application/json'].schema['$ref']"
+                ).value("#/components/schemas/ErrorResponse"))
+                .andExpect(jsonPath(
                         "$.components.schemas.SignupRequest.properties.nickname.description"
                 ).value("2~10자의 서비스 닉네임"))
                 .andExpect(jsonPath(
@@ -191,6 +205,11 @@ class OpenApiConfigTest {
         @Bean
         PublicChapterController publicChapterController() {
             return new PublicChapterController(mock(PublicChapterQueryService.class));
+        }
+
+        @Bean
+        LearningProgressController learningProgressController() {
+            return new LearningProgressController(mock(LearningProgressService.class));
         }
 
         @Bean

--- a/src/test/java/org/firstfolio/config/OpenApiConfigTest.java
+++ b/src/test/java/org/firstfolio/config/OpenApiConfigTest.java
@@ -5,7 +5,9 @@ import org.firstfolio.auth.controller.AuthController;
 import org.firstfolio.auth.domain.AuthenticatedUser;
 import org.firstfolio.auth.service.AuthUseCase;
 import org.firstfolio.learning.controller.LessonContentController;
+import org.firstfolio.learning.controller.PublicChapterController;
 import org.firstfolio.learning.service.LessonContentQueryService;
+import org.firstfolio.learning.service.PublicChapterQueryService;
 import org.firstfolio.portfolio.controller.PortfolioController;
 import org.firstfolio.portfolio.service.PortfolioQueryService;
 import org.firstfolio.portfolio.service.PortfolioResetService;
@@ -121,6 +123,15 @@ class OpenApiConfigTest {
                         "$.paths['/api/learning/sub-chapters/{subChapterId}'].get.parameters[0].description"
                 ).value("조회할 소단원 ID"))
                 .andExpect(jsonPath(
+                        "$.paths['/api/learning/main-chapters'].get.responses['200'].content['application/json'].schema['$ref']"
+                ).value("#/components/schemas/PublicMainChapterListApiResponse"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/learning/main-chapters/{mainChapterId}/sub-chapters'].get.responses['200'].content['application/json'].schema['$ref']"
+                ).value("#/components/schemas/PublicSubChapterListApiResponse"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/learning/main-chapters/{mainChapterId}/sub-chapters'].get.responses['404'].content['application/json'].schema['$ref']"
+                ).value("#/components/schemas/ErrorResponse"))
+                .andExpect(jsonPath(
                         "$.components.schemas.SignupRequest.properties.nickname.description"
                 ).value("2~10자의 서비스 닉네임"))
                 .andExpect(jsonPath(
@@ -175,6 +186,11 @@ class OpenApiConfigTest {
         @Bean
         LessonContentController lessonContentController() {
             return new LessonContentController(mock(LessonContentQueryService.class));
+        }
+
+        @Bean
+        PublicChapterController publicChapterController() {
+            return new PublicChapterController(mock(PublicChapterQueryService.class));
         }
 
         @Bean

--- a/src/test/java/org/firstfolio/config/OpenApiConfigTest.java
+++ b/src/test/java/org/firstfolio/config/OpenApiConfigTest.java
@@ -15,6 +15,8 @@ import org.firstfolio.portfolio.service.PortfolioQueryService;
 import org.firstfolio.portfolio.service.PortfolioResetService;
 import org.firstfolio.portfolio.service.TradeService;
 import org.firstfolio.quiz.controller.QuizAttemptController;
+import org.firstfolio.quiz.controller.QuizAnswerController;
+import org.firstfolio.quiz.service.QuizAnswerGradingService;
 import org.firstfolio.quiz.service.QuizAttemptStartService;
 import org.firstfolio.simulation.controller.InternalProductPriceController;
 import org.firstfolio.simulation.service.PriceRefreshService;
@@ -154,6 +156,12 @@ class OpenApiConfigTest {
                         "$.paths['/api/learning/sub-chapters/{subChapterId}/quiz-attempts'].post.responses['403'].content['application/json'].schema['$ref']"
                 ).value("#/components/schemas/ErrorResponse"))
                 .andExpect(jsonPath(
+                        "$.paths['/api/learning/quiz-attempts/{attemptId}/answers/{questionId}'].put.responses['200'].content['application/json'].schema['$ref']"
+                ).value("#/components/schemas/QuizAnswerGradingApiResponse"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/learning/quiz-attempts/{attemptId}/answers/{questionId}'].put.responses['409'].content['application/json'].schema['$ref']"
+                ).value("#/components/schemas/ErrorResponse"))
+                .andExpect(jsonPath(
                         "$.components.schemas.SignupRequest.properties.nickname.description"
                 ).value("2~10자의 서비스 닉네임"))
                 .andExpect(jsonPath(
@@ -223,6 +231,11 @@ class OpenApiConfigTest {
         @Bean
         QuizAttemptController quizAttemptController() {
             return new QuizAttemptController(mock(QuizAttemptStartService.class));
+        }
+
+        @Bean
+        QuizAnswerController quizAnswerController() {
+            return new QuizAnswerController(mock(QuizAnswerGradingService.class));
         }
 
         @Bean

--- a/src/test/java/org/firstfolio/config/OpenApiConfigTest.java
+++ b/src/test/java/org/firstfolio/config/OpenApiConfigTest.java
@@ -14,6 +14,8 @@ import org.firstfolio.portfolio.controller.PortfolioController;
 import org.firstfolio.portfolio.service.PortfolioQueryService;
 import org.firstfolio.portfolio.service.PortfolioResetService;
 import org.firstfolio.portfolio.service.TradeService;
+import org.firstfolio.quiz.controller.QuizAttemptController;
+import org.firstfolio.quiz.service.QuizAttemptStartService;
 import org.firstfolio.simulation.controller.InternalProductPriceController;
 import org.firstfolio.simulation.service.PriceRefreshService;
 import org.junit.jupiter.api.AfterEach;
@@ -146,6 +148,12 @@ class OpenApiConfigTest {
                         "$.paths['/api/learning/sub-chapters/{subChapterId}/progress'].get.responses['404'].content['application/json'].schema['$ref']"
                 ).value("#/components/schemas/ErrorResponse"))
                 .andExpect(jsonPath(
+                        "$.paths['/api/learning/sub-chapters/{subChapterId}/quiz-attempts'].post.responses['201'].content['application/json'].schema['$ref']"
+                ).value("#/components/schemas/QuizAttemptStartApiResponse"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/learning/sub-chapters/{subChapterId}/quiz-attempts'].post.responses['403'].content['application/json'].schema['$ref']"
+                ).value("#/components/schemas/ErrorResponse"))
+                .andExpect(jsonPath(
                         "$.components.schemas.SignupRequest.properties.nickname.description"
                 ).value("2~10자의 서비스 닉네임"))
                 .andExpect(jsonPath(
@@ -210,6 +218,11 @@ class OpenApiConfigTest {
         @Bean
         LearningProgressController learningProgressController() {
             return new LearningProgressController(mock(LearningProgressService.class));
+        }
+
+        @Bean
+        QuizAttemptController quizAttemptController() {
+            return new QuizAttemptController(mock(QuizAttemptStartService.class));
         }
 
         @Bean

--- a/src/test/java/org/firstfolio/config/OpenApiConfigTest.java
+++ b/src/test/java/org/firstfolio/config/OpenApiConfigTest.java
@@ -16,6 +16,8 @@ import org.firstfolio.portfolio.service.PortfolioResetService;
 import org.firstfolio.portfolio.service.TradeService;
 import org.firstfolio.quiz.controller.QuizAttemptController;
 import org.firstfolio.quiz.controller.QuizAnswerController;
+import org.firstfolio.quiz.controller.MainChapterQuizAttemptController;
+import org.firstfolio.quiz.service.MainChapterQuizAttemptStartService;
 import org.firstfolio.quiz.service.QuizAnswerGradingService;
 import org.firstfolio.quiz.service.QuizAttemptStartService;
 import org.firstfolio.simulation.controller.InternalProductPriceController;
@@ -156,6 +158,12 @@ class OpenApiConfigTest {
                         "$.paths['/api/learning/sub-chapters/{subChapterId}/quiz-attempts'].post.responses['403'].content['application/json'].schema['$ref']"
                 ).value("#/components/schemas/ErrorResponse"))
                 .andExpect(jsonPath(
+                        "$.paths['/api/learning/main-chapters/{mainChapterId}/quiz-attempts'].post.responses['201'].content['application/json'].schema['$ref']"
+                ).value("#/components/schemas/QuizAttemptStartApiResponse"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/learning/main-chapters/{mainChapterId}/quiz-attempts'].post.responses['403'].description"
+                ).value(org.hamcrest.Matchers.containsString("SUB_CHAPTERS_INCOMPLETE")))
+                .andExpect(jsonPath(
                         "$.paths['/api/learning/quiz-attempts/{attemptId}/answers/{questionId}'].put.responses['200'].content['application/json'].schema['$ref']"
                 ).value("#/components/schemas/QuizAnswerGradingApiResponse"))
                 .andExpect(jsonPath(
@@ -231,6 +239,13 @@ class OpenApiConfigTest {
         @Bean
         QuizAttemptController quizAttemptController() {
             return new QuizAttemptController(mock(QuizAttemptStartService.class));
+        }
+
+        @Bean
+        MainChapterQuizAttemptController mainChapterQuizAttemptController() {
+            return new MainChapterQuizAttemptController(
+                    mock(MainChapterQuizAttemptStartService.class)
+            );
         }
 
         @Bean

--- a/src/test/java/org/firstfolio/config/OpenApiConfigTest.java
+++ b/src/test/java/org/firstfolio/config/OpenApiConfigTest.java
@@ -5,9 +5,11 @@ import org.firstfolio.auth.controller.AuthController;
 import org.firstfolio.auth.domain.AuthenticatedUser;
 import org.firstfolio.auth.service.AuthUseCase;
 import org.firstfolio.learning.controller.LessonContentController;
+import org.firstfolio.learning.controller.LearningContinueController;
 import org.firstfolio.learning.controller.LearningProgressController;
 import org.firstfolio.learning.controller.PublicChapterController;
 import org.firstfolio.learning.service.LessonContentQueryService;
+import org.firstfolio.learning.service.LearningContinueService;
 import org.firstfolio.learning.service.LearningProgressService;
 import org.firstfolio.learning.service.PublicChapterQueryService;
 import org.firstfolio.portfolio.controller.PortfolioController;
@@ -152,6 +154,17 @@ class OpenApiConfigTest {
                         "$.paths['/api/learning/sub-chapters/{subChapterId}/progress'].get.responses['404'].content['application/json'].schema['$ref']"
                 ).value("#/components/schemas/ErrorResponse"))
                 .andExpect(jsonPath(
+                        "$.paths['/api/learning/continue'].get.responses['200'].content['application/json'].schema['$ref']"
+                ).value("#/components/schemas/LearningContinueApiResponse"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/learning/continue'].get.responses['404'].description"
+                ).value(org.hamcrest.Matchers.containsString(
+                        "CONTINUE_POSITION_NOT_FOUND"
+                )))
+                .andExpect(jsonPath(
+                        "$.paths['/api/learning/continue'].get.responses['503'].content['application/json'].schema['$ref']"
+                ).value("#/components/schemas/ErrorResponse"))
+                .andExpect(jsonPath(
                         "$.paths['/api/learning/sub-chapters/{subChapterId}/quiz-attempts'].post.responses['201'].content['application/json'].schema['$ref']"
                 ).value("#/components/schemas/QuizAttemptStartApiResponse"))
                 .andExpect(jsonPath(
@@ -234,6 +247,13 @@ class OpenApiConfigTest {
         @Bean
         LearningProgressController learningProgressController() {
             return new LearningProgressController(mock(LearningProgressService.class));
+        }
+
+        @Bean
+        LearningContinueController learningContinueController() {
+            return new LearningContinueController(
+                    mock(LearningContinueService.class)
+            );
         }
 
         @Bean

--- a/src/test/java/org/firstfolio/curriculum/mapper/ChapterMapperXmlTest.java
+++ b/src/test/java/org/firstfolio/curriculum/mapper/ChapterMapperXmlTest.java
@@ -33,6 +33,9 @@ class ChapterMapperXmlTest {
                 SubChapterMapper.class.getName() + ".findByIdForUpdate"
         ));
         assertTrue(configuration.hasStatement(
+                SubChapterMapper.class.getName() + ".findPublicByMainChapterId"
+        ));
+        assertTrue(configuration.hasStatement(
                 SubChapterMapper.class.getName() + ".updateCurrentContentVersion"
         ));
         assertTrue(configuration.hasStatement(

--- a/src/test/java/org/firstfolio/learning/controller/LearningContinueControllerTest.java
+++ b/src/test/java/org/firstfolio/learning/controller/LearningContinueControllerTest.java
@@ -1,0 +1,112 @@
+package org.firstfolio.learning.controller;
+
+import org.firstfolio.auth.domain.AuthenticatedUser;
+import org.firstfolio.auth.web.AuthenticationRequestAttributes;
+import org.firstfolio.auth.web.CurrentUserArgumentResolver;
+import org.firstfolio.common.json.ApiObjectMapperFactory;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.CommonExceptionAdvice;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.learning.domain.LearningContinueResult;
+import org.firstfolio.learning.service.LearningContinueService;
+import org.firstfolio.user.domain.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class LearningContinueControllerTest {
+
+    private static final long USER_ID = 11L;
+
+    private LearningContinueService service;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        service = mock(LearningContinueService.class);
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new LearningContinueController(service))
+                .setCustomArgumentResolvers(new CurrentUserArgumentResolver())
+                .setControllerAdvice(new CommonExceptionAdvice())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(
+                        ApiObjectMapperFactory.create()
+                ))
+                .build();
+    }
+
+    @Test
+    void returnsContinuePositionForCurrentUser() throws Exception {
+        when(service.getContinuePosition(USER_ID)).thenReturn(
+                new LearningContinueResult(
+                        502L,
+                        2L,
+                        101L,
+                        301L,
+                        "page-2",
+                        50,
+                        "/learning/sub-chapters/101?page=page-2"
+                )
+        );
+
+        mockMvc.perform(authenticated(get("/api/learning/continue")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.curriculum_item_id").value(502))
+                .andExpect(jsonPath("$.data.main_chapter_id").value(2))
+                .andExpect(jsonPath("$.data.sub_chapter_id").value(101))
+                .andExpect(jsonPath("$.data.content_version_id").value(301))
+                .andExpect(jsonPath("$.data.last_page_id").value("page-2"))
+                .andExpect(jsonPath("$.data.progress_percent").value(50))
+                .andExpect(jsonPath("$.data.route").value(
+                        "/learning/sub-chapters/101?page=page-2"
+                ));
+
+        verify(service).getContinuePosition(USER_ID);
+    }
+
+    @Test
+    void returnsNotFoundWhenThereIsNoContinuePosition() throws Exception {
+        when(service.getContinuePosition(USER_ID)).thenThrow(
+                new ApiException(ErrorCode.CONTINUE_POSITION_NOT_FOUND)
+        );
+
+        mockMvc.perform(authenticated(get("/api/learning/continue")))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code")
+                        .value("CONTINUE_POSITION_NOT_FOUND"));
+    }
+
+    @Test
+    void rejectsUnauthenticatedRequest() throws Exception {
+        mockMvc.perform(get("/api/learning/continue"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("UNAUTHORIZED"));
+
+        verify(service, never()).getContinuePosition(anyLong());
+    }
+
+    private static MockHttpServletRequestBuilder authenticated(
+            MockHttpServletRequestBuilder builder
+    ) {
+        return builder.requestAttr(
+                AuthenticationRequestAttributes.CURRENT_USER,
+                new AuthenticatedUser(
+                        USER_ID,
+                        "firebase-uid",
+                        "학습자",
+                        UserRole.USER
+                )
+        );
+    }
+}

--- a/src/test/java/org/firstfolio/learning/controller/LearningProgressControllerTest.java
+++ b/src/test/java/org/firstfolio/learning/controller/LearningProgressControllerTest.java
@@ -1,0 +1,188 @@
+package org.firstfolio.learning.controller;
+
+import org.firstfolio.auth.domain.AuthenticatedUser;
+import org.firstfolio.auth.web.AuthenticationRequestAttributes;
+import org.firstfolio.auth.web.CurrentUserArgumentResolver;
+import org.firstfolio.common.json.ApiObjectMapperFactory;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.CommonExceptionAdvice;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.learning.domain.LearningProgress;
+import org.firstfolio.learning.domain.LearningProgressStatus;
+import org.firstfolio.learning.domain.LearningProgressUpdateCommand;
+import org.firstfolio.learning.domain.LearningProgressUpdateResult;
+import org.firstfolio.learning.service.LearningProgressService;
+import org.firstfolio.user.domain.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class LearningProgressControllerTest {
+
+    private static final long USER_ID = 11L;
+    private static final long SUB_CHAPTER_ID = 101L;
+
+    private LearningProgressService service;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        service = mock(LearningProgressService.class);
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new LearningProgressController(service))
+                .setCustomArgumentResolvers(new CurrentUserArgumentResolver())
+                .setControllerAdvice(new CommonExceptionAdvice())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(
+                        ApiObjectMapperFactory.create()
+                ))
+                .build();
+    }
+
+    @Test
+    void putCreatesOrUpdatesLearningProgress() throws Exception {
+        LearningProgress progress = progress(LearningProgressStatus.IN_PROGRESS);
+        when(service.save(eq(USER_ID), eq(SUB_CHAPTER_ID), any()))
+                .thenReturn(new LearningProgressUpdateResult(progress, true));
+
+        mockMvc.perform(authenticated(put(
+                        "/api/learning/sub-chapters/101/progress"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "content_version_id": 301,
+                                  "last_page_id": "page-2",
+                                  "status": "IN_PROGRESS"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.sub_chapter_id").value(101))
+                .andExpect(jsonPath("$.data.content_version_id").value(301))
+                .andExpect(jsonPath("$.data.status").value("IN_PROGRESS"))
+                .andExpect(jsonPath("$.data.started_at")
+                        .value("2026-08-10T01:30:00Z"))
+                .andExpect(jsonPath("$.data.last_page_id").value("page-2"))
+                .andExpect(jsonPath("$.data.updated").value(true));
+
+        ArgumentCaptor<LearningProgressUpdateCommand> captor =
+                ArgumentCaptor.forClass(LearningProgressUpdateCommand.class);
+        verify(service).save(eq(USER_ID), eq(SUB_CHAPTER_ID), captor.capture());
+        assertEquals(301L, captor.getValue().contentVersionId());
+        assertEquals("page-2", captor.getValue().lastPageId());
+        assertEquals(LearningProgressStatus.IN_PROGRESS, captor.getValue().status());
+    }
+
+    @Test
+    void postStartEndpointNoLongerExists() throws Exception {
+        mockMvc.perform(authenticated(post(
+                        "/api/learning/sub-chapters/101/progress")))
+                .andExpect(status().isMethodNotAllowed());
+    }
+
+    @Test
+    void returnsNotStartedStatusWithoutCreatingProgress() throws Exception {
+        LearningProgress progress = progress(LearningProgressStatus.NOT_STARTED);
+        progress.setStartedAt(null);
+        when(service.getStatus(USER_ID, SUB_CHAPTER_ID)).thenReturn(progress);
+
+        mockMvc.perform(authenticated(get(
+                        "/api/learning/sub-chapters/101/progress")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.sub_chapter_id").value(101))
+                .andExpect(jsonPath("$.data.content_version_id").value(301))
+                .andExpect(jsonPath("$.data.status").value("NOT_STARTED"))
+                .andExpect(jsonPath("$.data.started_at").isEmpty())
+                .andExpect(jsonPath("$.data.completed_at").isEmpty());
+
+        verify(service).getStatus(USER_ID, SUB_CHAPTER_ID);
+    }
+
+    @Test
+    void rejectsInvalidPutStatus() throws Exception {
+        mockMvc.perform(authenticated(put(
+                        "/api/learning/sub-chapters/101/progress"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "content_version_id": 301,
+                                  "last_page_id": null,
+                                  "status": "NOT_STARTED"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("INVALID_REQUEST"));
+
+        verify(service, never()).save(anyLong(), anyLong(), any());
+    }
+
+    @Test
+    void rejectsUnauthenticatedRequest() throws Exception {
+        mockMvc.perform(get("/api/learning/sub-chapters/101/progress"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("UNAUTHORIZED"));
+
+        verify(service, never()).getStatus(anyLong(), anyLong());
+    }
+
+    @Test
+    void returnsContentVersionMismatch() throws Exception {
+        when(service.save(eq(USER_ID), eq(SUB_CHAPTER_ID), any()))
+                .thenThrow(new ApiException(ErrorCode.CONTENT_VERSION_MISMATCH));
+
+        mockMvc.perform(authenticated(put(
+                        "/api/learning/sub-chapters/101/progress"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "content_version_id": 999,
+                                  "last_page_id": "page-2",
+                                  "status": "IN_PROGRESS"
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code")
+                        .value("CONTENT_VERSION_MISMATCH"));
+    }
+
+    private static MockHttpServletRequestBuilder authenticated(
+            MockHttpServletRequestBuilder builder
+    ) {
+        return builder.requestAttr(
+                AuthenticationRequestAttributes.CURRENT_USER,
+                new AuthenticatedUser(USER_ID, "firebase-uid", "학습자", UserRole.USER)
+        );
+    }
+
+    private LearningProgress progress(LearningProgressStatus status) {
+        LearningProgress progress = new LearningProgress();
+        progress.setProgressId(901L);
+        progress.setUserId(USER_ID);
+        progress.setSubChapterId(SUB_CHAPTER_ID);
+        progress.setContentVersionId(301L);
+        progress.setLastPageId("page-2");
+        progress.setStatus(status);
+        progress.setStartedAt(LocalDateTime.of(2026, 8, 10, 1, 30));
+        progress.setUpdatedAt(LocalDateTime.of(2026, 8, 10, 1, 30));
+        return progress;
+    }
+}

--- a/src/test/java/org/firstfolio/learning/controller/PublicChapterControllerTest.java
+++ b/src/test/java/org/firstfolio/learning/controller/PublicChapterControllerTest.java
@@ -1,0 +1,137 @@
+package org.firstfolio.learning.controller;
+
+import org.firstfolio.common.json.ApiObjectMapperFactory;
+import org.firstfolio.common.web.RequestIdFilter;
+import org.firstfolio.curriculum.domain.AssetType;
+import org.firstfolio.curriculum.domain.ChapterType;
+import org.firstfolio.curriculum.domain.MainChapter;
+import org.firstfolio.curriculum.domain.PublicSubChapter;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.CommonExceptionAdvice;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.learning.service.PublicChapterQueryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class PublicChapterControllerTest {
+
+    private PublicChapterQueryService service;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        service = mock(PublicChapterQueryService.class);
+        MappingJackson2HttpMessageConverter converter =
+                new MappingJackson2HttpMessageConverter(ApiObjectMapperFactory.create());
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new PublicChapterController(service))
+                .setControllerAdvice(new CommonExceptionAdvice())
+                .setMessageConverters(converter)
+                .addFilter(new RequestIdFilter())
+                .build();
+    }
+
+    @Test
+    void returnsActiveMainChapterMetadataWithoutInternalFields() throws Exception {
+        MainChapter foundation = mainChapter(
+                1L,
+                ChapterType.FOUNDATION,
+                null,
+                "포트폴리오 기초",
+                true
+        );
+        when(service.getMainChapters()).thenReturn(List.of(foundation));
+
+        mockMvc.perform(get("/api/learning/main-chapters"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items[0].main_chapter_id").value(1))
+                .andExpect(jsonPath("$.data.items[0].chapter_type").value("FOUNDATION"))
+                .andExpect(jsonPath("$.data.items[0].asset_type").isEmpty())
+                .andExpect(jsonPath("$.data.items[0].title").value("포트폴리오 기초"))
+                .andExpect(jsonPath("$.data.items[0].display_order").value(1))
+                .andExpect(jsonPath("$.data.items[0].is_required").value(true))
+                .andExpect(jsonPath("$.data.items[0].is_active").doesNotExist())
+                .andExpect(jsonPath("$.data.items[0].created_at").doesNotExist());
+
+        verify(service).getMainChapters();
+    }
+
+    @Test
+    void returnsSubChaptersWithContentAvailabilityWithoutStorageReference()
+            throws Exception {
+        PublicSubChapter published = publicSubChapter(101L, 1, true);
+        PublicSubChapter unpublished = publicSubChapter(102L, 2, false);
+        when(service.getSubChapters(2L))
+                .thenReturn(List.of(published, unpublished));
+
+        mockMvc.perform(get("/api/learning/main-chapters/2/sub-chapters"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items[0].sub_chapter_id").value(101))
+                .andExpect(jsonPath("$.data.items[0].display_order").value(1))
+                .andExpect(jsonPath("$.data.items[0].content_available").value(true))
+                .andExpect(jsonPath("$.data.items[1].sub_chapter_id").value(102))
+                .andExpect(jsonPath("$.data.items[1].content_available").value(false))
+                .andExpect(jsonPath("$.data.items[0].current_content_version_id")
+                        .doesNotExist())
+                .andExpect(jsonPath("$.data.items[0].storage_object_key").doesNotExist())
+                .andExpect(jsonPath("$.data.items[0].storage_version_id").doesNotExist());
+
+        verify(service).getSubChapters(2L);
+    }
+
+    @Test
+    void returnsNotFoundForMissingOrInactiveMainChapter() throws Exception {
+        when(service.getSubChapters(2L))
+                .thenThrow(new ApiException(ErrorCode.MAIN_CHAPTER_NOT_FOUND));
+
+        mockMvc.perform(get("/api/learning/main-chapters/2/sub-chapters"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("MAIN_CHAPTER_NOT_FOUND"));
+    }
+
+    private MainChapter mainChapter(
+            long id,
+            ChapterType chapterType,
+            AssetType assetType,
+            String title,
+            boolean required
+    ) {
+        MainChapter chapter = new MainChapter();
+        chapter.setMainChapterId(id);
+        chapter.setChapterType(chapterType);
+        chapter.setAssetType(assetType);
+        chapter.setTitle(title);
+        chapter.setDescription("설명");
+        chapter.setDisplayOrder((int) id);
+        chapter.setRequired(required);
+        chapter.setActive(true);
+        return chapter;
+    }
+
+    private PublicSubChapter publicSubChapter(
+            long id,
+            int displayOrder,
+            boolean contentAvailable
+    ) {
+        PublicSubChapter chapter = new PublicSubChapter();
+        chapter.setSubChapterId(id);
+        chapter.setMainChapterId(2L);
+        chapter.setTitle("소단원 " + id);
+        chapter.setDescription("설명");
+        chapter.setDisplayOrder(displayOrder);
+        chapter.setContentAvailable(contentAvailable);
+        return chapter;
+    }
+}

--- a/src/test/java/org/firstfolio/learning/mapper/LearningContinueMapperXmlTest.java
+++ b/src/test/java/org/firstfolio/learning/mapper/LearningContinueMapperXmlTest.java
@@ -1,0 +1,46 @@
+package org.firstfolio.learning.mapper;
+
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.mapping.BoundSql;
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LearningContinueMapperXmlTest {
+
+    private static final String RESOURCE =
+            "mappers/learning/LearningContinueMapper.xml";
+
+    @Test
+    void parsesLatestInProgressQuery() throws Exception {
+        Configuration configuration = new Configuration();
+        try (InputStream input = Resources.getResourceAsStream(RESOURCE)) {
+            new XMLMapperBuilder(
+                    input,
+                    configuration,
+                    RESOURCE,
+                    configuration.getSqlFragments()
+            ).parse();
+        }
+
+        String statement = LearningContinueMapper.class.getName()
+                + ".findLatestInProgress";
+        assertTrue(configuration.hasMapper(LearningContinueMapper.class));
+        assertTrue(configuration.hasStatement(statement));
+
+        BoundSql boundSql = configuration.getMappedStatement(statement)
+                .getBoundSql(Map.of("userId", 11L));
+        String sql = boundSql.getSql().replaceAll("\\s+", " ").trim();
+        assertTrue(sql.contains("progress.status = 'IN_PROGRESS'"));
+        assertTrue(sql.contains("curriculum.status = 'ACTIVE'"));
+        assertTrue(sql.contains("curriculum.completed_at IS NULL"));
+        assertTrue(sql.endsWith(
+                "ORDER BY progress.updated_at DESC, progress.progress_id DESC LIMIT 1"
+        ));
+    }
+}

--- a/src/test/java/org/firstfolio/learning/mapper/LearningProgressMapperXmlTest.java
+++ b/src/test/java/org/firstfolio/learning/mapper/LearningProgressMapperXmlTest.java
@@ -1,0 +1,47 @@
+package org.firstfolio.learning.mapper;
+
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LearningProgressMapperXmlTest {
+
+    @Test
+    void parsesMapperAndRegistersProgressStatements() throws Exception {
+        Configuration configuration = new Configuration();
+        String resource = "mappers/learning/LearningProgressMapper.xml";
+
+        try (InputStream input = Resources.getResourceAsStream(resource)) {
+            new XMLMapperBuilder(
+                    input,
+                    configuration,
+                    resource,
+                    configuration.getSqlFragments()
+            ).parse();
+        }
+
+        assertTrue(configuration.hasMapper(LearningProgressMapper.class));
+        assertTrue(configuration.hasStatement(
+                LearningProgressMapper.class.getName()
+                        + ".findByUserIdAndSubChapterId"
+        ));
+        assertTrue(configuration.hasStatement(
+                LearningProgressMapper.class.getName() + ".insertIfAbsent"
+        ));
+        assertTrue(configuration.hasStatement(
+                LearningProgressMapper.class.getName()
+                        + ".findByUserIdAndSubChapterIdForUpdate"
+        ));
+        assertTrue(configuration.hasStatement(
+                LearningProgressMapper.class.getName() + ".updateProgress"
+        ));
+        assertTrue(configuration.hasStatement(
+                LearningProgressMapper.class.getName() + ".insertEvent"
+        ));
+    }
+}

--- a/src/test/java/org/firstfolio/learning/mapper/MainChapterLearningMapperXmlTest.java
+++ b/src/test/java/org/firstfolio/learning/mapper/MainChapterLearningMapperXmlTest.java
@@ -1,0 +1,81 @@
+package org.firstfolio.learning.mapper;
+
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.mapping.BoundSql;
+import org.apache.ibatis.session.Configuration;
+import org.firstfolio.learning.domain.UserCurriculumItem;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MainChapterLearningMapperXmlTest {
+
+    private static final String RESOURCE =
+            "mappers/learning/MainChapterLearningMapper.xml";
+
+    @Test
+    void parsesEligibilityAndCompletionStatements() throws IOException {
+        Configuration configuration = new Configuration();
+        try (InputStream input = Resources.getResourceAsStream(RESOURCE)) {
+            new XMLMapperBuilder(
+                    input,
+                    configuration,
+                    RESOURCE,
+                    configuration.getSqlFragments()
+            ).parse();
+        }
+
+        assertTrue(configuration.hasMapper(MainChapterLearningMapper.class));
+        assertTrue(configuration.hasStatement(id(
+                "findActiveCurriculumItemForUpdate"
+        )));
+        assertTrue(configuration.hasStatement(id("countActiveSubChapters")));
+        assertTrue(configuration.hasStatement(id(
+                "countIncompleteActiveSubChapters"
+        )));
+        assertTrue(configuration.hasStatement(id(
+                "completeCurriculumItemIfIncomplete"
+        )));
+
+        BoundSql lockSql = configuration.getMappedStatement(id(
+                        "findActiveCurriculumItemForUpdate"
+                ))
+                .getBoundSql(Map.of("userId", 11L, "mainChapterId", 10L));
+        assertTrue(normalize(lockSql.getSql()).contains(
+                "AND status = 'ACTIVE' FOR UPDATE"
+        ));
+
+        BoundSql incompleteSql = configuration.getMappedStatement(id(
+                        "countIncompleteActiveSubChapters"
+                ))
+                .getBoundSql(Map.of("userId", 11L, "mainChapterId", 10L));
+        assertTrue(normalize(incompleteSql.getSql()).contains(
+                "progress.status = 'COMPLETED'"
+        ));
+
+        BoundSql completeSql = configuration.getMappedStatement(id(
+                        "completeCurriculumItemIfIncomplete"
+                ))
+                .getBoundSql(Map.of(
+                        "curriculumItemId", 100L,
+                        "completedAt", LocalDateTime.now()
+                ));
+        assertTrue(normalize(completeSql.getSql()).contains(
+                "AND status = 'ACTIVE' AND completed_at IS NULL"
+        ));
+    }
+
+    private String id(String statement) {
+        return MainChapterLearningMapper.class.getName() + "." + statement;
+    }
+
+    private String normalize(String sql) {
+        return sql.replaceAll("\\s+", " ").trim();
+    }
+}

--- a/src/test/java/org/firstfolio/learning/service/LearningContinueServiceTest.java
+++ b/src/test/java/org/firstfolio/learning/service/LearningContinueServiceTest.java
@@ -1,0 +1,208 @@
+package org.firstfolio.learning.service;
+
+import org.firstfolio.content.domain.ContentVersion;
+import org.firstfolio.content.domain.ContentVersionStatus;
+import org.firstfolio.content.domain.StoredContent;
+import org.firstfolio.content.domain.StoredObjectRef;
+import org.firstfolio.content.exception.ContentStorageError;
+import org.firstfolio.content.exception.ContentStorageException;
+import org.firstfolio.content.mapper.ContentVersionMapper;
+import org.firstfolio.content.service.StaticContentStorage;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.learning.domain.LearningContinueCandidate;
+import org.firstfolio.learning.domain.LearningContinueResult;
+import org.firstfolio.learning.mapper.LearningContinueMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class LearningContinueServiceTest {
+
+    private static final long USER_ID = 11L;
+    private static final long CONTENT_VERSION_ID = 301L;
+    private static final StoredObjectRef STORED_OBJECT = new StoredObjectRef(
+            "learning/sub-chapters/101/lesson.json",
+            "storage-version-1"
+    );
+
+    private LearningContinueMapper learningContinueMapper;
+    private ContentVersionMapper contentVersionMapper;
+    private StaticContentStorage contentStorage;
+    private LearningContinueService service;
+
+    @BeforeEach
+    void setUp() {
+        learningContinueMapper = mock(LearningContinueMapper.class);
+        contentVersionMapper = mock(ContentVersionMapper.class);
+        contentStorage = mock(StaticContentStorage.class);
+        service = new LearningContinueService(
+                learningContinueMapper,
+                contentVersionMapper,
+                contentStorage
+        );
+    }
+
+    @Test
+    void returnsLatestPageAndCalculatedLessonProgress() {
+        when(learningContinueMapper.findLatestInProgress(USER_ID))
+                .thenReturn(candidate("page-2"));
+        when(contentVersionMapper.findById(CONTENT_VERSION_ID))
+                .thenReturn(publishedVersion());
+        when(contentStorage.load(STORED_OBJECT)).thenReturn(lesson(
+                "page-1", "page-2", "page-3", "page-4"
+        ));
+
+        LearningContinueResult result = service.getContinuePosition(USER_ID);
+
+        assertEquals(502L, result.curriculumItemId());
+        assertEquals(2L, result.mainChapterId());
+        assertEquals(101L, result.subChapterId());
+        assertEquals(CONTENT_VERSION_ID, result.contentVersionId());
+        assertEquals("page-2", result.lastPageId());
+        assertEquals(50, result.progressPercent());
+        assertEquals(
+                "/learning/sub-chapters/101?page=page-2",
+                result.route()
+        );
+    }
+
+    @Test
+    void returnsLessonStartWhenNoPageWasSaved() {
+        when(learningContinueMapper.findLatestInProgress(USER_ID))
+                .thenReturn(candidate(null));
+        when(contentVersionMapper.findById(CONTENT_VERSION_ID))
+                .thenReturn(publishedVersion());
+        when(contentStorage.load(STORED_OBJECT)).thenReturn(lesson(
+                "page-1", "page-2"
+        ));
+
+        LearningContinueResult result = service.getContinuePosition(USER_ID);
+
+        assertNull(result.lastPageId());
+        assertEquals(0, result.progressPercent());
+        assertEquals("/learning/sub-chapters/101", result.route());
+    }
+
+    @Test
+    void returnsNotFoundWhenThereIsNoInProgressPosition() {
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.getContinuePosition(USER_ID)
+        );
+
+        assertEquals(
+                ErrorCode.CONTINUE_POSITION_NOT_FOUND,
+                exception.getErrorCode()
+        );
+        verify(contentVersionMapper, never()).findById(CONTENT_VERSION_ID);
+    }
+
+    @Test
+    void rejectsInactiveOrChangedContentBeforeStorageLookup() {
+        LearningContinueCandidate inactive = candidate("page-1");
+        inactive.setSubChapterActive(false);
+        when(learningContinueMapper.findLatestInProgress(USER_ID))
+                .thenReturn(inactive);
+
+        ApiException inactiveException = assertThrows(
+                ApiException.class,
+                () -> service.getContinuePosition(USER_ID)
+        );
+        assertEquals(ErrorCode.CONTENT_UNAVAILABLE,
+                inactiveException.getErrorCode());
+
+        LearningContinueCandidate changed = candidate("page-1");
+        changed.setCurrentContentVersionId(302L);
+        when(learningContinueMapper.findLatestInProgress(USER_ID))
+                .thenReturn(changed);
+        ApiException changedException = assertThrows(
+                ApiException.class,
+                () -> service.getContinuePosition(USER_ID)
+        );
+        assertEquals(ErrorCode.CONTENT_UNAVAILABLE,
+                changedException.getErrorCode());
+        verify(contentStorage, never()).load(STORED_OBJECT);
+    }
+
+    @Test
+    void rejectsMissingPageAndStorageFailure() {
+        when(learningContinueMapper.findLatestInProgress(USER_ID))
+                .thenReturn(candidate("removed-page"));
+        when(contentVersionMapper.findById(CONTENT_VERSION_ID))
+                .thenReturn(publishedVersion());
+        when(contentStorage.load(STORED_OBJECT))
+                .thenReturn(lesson("page-1"));
+
+        ApiException missingPage = assertThrows(
+                ApiException.class,
+                () -> service.getContinuePosition(USER_ID)
+        );
+        assertEquals(ErrorCode.CONTENT_UNAVAILABLE,
+                missingPage.getErrorCode());
+
+        when(contentStorage.load(STORED_OBJECT)).thenThrow(
+                new ContentStorageException(
+                        ContentStorageError.OBJECT_NOT_FOUND,
+                        "missing"
+                )
+        );
+        ApiException storageFailure = assertThrows(
+                ApiException.class,
+                () -> service.getContinuePosition(USER_ID)
+        );
+        assertEquals(ErrorCode.CONTENT_UNAVAILABLE,
+                storageFailure.getErrorCode());
+    }
+
+    private LearningContinueCandidate candidate(String lastPageId) {
+        LearningContinueCandidate candidate = new LearningContinueCandidate();
+        candidate.setCurriculumItemId(502L);
+        candidate.setMainChapterId(2L);
+        candidate.setMainChapterActive(true);
+        candidate.setSubChapterId(101L);
+        candidate.setSubChapterActive(true);
+        candidate.setCurrentContentVersionId(CONTENT_VERSION_ID);
+        candidate.setContentVersionId(CONTENT_VERSION_ID);
+        candidate.setLastPageId(lastPageId);
+        return candidate;
+    }
+
+    private ContentVersion publishedVersion() {
+        ContentVersion version = new ContentVersion();
+        version.setContentVersionId(CONTENT_VERSION_ID);
+        version.setSubChapterId(101L);
+        version.setSchemaVersion("1.0");
+        version.setStorageObjectKey(STORED_OBJECT.objectKey());
+        version.setStorageVersionId(STORED_OBJECT.versionId());
+        version.setStatus(ContentVersionStatus.PUBLISHED);
+        return version;
+    }
+
+    private StoredContent lesson(String... pageIds) {
+        StringBuilder pages = new StringBuilder();
+        for (int index = 0; index < pageIds.length; index++) {
+            if (index > 0) {
+                pages.append(',');
+            }
+            pages.append("{\"id\":\"")
+                    .append(pageIds[index])
+                    .append("\"}");
+        }
+        String json = "{\"schemaVersion\":\"1.0\",\"pages\":["
+                + pages + "]}";
+        return new StoredContent(
+                json.getBytes(StandardCharsets.UTF_8),
+                "application/json"
+        );
+    }
+}

--- a/src/test/java/org/firstfolio/learning/service/LearningProgressServiceTest.java
+++ b/src/test/java/org/firstfolio/learning/service/LearningProgressServiceTest.java
@@ -1,0 +1,395 @@
+package org.firstfolio.learning.service;
+
+import org.firstfolio.content.domain.ContentVersion;
+import org.firstfolio.content.domain.PublishedLessonReference;
+import org.firstfolio.content.domain.StoredContent;
+import org.firstfolio.content.domain.StoredObjectRef;
+import org.firstfolio.content.mapper.ContentVersionMapper;
+import org.firstfolio.content.service.StaticContentStorage;
+import org.firstfolio.curriculum.domain.SubChapter;
+import org.firstfolio.curriculum.mapper.SubChapterMapper;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.learning.domain.LearningProgress;
+import org.firstfolio.learning.domain.LearningProgressEvent;
+import org.firstfolio.learning.domain.LearningProgressStatus;
+import org.firstfolio.learning.domain.LearningProgressUpdateCommand;
+import org.firstfolio.learning.domain.LearningProgressUpdateResult;
+import org.firstfolio.learning.mapper.LearningProgressMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class LearningProgressServiceTest {
+
+    private static final long USER_ID = 11L;
+    private static final long SUB_CHAPTER_ID = 101L;
+    private static final long CONTENT_VERSION_ID = 301L;
+    private static final Instant NOW = Instant.parse("2026-08-10T01:30:00Z");
+    private static final StoredObjectRef STORED_OBJECT = new StoredObjectRef(
+            "learning/sub-chapters/101/lesson.json",
+            "storage-version-1"
+    );
+
+    private LearningProgressMapper learningProgressMapper;
+    private ContentVersionMapper contentVersionMapper;
+    private SubChapterMapper subChapterMapper;
+    private StaticContentStorage contentStorage;
+    private LearningProgressService service;
+
+    @BeforeEach
+    void setUp() {
+        learningProgressMapper = mock(LearningProgressMapper.class);
+        contentVersionMapper = mock(ContentVersionMapper.class);
+        subChapterMapper = mock(SubChapterMapper.class);
+        contentStorage = mock(StaticContentStorage.class);
+        service = new LearningProgressService(
+                learningProgressMapper,
+                contentVersionMapper,
+                subChapterMapper,
+                contentStorage,
+                Clock.fixed(NOW, ZoneOffset.UTC)
+        );
+        when(subChapterMapper.findById(SUB_CHAPTER_ID))
+                .thenReturn(activeSubChapter());
+    }
+
+    @Test
+    void firstPutCreatesProgressForCurrentPublishedVersion() {
+        LearningProgress stored = progress(LearningProgressStatus.IN_PROGRESS, "page-1");
+        when(learningProgressMapper.findByUserIdAndSubChapterIdForUpdate(
+                USER_ID, SUB_CHAPTER_ID
+        )).thenReturn(null, stored);
+        when(contentVersionMapper.findCurrentPublishedLesson(SUB_CHAPTER_ID))
+                .thenReturn(publishedLesson());
+        stubValidPage("page-1");
+        when(learningProgressMapper.insertIfAbsent(any())).thenReturn(1);
+        when(learningProgressMapper.insertEvent(any())).thenReturn(1);
+
+        LearningProgressUpdateResult result = service.save(
+                USER_ID,
+                SUB_CHAPTER_ID,
+                command("page-1", LearningProgressStatus.IN_PROGRESS)
+        );
+
+        assertTrue(result.updated());
+        assertEquals(stored, result.progress());
+
+        ArgumentCaptor<LearningProgress> progressCaptor =
+                ArgumentCaptor.forClass(LearningProgress.class);
+        verify(learningProgressMapper).insertIfAbsent(progressCaptor.capture());
+        LearningProgress inserted = progressCaptor.getValue();
+        assertEquals(CONTENT_VERSION_ID, inserted.getContentVersionId());
+        assertEquals("page-1", inserted.getLastPageId());
+        assertEquals(LearningProgressStatus.IN_PROGRESS, inserted.getStatus());
+        assertEquals(LocalDateTime.of(2026, 8, 10, 1, 30), inserted.getStartedAt());
+
+        ArgumentCaptor<LearningProgressEvent> eventCaptor =
+                ArgumentCaptor.forClass(LearningProgressEvent.class);
+        verify(learningProgressMapper).insertEvent(eventCaptor.capture());
+        assertEquals(LearningProgressStatus.NOT_STARTED,
+                eventCaptor.getValue().getPreviousStatus());
+        assertEquals("PROGRESS_UPDATED", eventCaptor.getValue().getEventType());
+    }
+
+    @Test
+    void existingPutUpdatesPageAndWritesHistory() {
+        LearningProgress existing = progress(
+                LearningProgressStatus.IN_PROGRESS,
+                "page-1"
+        );
+        when(learningProgressMapper.findByUserIdAndSubChapterIdForUpdate(
+                USER_ID, SUB_CHAPTER_ID
+        )).thenReturn(existing);
+        stubValidPage("page-2");
+        when(learningProgressMapper.updateProgress(existing)).thenReturn(1);
+        when(learningProgressMapper.insertEvent(any())).thenReturn(1);
+
+        LearningProgressUpdateResult result = service.save(
+                USER_ID,
+                SUB_CHAPTER_ID,
+                command("page-2", LearningProgressStatus.IN_PROGRESS)
+        );
+
+        assertTrue(result.updated());
+        assertEquals("page-2", result.progress().getLastPageId());
+        assertEquals(LocalDateTime.of(2026, 8, 10, 1, 30),
+                result.progress().getUpdatedAt());
+        verify(learningProgressMapper).updateProgress(existing);
+
+        ArgumentCaptor<LearningProgressEvent> eventCaptor =
+                ArgumentCaptor.forClass(LearningProgressEvent.class);
+        verify(learningProgressMapper).insertEvent(eventCaptor.capture());
+        assertEquals("page-1", eventCaptor.getValue().getPreviousPageId());
+        assertEquals("page-2", eventCaptor.getValue().getLastPageId());
+    }
+
+    @Test
+    void completionIsRecordedOnceAndLaterRequestsDoNotChangeIt() {
+        LearningProgress existing = progress(
+                LearningProgressStatus.IN_PROGRESS,
+                "page-2"
+        );
+        when(learningProgressMapper.findByUserIdAndSubChapterIdForUpdate(
+                USER_ID, SUB_CHAPTER_ID
+        )).thenReturn(existing);
+        stubValidPage("page-3");
+        when(learningProgressMapper.updateProgress(existing)).thenReturn(1);
+        when(learningProgressMapper.insertEvent(any())).thenReturn(1);
+
+        LearningProgressUpdateResult completed = service.save(
+                USER_ID,
+                SUB_CHAPTER_ID,
+                command("page-3", LearningProgressStatus.COMPLETED)
+        );
+
+        assertTrue(completed.updated());
+        assertEquals(LearningProgressStatus.COMPLETED,
+                completed.progress().getStatus());
+        assertEquals(LocalDateTime.of(2026, 8, 10, 1, 30),
+                completed.progress().getCompletedAt());
+
+        ArgumentCaptor<LearningProgressEvent> eventCaptor =
+                ArgumentCaptor.forClass(LearningProgressEvent.class);
+        verify(learningProgressMapper).insertEvent(eventCaptor.capture());
+        assertEquals("COMPLETED", eventCaptor.getValue().getEventType());
+
+        LearningProgress alreadyCompleted = progress(
+                LearningProgressStatus.COMPLETED,
+                "page-3"
+        );
+        alreadyCompleted.setCompletedAt(LocalDateTime.of(2026, 8, 9, 4, 0));
+        when(learningProgressMapper.findByUserIdAndSubChapterIdForUpdate(
+                USER_ID, SUB_CHAPTER_ID
+        )).thenReturn(alreadyCompleted);
+
+        LearningProgressUpdateResult replay = service.save(
+                USER_ID,
+                SUB_CHAPTER_ID,
+                command("page-3", LearningProgressStatus.COMPLETED)
+        );
+
+        assertFalse(replay.updated());
+        assertEquals(LocalDateTime.of(2026, 8, 9, 4, 0),
+                replay.progress().getCompletedAt());
+    }
+
+    @Test
+    void identicalInProgressPutIsIdempotent() {
+        LearningProgress existing = progress(
+                LearningProgressStatus.IN_PROGRESS,
+                "page-2"
+        );
+        when(learningProgressMapper.findByUserIdAndSubChapterIdForUpdate(
+                USER_ID, SUB_CHAPTER_ID
+        )).thenReturn(existing);
+        stubValidPage("page-2");
+
+        LearningProgressUpdateResult result = service.save(
+                USER_ID,
+                SUB_CHAPTER_ID,
+                command("page-2", LearningProgressStatus.IN_PROGRESS)
+        );
+
+        assertFalse(result.updated());
+        verify(learningProgressMapper, never()).updateProgress(any());
+        verify(learningProgressMapper, never()).insertEvent(any());
+    }
+
+    @Test
+    void lateRequestCannotMoveProgressBackToAnEarlierPage() {
+        LearningProgress existing = progress(
+                LearningProgressStatus.IN_PROGRESS,
+                "page-3"
+        );
+        when(learningProgressMapper.findByUserIdAndSubChapterIdForUpdate(
+                USER_ID, SUB_CHAPTER_ID
+        )).thenReturn(existing);
+        stubValidPage("page-1");
+
+        LearningProgressUpdateResult result = service.save(
+                USER_ID,
+                SUB_CHAPTER_ID,
+                command("page-1", LearningProgressStatus.IN_PROGRESS)
+        );
+
+        assertFalse(result.updated());
+        assertEquals("page-3", result.progress().getLastPageId());
+        verify(learningProgressMapper, never()).updateProgress(any());
+        verify(learningProgressMapper, never()).insertEvent(any());
+    }
+
+    @Test
+    void omittedPageKeepsCurrentPositionWhileCompleting() {
+        LearningProgress existing = progress(
+                LearningProgressStatus.IN_PROGRESS,
+                "page-3"
+        );
+        when(learningProgressMapper.findByUserIdAndSubChapterIdForUpdate(
+                USER_ID, SUB_CHAPTER_ID
+        )).thenReturn(existing);
+        stubValidPage("page-3");
+        when(learningProgressMapper.updateProgress(existing)).thenReturn(1);
+        when(learningProgressMapper.insertEvent(any())).thenReturn(1);
+
+        LearningProgressUpdateResult result = service.save(
+                USER_ID,
+                SUB_CHAPTER_ID,
+                command(null, LearningProgressStatus.COMPLETED)
+        );
+
+        assertTrue(result.updated());
+        assertEquals("page-3", result.progress().getLastPageId());
+        assertEquals(LearningProgressStatus.COMPLETED,
+                result.progress().getStatus());
+    }
+
+    @Test
+    void rejectsWrongContentVersionOrPageId() {
+        LearningProgress existing = progress(
+                LearningProgressStatus.IN_PROGRESS,
+                "page-1"
+        );
+        when(learningProgressMapper.findByUserIdAndSubChapterIdForUpdate(
+                USER_ID, SUB_CHAPTER_ID
+        )).thenReturn(existing);
+
+        ApiException mismatch = assertThrows(
+                ApiException.class,
+                () -> service.save(USER_ID, SUB_CHAPTER_ID,
+                        new LearningProgressUpdateCommand(
+                                999L,
+                                "page-1",
+                                LearningProgressStatus.IN_PROGRESS
+                        ))
+        );
+        assertEquals(ErrorCode.CONTENT_VERSION_MISMATCH, mismatch.getErrorCode());
+
+        stubValidPage("page-1");
+        ApiException invalidPage = assertThrows(
+                ApiException.class,
+                () -> service.save(
+                        USER_ID,
+                        SUB_CHAPTER_ID,
+                        command("unknown", LearningProgressStatus.IN_PROGRESS)
+                )
+        );
+        assertEquals(ErrorCode.INVALID_PAGE_ID, invalidPage.getErrorCode());
+    }
+
+    @Test
+    void returnsNotStartedWithoutWritingWhenNoProgressExists() {
+        when(learningProgressMapper.findByUserIdAndSubChapterId(
+                USER_ID, SUB_CHAPTER_ID
+        )).thenReturn(null);
+        when(contentVersionMapper.findCurrentPublishedLesson(SUB_CHAPTER_ID))
+                .thenReturn(publishedLesson());
+
+        LearningProgress result = service.getStatus(USER_ID, SUB_CHAPTER_ID);
+
+        assertEquals(LearningProgressStatus.NOT_STARTED, result.getStatus());
+        assertEquals(CONTENT_VERSION_ID, result.getContentVersionId());
+        assertNull(result.getStartedAt());
+        verify(learningProgressMapper, never()).insertIfAbsent(any());
+    }
+
+    @Test
+    void firstPutRejectsUnpublishedContent() {
+        when(learningProgressMapper.findByUserIdAndSubChapterIdForUpdate(
+                USER_ID, SUB_CHAPTER_ID
+        )).thenReturn(null);
+        when(contentVersionMapper.findCurrentPublishedLesson(SUB_CHAPTER_ID))
+                .thenReturn(null);
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.save(
+                        USER_ID,
+                        SUB_CHAPTER_ID,
+                        command(null, LearningProgressStatus.IN_PROGRESS)
+                )
+        );
+
+        assertEquals(ErrorCode.CONTENT_NOT_PUBLISHED, exception.getErrorCode());
+    }
+
+    private void stubValidPage(String pageId) {
+        when(contentVersionMapper.findById(CONTENT_VERSION_ID))
+                .thenReturn(contentVersion());
+        when(contentStorage.load(STORED_OBJECT)).thenReturn(new StoredContent(
+                ("{\"schemaVersion\":\"1.0\",\"pages\":["
+                        + "{\"id\":\"page-1\"},{\"id\":\"page-2\"},"
+                        + "{\"id\":\"page-3\"}]}")
+                        .getBytes(StandardCharsets.UTF_8),
+                "application/json"
+        ));
+    }
+
+    private PublishedLessonReference publishedLesson() {
+        PublishedLessonReference reference = new PublishedLessonReference();
+        reference.setSubChapterId(SUB_CHAPTER_ID);
+        reference.setContentVersionId(CONTENT_VERSION_ID);
+        return reference;
+    }
+
+    private ContentVersion contentVersion() {
+        ContentVersion version = new ContentVersion();
+        version.setContentVersionId(CONTENT_VERSION_ID);
+        version.setSubChapterId(SUB_CHAPTER_ID);
+        version.setSchemaVersion("1.0");
+        version.setStorageObjectKey(STORED_OBJECT.objectKey());
+        version.setStorageVersionId(STORED_OBJECT.versionId());
+        return version;
+    }
+
+    private SubChapter activeSubChapter() {
+        SubChapter subChapter = new SubChapter();
+        subChapter.setSubChapterId(SUB_CHAPTER_ID);
+        subChapter.setActive(true);
+        return subChapter;
+    }
+
+    private LearningProgressUpdateCommand command(
+            String pageId,
+            LearningProgressStatus status
+    ) {
+        return new LearningProgressUpdateCommand(
+                CONTENT_VERSION_ID,
+                pageId,
+                status
+        );
+    }
+
+    private LearningProgress progress(
+            LearningProgressStatus status,
+            String pageId
+    ) {
+        LearningProgress progress = new LearningProgress();
+        progress.setProgressId(901L);
+        progress.setUserId(USER_ID);
+        progress.setSubChapterId(SUB_CHAPTER_ID);
+        progress.setContentVersionId(CONTENT_VERSION_ID);
+        progress.setLastPageId(pageId);
+        progress.setStatus(status);
+        progress.setStartedAt(LocalDateTime.of(2026, 8, 9, 3, 0));
+        progress.setUpdatedAt(LocalDateTime.of(2026, 8, 9, 3, 10));
+        return progress;
+    }
+}

--- a/src/test/java/org/firstfolio/learning/service/MainChapterCompletionServiceTest.java
+++ b/src/test/java/org/firstfolio/learning/service/MainChapterCompletionServiceTest.java
@@ -1,0 +1,134 @@
+package org.firstfolio.learning.service;
+
+import org.firstfolio.curriculum.domain.ChapterType;
+import org.firstfolio.curriculum.domain.MainChapter;
+import org.firstfolio.curriculum.mapper.MainChapterMapper;
+import org.firstfolio.learning.domain.MainChapterCompletionResult;
+import org.firstfolio.learning.domain.UserCurriculumItem;
+import org.firstfolio.learning.mapper.MainChapterLearningMapper;
+import org.firstfolio.portfolio.service.InitialGrantResult;
+import org.firstfolio.portfolio.service.InitialGrantService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class MainChapterCompletionServiceTest {
+
+    private static final long USER_ID = 11L;
+    private static final long MAIN_CHAPTER_ID = 10L;
+    private static final long CURRICULUM_ITEM_ID = 100L;
+    private static final LocalDateTime COMPLETED_AT =
+            LocalDateTime.of(2026, 8, 11, 2, 30);
+
+    private MainChapterLearningMapper learningMapper;
+    private MainChapterMapper mainChapterMapper;
+    private InitialGrantService initialGrantService;
+    private MainChapterCompletionService service;
+
+    @BeforeEach
+    void setUp() {
+        learningMapper = mock(MainChapterLearningMapper.class);
+        mainChapterMapper = mock(MainChapterMapper.class);
+        initialGrantService = mock(InitialGrantService.class);
+        service = new MainChapterCompletionService(
+                learningMapper,
+                mainChapterMapper,
+                initialGrantService
+        );
+    }
+
+    @Test
+    void completesAssetChapterWithoutPassingScoreOrFoundationGrant() {
+        arrange(null, ChapterType.ASSET);
+        when(learningMapper.completeCurriculumItemIfIncomplete(
+                CURRICULUM_ITEM_ID,
+                COMPLETED_AT
+        )).thenReturn(1);
+
+        MainChapterCompletionResult result = service.complete(
+                USER_ID,
+                MAIN_CHAPTER_ID,
+                COMPLETED_AT
+        );
+
+        assertTrue(result.completedNow());
+        assertEquals(ChapterType.ASSET, result.chapterType());
+        assertNull(result.foundationGrant());
+        verify(initialGrantService, never())
+                .grantOnFoundationCompleted(USER_ID, CURRICULUM_ITEM_ID);
+    }
+
+    @Test
+    void preservesFirstCompletionOnReattempt() {
+        arrange(COMPLETED_AT.minusDays(1), ChapterType.ASSET);
+
+        MainChapterCompletionResult result = service.complete(
+                USER_ID,
+                MAIN_CHAPTER_ID,
+                COMPLETED_AT
+        );
+
+        assertFalse(result.completedNow());
+        verify(learningMapper, never()).completeCurriculumItemIfIncomplete(
+                CURRICULUM_ITEM_ID,
+                COMPLETED_AT
+        );
+    }
+
+    @Test
+    void grantsInitialSimulationMoneyForFoundationChapter() {
+        arrange(null, ChapterType.FOUNDATION);
+        when(learningMapper.completeCurriculumItemIfIncomplete(
+                CURRICULUM_ITEM_ID,
+                COMPLETED_AT
+        )).thenReturn(1);
+        InitialGrantResult grant = new InitialGrantResult(
+                true,
+                new BigDecimal("30000000.00"),
+                501L
+        );
+        when(initialGrantService.grantOnFoundationCompleted(
+                USER_ID,
+                CURRICULUM_ITEM_ID
+        )).thenReturn(grant);
+
+        MainChapterCompletionResult result = service.complete(
+                USER_ID,
+                MAIN_CHAPTER_ID,
+                COMPLETED_AT
+        );
+
+        assertTrue(result.completedNow());
+        assertEquals(grant, result.foundationGrant());
+    }
+
+    private void arrange(LocalDateTime completedAt, ChapterType type) {
+        UserCurriculumItem item = new UserCurriculumItem();
+        item.setCurriculumItemId(CURRICULUM_ITEM_ID);
+        item.setUserId(USER_ID);
+        item.setMainChapterId(MAIN_CHAPTER_ID);
+        item.setStatus("ACTIVE");
+        item.setCompletedAt(completedAt);
+        when(learningMapper.findActiveCurriculumItemForUpdate(
+                USER_ID,
+                MAIN_CHAPTER_ID
+        )).thenReturn(item);
+
+        MainChapter chapter = new MainChapter();
+        chapter.setMainChapterId(MAIN_CHAPTER_ID);
+        chapter.setChapterType(type);
+        chapter.setActive(true);
+        when(mainChapterMapper.findById(MAIN_CHAPTER_ID)).thenReturn(chapter);
+    }
+}

--- a/src/test/java/org/firstfolio/learning/service/PublicChapterQueryServiceTest.java
+++ b/src/test/java/org/firstfolio/learning/service/PublicChapterQueryServiceTest.java
@@ -1,0 +1,129 @@
+package org.firstfolio.learning.service;
+
+import org.firstfolio.curriculum.domain.AssetType;
+import org.firstfolio.curriculum.domain.ChapterType;
+import org.firstfolio.curriculum.domain.MainChapter;
+import org.firstfolio.curriculum.domain.PublicSubChapter;
+import org.firstfolio.curriculum.mapper.MainChapterMapper;
+import org.firstfolio.curriculum.mapper.SubChapterMapper;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PublicChapterQueryServiceTest {
+
+    private MainChapterMapper mainChapterMapper;
+    private SubChapterMapper subChapterMapper;
+    private PublicChapterQueryService service;
+
+    @BeforeEach
+    void setUp() {
+        mainChapterMapper = mock(MainChapterMapper.class);
+        subChapterMapper = mock(SubChapterMapper.class);
+        service = new PublicChapterQueryService(mainChapterMapper, subChapterMapper);
+    }
+
+    @Test
+    void returnsOnlyActiveMainChaptersInMapperOrder() {
+        MainChapter foundation = mainChapter(1L, ChapterType.FOUNDATION, null, true);
+        MainChapter deposit = mainChapter(
+                2L,
+                ChapterType.ASSET,
+                AssetType.DEPOSIT_SAVINGS,
+                true
+        );
+        when(mainChapterMapper.findAll(null, true))
+                .thenReturn(List.of(foundation, deposit));
+
+        List<MainChapter> result = service.getMainChapters();
+
+        assertEquals(List.of(foundation, deposit), result);
+        verify(mainChapterMapper).findAll(null, true);
+    }
+
+    @Test
+    void returnsActiveSubChaptersWithPublishedContentAvailability() {
+        MainChapter mainChapter = mainChapter(
+                2L,
+                ChapterType.ASSET,
+                AssetType.DEPOSIT_SAVINGS,
+                true
+        );
+        PublicSubChapter first = publicSubChapter(101L, true);
+        PublicSubChapter second = publicSubChapter(102L, false);
+        when(mainChapterMapper.findById(2L)).thenReturn(mainChapter);
+        when(subChapterMapper.findPublicByMainChapterId(2L))
+                .thenReturn(List.of(first, second));
+
+        List<PublicSubChapter> result = service.getSubChapters(2L);
+
+        assertEquals(List.of(first, second), result);
+        verify(subChapterMapper).findPublicByMainChapterId(2L);
+    }
+
+    @Test
+    void hidesMissingOrInactiveMainChapter() {
+        when(mainChapterMapper.findById(2L)).thenReturn(null);
+
+        ApiException missing = assertThrows(
+                ApiException.class,
+                () -> service.getSubChapters(2L)
+        );
+        assertEquals(ErrorCode.MAIN_CHAPTER_NOT_FOUND, missing.getErrorCode());
+
+        MainChapter inactive = mainChapter(
+                2L,
+                ChapterType.ASSET,
+                AssetType.DEPOSIT_SAVINGS,
+                false
+        );
+        when(mainChapterMapper.findById(2L)).thenReturn(inactive);
+
+        ApiException hidden = assertThrows(
+                ApiException.class,
+                () -> service.getSubChapters(2L)
+        );
+        assertEquals(ErrorCode.MAIN_CHAPTER_NOT_FOUND, hidden.getErrorCode());
+        verify(subChapterMapper, never()).findPublicByMainChapterId(2L);
+    }
+
+    private MainChapter mainChapter(
+            long id,
+            ChapterType chapterType,
+            AssetType assetType,
+            boolean active
+    ) {
+        MainChapter chapter = new MainChapter();
+        chapter.setMainChapterId(id);
+        chapter.setChapterType(chapterType);
+        chapter.setAssetType(assetType);
+        chapter.setTitle(chapterType == ChapterType.FOUNDATION
+                ? "포트폴리오 기초" : "예·적금");
+        chapter.setDescription("설명");
+        chapter.setDisplayOrder((int) id);
+        chapter.setRequired(chapterType == ChapterType.FOUNDATION);
+        chapter.setActive(active);
+        return chapter;
+    }
+
+    private PublicSubChapter publicSubChapter(long id, boolean contentAvailable) {
+        PublicSubChapter chapter = new PublicSubChapter();
+        chapter.setSubChapterId(id);
+        chapter.setMainChapterId(2L);
+        chapter.setTitle("소단원 " + id);
+        chapter.setDescription("설명");
+        chapter.setDisplayOrder((int) (id - 100));
+        chapter.setContentAvailable(contentAvailable);
+        return chapter;
+    }
+}

--- a/src/test/java/org/firstfolio/quiz/controller/AdminQuizQuestionControllerTest.java
+++ b/src/test/java/org/firstfolio/quiz/controller/AdminQuizQuestionControllerTest.java
@@ -1,0 +1,226 @@
+package org.firstfolio.quiz.controller;
+
+import org.firstfolio.auth.domain.AuthenticatedUser;
+import org.firstfolio.auth.web.AuthenticationRequestAttributes;
+import org.firstfolio.auth.web.CurrentUserArgumentResolver;
+import org.firstfolio.common.json.ApiObjectMapperFactory;
+import org.firstfolio.common.web.RequestIdFilter;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.CommonExceptionAdvice;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.quiz.domain.QuizDifficulty;
+import org.firstfolio.quiz.domain.QuizGenerationType;
+import org.firstfolio.quiz.domain.QuizQuestion;
+import org.firstfolio.quiz.domain.QuizQuestionType;
+import org.firstfolio.quiz.domain.QuizUsageType;
+import org.firstfolio.quiz.service.QuizQuestionRegistrationService;
+import org.firstfolio.user.domain.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class AdminQuizQuestionControllerTest {
+
+    private static final AuthenticatedUser ADMIN = new AuthenticatedUser(
+            900L,
+            "firebase-admin",
+            "관리자",
+            UserRole.ADMIN
+    );
+
+    private QuizQuestionRegistrationService service;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        service = mock(QuizQuestionRegistrationService.class);
+        MappingJackson2HttpMessageConverter converter =
+                new MappingJackson2HttpMessageConverter(ApiObjectMapperFactory.create());
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new AdminQuizQuestionController(service))
+                .setControllerAdvice(new CommonExceptionAdvice())
+                .setCustomArgumentResolvers(new CurrentUserArgumentResolver())
+                .setMessageConverters(converter)
+                .addFilter(new RequestIdFilter())
+                .build();
+    }
+
+    @Test
+    void createsFirstDraftUsingQuizJsonSchemaFieldNames() throws Exception {
+        when(service.createQuestion(any(), eq(900L), anyString()))
+                .thenReturn(question(1201L, 1));
+
+        mockMvc.perform(post("/api/admin/quiz-questions")
+                        .requestAttr(AuthenticationRequestAttributes.CURRENT_USER, ADMIN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(createRequestBody()))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.question_id").value(1201))
+                .andExpect(jsonPath("$.data.question_key").value("deposit-basic-001"))
+                .andExpect(jsonPath("$.data.version_no").value(1))
+                .andExpect(jsonPath("$.data.generation_type").value("HUMAN"))
+                .andExpect(jsonPath("$.data.status").value("DRAFT"));
+
+        verify(service).createQuestion(any(), eq(900L), anyString());
+    }
+
+    @Test
+    void createsNewVersionFromExistingQuestionId() throws Exception {
+        when(service.createVersion(eq(1201L), any(), eq(900L), anyString()))
+                .thenReturn(question(1202L, 2));
+
+        mockMvc.perform(post("/api/admin/quiz-questions/1201/versions")
+                        .requestAttr(AuthenticationRequestAttributes.CURRENT_USER, ADMIN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(versionRequestBody()))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.question_id").value(1202))
+                .andExpect(jsonPath("$.data.question_key").value("deposit-basic-001"))
+                .andExpect(jsonPath("$.data.version_no").value(2))
+                .andExpect(jsonPath("$.data.status").value("DRAFT"));
+
+        verify(service).createVersion(eq(1201L), any(), eq(900L), anyString());
+    }
+
+    @Test
+    void bindsCanonicalJsonFieldsToCreateRequest() throws Exception {
+        when(service.createQuestion(any(), eq(900L), anyString()))
+                .thenReturn(question(1201L, 1));
+        ArgumentCaptor<org.firstfolio.quiz.dto.request.QuizQuestionCreateRequest> captor =
+                ArgumentCaptor.forClass(
+                        org.firstfolio.quiz.dto.request.QuizQuestionCreateRequest.class
+                );
+
+        mockMvc.perform(post("/api/admin/quiz-questions")
+                        .requestAttr(AuthenticationRequestAttributes.CURRENT_USER, ADMIN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(createRequestBody()))
+                .andExpect(status().isCreated());
+
+        verify(service).createQuestion(captor.capture(), eq(900L), anyString());
+        assertEquals("SUB_CHAPTER", captor.getValue().usageType());
+        assertEquals("SINGLE_CHOICE", captor.getValue().questionType());
+        assertEquals("1", captor.getValue().correctAnswerJson().path("key").textValue());
+        assertEquals(2, captor.getValue().optionsJson().size());
+    }
+
+    @Test
+    void rejectsOutdatedNotionBodyAliasesAsUnknownFields() throws Exception {
+        mockMvc.perform(post("/api/admin/quiz-questions")
+                        .requestAttr(AuthenticationRequestAttributes.CURRENT_USER, ADMIN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "question_key": "deposit-basic-001",
+                                  "usage_type": "SUB_CHAPTER",
+                                  "question_type": "SINGLE_CHOICE",
+                                  "prompt": "질문",
+                                  "choices": [],
+                                  "correct_answer": {"key": "1"},
+                                  "explanation": "해설"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("INVALID_REQUEST"));
+    }
+
+    @Test
+    void returnsNotionSpecifiedQuestionErrors() throws Exception {
+        when(service.createQuestion(any(), eq(900L), anyString()))
+                .thenThrow(new ApiException(ErrorCode.QUESTION_KEY_CONFLICT));
+        when(service.createVersion(eq(9999L), any(), eq(900L), anyString()))
+                .thenThrow(new ApiException(ErrorCode.QUESTION_NOT_FOUND));
+
+        mockMvc.perform(post("/api/admin/quiz-questions")
+                        .requestAttr(AuthenticationRequestAttributes.CURRENT_USER, ADMIN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(createRequestBody()))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("QUESTION_KEY_CONFLICT"));
+
+        mockMvc.perform(post("/api/admin/quiz-questions/9999/versions")
+                        .requestAttr(AuthenticationRequestAttributes.CURRENT_USER, ADMIN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(versionRequestBody()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("QUESTION_NOT_FOUND"));
+    }
+
+    private QuizQuestion question(long id, int versionNo) {
+        QuizQuestion question = QuizQuestion.draft(
+                "deposit-basic-001",
+                versionNo,
+                QuizUsageType.SUB_CHAPTER,
+                2L,
+                101L,
+                null,
+                QuizQuestionType.SINGLE_CHOICE,
+                QuizDifficulty.EASY,
+                "질문",
+                null,
+                "[]",
+                "{\"key\":\"1\"}",
+                "해설",
+                QuizGenerationType.HUMAN,
+                null,
+                900L,
+                LocalDateTime.of(2026, 8, 10, 6, 0)
+        );
+        question.setQuestionId(id);
+        return question;
+    }
+
+    private String createRequestBody() {
+        return """
+                {
+                  "question_key": "deposit-basic-001",
+                  "usage_type": "SUB_CHAPTER",
+                  "main_chapter_id": null,
+                  "sub_chapter_id": 101,
+                  "question_type": "SINGLE_CHOICE",
+                  "difficulty": "EASY",
+                  "prompt": "예금의 특징으로 적절한 것은?",
+                  "scenario_json": null,
+                  "options_json": [
+                    {"key": "1", "label": "선택지 1"},
+                    {"key": "2", "label": "선택지 2", "description": null}
+                  ],
+                  "correct_answer_json": {"key": "1"},
+                  "explanation": "정답 해설"
+                }
+                """;
+    }
+
+    private String versionRequestBody() {
+        return """
+                {
+                  "prompt": "수정된 질문",
+                  "scenario_json": null,
+                  "options_json": [
+                    {"key": "1", "label": "선택지 1"},
+                    {"key": "2", "label": "선택지 2"}
+                  ],
+                  "correct_answer_json": {"key": "1"},
+                  "explanation": "수정된 해설",
+                  "source_refs_json": null
+                }
+                """;
+    }
+}

--- a/src/test/java/org/firstfolio/quiz/controller/MainChapterQuizAttemptControllerTest.java
+++ b/src/test/java/org/firstfolio/quiz/controller/MainChapterQuizAttemptControllerTest.java
@@ -1,0 +1,122 @@
+package org.firstfolio.quiz.controller;
+
+import org.firstfolio.auth.domain.AuthenticatedUser;
+import org.firstfolio.auth.web.AuthenticationRequestAttributes;
+import org.firstfolio.auth.web.CurrentUserArgumentResolver;
+import org.firstfolio.common.json.ApiObjectMapperFactory;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.CommonExceptionAdvice;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.quiz.domain.QuizAttempt;
+import org.firstfolio.quiz.domain.QuizAttemptQuestion;
+import org.firstfolio.quiz.domain.QuizAttemptStartResult;
+import org.firstfolio.quiz.domain.QuizAttemptStatus;
+import org.firstfolio.quiz.domain.QuizChoice;
+import org.firstfolio.quiz.domain.QuizGenerationType;
+import org.firstfolio.quiz.domain.QuizQuestionType;
+import org.firstfolio.quiz.domain.QuizType;
+import org.firstfolio.quiz.service.MainChapterQuizAttemptStartService;
+import org.firstfolio.user.domain.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class MainChapterQuizAttemptControllerTest {
+
+    private static final long USER_ID = 11L;
+    private static final long MAIN_CHAPTER_ID = 10L;
+
+    private MainChapterQuizAttemptStartService service;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        service = mock(MainChapterQuizAttemptStartService.class);
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new MainChapterQuizAttemptController(service))
+                .setCustomArgumentResolvers(new CurrentUserArgumentResolver())
+                .setControllerAdvice(new CommonExceptionAdvice())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(
+                        ApiObjectMapperFactory.create()
+                ))
+                .build();
+    }
+
+    @Test
+    void startsMainChapterQuizWithoutSubChapterScope() throws Exception {
+        when(service.start(USER_ID, MAIN_CHAPTER_ID)).thenReturn(result());
+
+        mockMvc.perform(authenticated(post(
+                        "/api/learning/main-chapters/10/quiz-attempts")))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.attempt_id").value(4001))
+                .andExpect(jsonPath("$.data.quiz_type").value("MAIN_CHAPTER"))
+                .andExpect(jsonPath("$.data.main_chapter_id").value(10))
+                .andExpect(jsonPath("$.data.sub_chapter_id").doesNotExist())
+                .andExpect(jsonPath("$.data.content_version_id").doesNotExist())
+                .andExpect(jsonPath("$.data.question_count").value(1))
+                .andExpect(jsonPath("$.data.questions[0].question_type")
+                        .value("SCENARIO"));
+    }
+
+    @Test
+    void returnsSubChaptersIncomplete() throws Exception {
+        when(service.start(USER_ID, MAIN_CHAPTER_ID)).thenThrow(
+                new ApiException(ErrorCode.SUB_CHAPTERS_INCOMPLETE)
+        );
+
+        mockMvc.perform(authenticated(post(
+                        "/api/learning/main-chapters/10/quiz-attempts")))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code")
+                        .value("SUB_CHAPTERS_INCOMPLETE"));
+    }
+
+    private QuizAttemptStartResult result() {
+        QuizAttempt attempt = new QuizAttempt();
+        attempt.setAttemptId(4001L);
+        attempt.setUserId(USER_ID);
+        attempt.setQuizType(QuizType.MAIN_CHAPTER);
+        attempt.setMainChapterId(MAIN_CHAPTER_ID);
+        attempt.setAttemptNo(1);
+        attempt.setStatus(QuizAttemptStatus.IN_PROGRESS);
+        attempt.setTotalCount(1);
+        return new QuizAttemptStartResult(
+                attempt,
+                List.of(new QuizAttemptQuestion(
+                        2001L,
+                        1,
+                        QuizQuestionType.SCENARIO,
+                        QuizGenerationType.HUMAN,
+                        "금리 상승 시 채권 가격은?",
+                        null,
+                        List.of(new QuizChoice("A", "하락"))
+                ))
+        );
+    }
+
+    private static MockHttpServletRequestBuilder authenticated(
+            MockHttpServletRequestBuilder builder
+    ) {
+        return builder.requestAttr(
+                AuthenticationRequestAttributes.CURRENT_USER,
+                new AuthenticatedUser(
+                        USER_ID,
+                        "firebase-uid",
+                        "학습자",
+                        UserRole.USER
+                )
+        );
+    }
+}

--- a/src/test/java/org/firstfolio/quiz/controller/QuizAnswerControllerTest.java
+++ b/src/test/java/org/firstfolio/quiz/controller/QuizAnswerControllerTest.java
@@ -11,6 +11,7 @@ import org.firstfolio.quiz.domain.QuizAnswerGradingResult;
 import org.firstfolio.quiz.domain.QuizAttemptStatus;
 import org.firstfolio.quiz.domain.QuizGenerationType;
 import org.firstfolio.quiz.service.QuizAnswerGradingService;
+import org.firstfolio.reward.domain.QuizRewardResult;
 import org.firstfolio.user.domain.UserRole;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -78,7 +79,11 @@ class QuizAnswerControllerTest {
                 .andExpect(jsonPath("$.data.attempt.status").value("IN_PROGRESS"))
                 .andExpect(jsonPath("$.data.attempt.answered_count").value(1))
                 .andExpect(jsonPath("$.data.attempt.total_count").value(3))
-                .andExpect(jsonPath("$.data.attempt.completed").value(false));
+                .andExpect(jsonPath("$.data.attempt.completed").value(false))
+                .andExpect(jsonPath("$.data.attempt.correct_count").doesNotExist())
+                .andExpect(jsonPath("$.data.attempt.score").doesNotExist())
+                .andExpect(jsonPath("$.data.reward").doesNotExist())
+                .andExpect(jsonPath("$.data.next_action").doesNotExist());
 
         verify(service).grade(USER_ID, ATTEMPT_ID, QUESTION_ID, "B");
     }
@@ -124,6 +129,28 @@ class QuizAnswerControllerTest {
     }
 
     @Test
+    void returnsFinalScoreAndRewardWhenLastQuestionCompletesQuiz() throws Exception {
+        when(service.grade(USER_ID, ATTEMPT_ID, QUESTION_ID, "C"))
+                .thenReturn(completedResult());
+
+        mockMvc.perform(authenticated(put(
+                        "/api/learning/quiz-attempts/3001/answers/1001"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"answer\":{\"key\":\"C\"}}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.attempt.status").value("GRADED"))
+                .andExpect(jsonPath("$.data.attempt.answered_count").value(3))
+                .andExpect(jsonPath("$.data.attempt.correct_count").value(2))
+                .andExpect(jsonPath("$.data.attempt.score").value(67))
+                .andExpect(jsonPath("$.data.attempt.completed").value(true))
+                .andExpect(jsonPath("$.data.reward.points").value(200))
+                .andExpect(jsonPath("$.data.reward.point_transaction_id")
+                        .value(7001))
+                .andExpect(jsonPath("$.data.next_action")
+                        .value("NEXT_SUB_CHAPTER"));
+    }
+
+    @Test
     void rejectsUnauthenticatedRequest() throws Exception {
         mockMvc.perform(put(
                         "/api/learning/quiz-attempts/3001/answers/1001")
@@ -147,7 +174,31 @@ class QuizAnswerControllerTest {
                 QuizAttemptStatus.IN_PROGRESS,
                 1,
                 3,
-                false
+                false,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+    private QuizAnswerGradingResult completedResult() {
+        return new QuizAnswerGradingResult(
+                ATTEMPT_ID,
+                QUESTION_ID,
+                QuizGenerationType.HUMAN,
+                "C",
+                true,
+                "C",
+                "정기예금 해설",
+                QuizAttemptStatus.GRADED,
+                3,
+                3,
+                true,
+                2,
+                67,
+                new QuizRewardResult(91L, 200, 7001L),
+                "NEXT_SUB_CHAPTER"
         );
     }
 

--- a/src/test/java/org/firstfolio/quiz/controller/QuizAnswerControllerTest.java
+++ b/src/test/java/org/firstfolio/quiz/controller/QuizAnswerControllerTest.java
@@ -1,5 +1,6 @@
 package org.firstfolio.quiz.controller;
 
+import org.firstfolio.curriculum.domain.ChapterType;
 import org.firstfolio.auth.domain.AuthenticatedUser;
 import org.firstfolio.auth.web.AuthenticationRequestAttributes;
 import org.firstfolio.auth.web.CurrentUserArgumentResolver;
@@ -7,6 +8,8 @@ import org.firstfolio.common.json.ApiObjectMapperFactory;
 import org.firstfolio.exception.ApiException;
 import org.firstfolio.exception.CommonExceptionAdvice;
 import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.learning.domain.MainChapterCompletionResult;
+import org.firstfolio.portfolio.service.InitialGrantResult;
 import org.firstfolio.quiz.domain.QuizAnswerGradingResult;
 import org.firstfolio.quiz.domain.QuizAttemptStatus;
 import org.firstfolio.quiz.domain.QuizGenerationType;
@@ -20,6 +23,8 @@ import org.springframework.http.converter.json.MappingJackson2HttpMessageConvert
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.math.BigDecimal;
 
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -83,6 +88,8 @@ class QuizAnswerControllerTest {
                 .andExpect(jsonPath("$.data.attempt.correct_count").doesNotExist())
                 .andExpect(jsonPath("$.data.attempt.score").doesNotExist())
                 .andExpect(jsonPath("$.data.reward").doesNotExist())
+                .andExpect(jsonPath("$.data.main_chapter_completed").doesNotExist())
+                .andExpect(jsonPath("$.data.foundation_grant").doesNotExist())
                 .andExpect(jsonPath("$.data.next_action").doesNotExist());
 
         verify(service).grade(USER_ID, ATTEMPT_ID, QUESTION_ID, "B");
@@ -146,6 +153,8 @@ class QuizAnswerControllerTest {
                 .andExpect(jsonPath("$.data.reward.points").value(200))
                 .andExpect(jsonPath("$.data.reward.point_transaction_id")
                         .value(7001))
+                .andExpect(jsonPath("$.data.main_chapter_completed")
+                        .value(false))
                 .andExpect(jsonPath("$.data.next_action")
                         .value("NEXT_SUB_CHAPTER"));
     }
@@ -162,6 +171,26 @@ class QuizAnswerControllerTest {
         verify(service, never()).grade(anyLong(), anyLong(), anyLong(), isNull());
     }
 
+    @Test
+    void returnsFoundationCompletionAndInitialGrant() throws Exception {
+        when(service.grade(USER_ID, ATTEMPT_ID, QUESTION_ID, "C"))
+                .thenReturn(completedFoundationResult());
+
+        mockMvc.perform(authenticated(put(
+                        "/api/learning/quiz-attempts/3001/answers/1001"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"answer\":{\"key\":\"C\"}}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.main_chapter_completed")
+                        .value(true))
+                .andExpect(jsonPath("$.data.foundation_grant.granted")
+                        .value(true))
+                .andExpect(jsonPath("$.data.foundation_grant.portfolio_id")
+                        .value(501))
+                .andExpect(jsonPath("$.data.next_action")
+                        .value("PORTFOLIO_SETUP"));
+    }
+
     private QuizAnswerGradingResult result() {
         return new QuizAnswerGradingResult(
                 ATTEMPT_ID,
@@ -175,6 +204,7 @@ class QuizAnswerControllerTest {
                 1,
                 3,
                 false,
+                null,
                 null,
                 null,
                 null,
@@ -198,7 +228,37 @@ class QuizAnswerControllerTest {
                 2,
                 67,
                 new QuizRewardResult(91L, 200, 7001L),
+                null,
                 "NEXT_SUB_CHAPTER"
+        );
+    }
+
+    private QuizAnswerGradingResult completedFoundationResult() {
+        return new QuizAnswerGradingResult(
+                ATTEMPT_ID,
+                QUESTION_ID,
+                QuizGenerationType.HUMAN,
+                "C",
+                true,
+                "C",
+                "정기예금 해설",
+                QuizAttemptStatus.GRADED,
+                3,
+                3,
+                true,
+                2,
+                67,
+                new QuizRewardResult(91L, 200, 7001L),
+                new MainChapterCompletionResult(
+                        ChapterType.FOUNDATION,
+                        true,
+                        new InitialGrantResult(
+                                true,
+                                new BigDecimal("30000000.00"),
+                                501L
+                        )
+                ),
+                "PORTFOLIO_SETUP"
         );
     }
 

--- a/src/test/java/org/firstfolio/quiz/controller/QuizAnswerControllerTest.java
+++ b/src/test/java/org/firstfolio/quiz/controller/QuizAnswerControllerTest.java
@@ -1,0 +1,167 @@
+package org.firstfolio.quiz.controller;
+
+import org.firstfolio.auth.domain.AuthenticatedUser;
+import org.firstfolio.auth.web.AuthenticationRequestAttributes;
+import org.firstfolio.auth.web.CurrentUserArgumentResolver;
+import org.firstfolio.common.json.ApiObjectMapperFactory;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.CommonExceptionAdvice;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.quiz.domain.QuizAnswerGradingResult;
+import org.firstfolio.quiz.domain.QuizAttemptStatus;
+import org.firstfolio.quiz.domain.QuizGenerationType;
+import org.firstfolio.quiz.service.QuizAnswerGradingService;
+import org.firstfolio.user.domain.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class QuizAnswerControllerTest {
+
+    private static final long USER_ID = 11L;
+    private static final long ATTEMPT_ID = 3001L;
+    private static final long QUESTION_ID = 1001L;
+
+    private QuizAnswerGradingService service;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        service = mock(QuizAnswerGradingService.class);
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new QuizAnswerController(service))
+                .setCustomArgumentResolvers(new CurrentUserArgumentResolver())
+                .setControllerAdvice(new CommonExceptionAdvice())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(
+                        ApiObjectMapperFactory.create()
+                ))
+                .build();
+    }
+
+    @Test
+    void gradesOneQuestionAndReturnsImmediateFeedback() throws Exception {
+        when(service.grade(USER_ID, ATTEMPT_ID, QUESTION_ID, "B"))
+                .thenReturn(result());
+
+        mockMvc.perform(authenticated(put(
+                        "/api/learning/quiz-attempts/3001/answers/1001"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "answer": {
+                                    "key": "B"
+                                  }
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.attempt_id").value(3001))
+                .andExpect(jsonPath("$.data.question_id").value(1001))
+                .andExpect(jsonPath("$.data.generation_type").value("HUMAN"))
+                .andExpect(jsonPath("$.data.selected_key").value("B"))
+                .andExpect(jsonPath("$.data.is_correct").value(false))
+                .andExpect(jsonPath("$.data.correct_answer.key").value("C"))
+                .andExpect(jsonPath("$.data.explanation").value("정기예금 해설"))
+                .andExpect(jsonPath("$.data.attempt.status").value("IN_PROGRESS"))
+                .andExpect(jsonPath("$.data.attempt.answered_count").value(1))
+                .andExpect(jsonPath("$.data.attempt.total_count").value(3))
+                .andExpect(jsonPath("$.data.attempt.completed").value(false));
+
+        verify(service).grade(USER_ID, ATTEMPT_ID, QUESTION_ID, "B");
+    }
+
+    @Test
+    void rejectsPreviousSelectedKeyRequestShape() throws Exception {
+        mockMvc.perform(authenticated(put(
+                        "/api/learning/quiz-attempts/3001/answers/1001"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"selected_key\":\"B\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("INVALID_REQUEST"));
+
+        verify(service, never()).grade(anyLong(), anyLong(), anyLong(), isNull());
+    }
+
+    @Test
+    void returnsInvalidSelectedChoiceForMissingAnswerKey() throws Exception {
+        when(service.grade(USER_ID, ATTEMPT_ID, QUESTION_ID, null))
+                .thenThrow(new ApiException(ErrorCode.INVALID_SELECTED_CHOICE));
+
+        mockMvc.perform(authenticated(put(
+                        "/api/learning/quiz-attempts/3001/answers/1001"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"answer\":{}}"))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.error.code")
+                        .value("INVALID_SELECTED_CHOICE"));
+    }
+
+    @Test
+    void returnsAnswerAlreadySubmittedConflict() throws Exception {
+        when(service.grade(USER_ID, ATTEMPT_ID, QUESTION_ID, "C"))
+                .thenThrow(new ApiException(ErrorCode.ANSWER_ALREADY_SUBMITTED));
+
+        mockMvc.perform(authenticated(put(
+                        "/api/learning/quiz-attempts/3001/answers/1001"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"answer\":{\"key\":\"C\"}}"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code")
+                        .value("ANSWER_ALREADY_SUBMITTED"));
+    }
+
+    @Test
+    void rejectsUnauthenticatedRequest() throws Exception {
+        mockMvc.perform(put(
+                        "/api/learning/quiz-attempts/3001/answers/1001")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"answer\":{\"key\":\"B\"}}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("UNAUTHORIZED"));
+
+        verify(service, never()).grade(anyLong(), anyLong(), anyLong(), isNull());
+    }
+
+    private QuizAnswerGradingResult result() {
+        return new QuizAnswerGradingResult(
+                ATTEMPT_ID,
+                QUESTION_ID,
+                QuizGenerationType.HUMAN,
+                "B",
+                false,
+                "C",
+                "정기예금 해설",
+                QuizAttemptStatus.IN_PROGRESS,
+                1,
+                3,
+                false
+        );
+    }
+
+    private static MockHttpServletRequestBuilder authenticated(
+            MockHttpServletRequestBuilder builder
+    ) {
+        return builder.requestAttr(
+                AuthenticationRequestAttributes.CURRENT_USER,
+                new AuthenticatedUser(
+                        USER_ID,
+                        "firebase-uid",
+                        "학습자",
+                        UserRole.USER
+                )
+        );
+    }
+}

--- a/src/test/java/org/firstfolio/quiz/controller/QuizAttemptControllerTest.java
+++ b/src/test/java/org/firstfolio/quiz/controller/QuizAttemptControllerTest.java
@@ -65,6 +65,7 @@ class QuizAttemptControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.data.attempt_id").value(3001))
                 .andExpect(jsonPath("$.data.quiz_type").value("SUB_CHAPTER"))
+                .andExpect(jsonPath("$.data.main_chapter_id").doesNotExist())
                 .andExpect(jsonPath("$.data.sub_chapter_id").value(101))
                 .andExpect(jsonPath("$.data.content_version_id").value(301))
                 .andExpect(jsonPath("$.data.status").value("IN_PROGRESS"))

--- a/src/test/java/org/firstfolio/quiz/controller/QuizAttemptControllerTest.java
+++ b/src/test/java/org/firstfolio/quiz/controller/QuizAttemptControllerTest.java
@@ -1,0 +1,154 @@
+package org.firstfolio.quiz.controller;
+
+import org.firstfolio.auth.domain.AuthenticatedUser;
+import org.firstfolio.auth.web.AuthenticationRequestAttributes;
+import org.firstfolio.auth.web.CurrentUserArgumentResolver;
+import org.firstfolio.common.json.ApiObjectMapperFactory;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.CommonExceptionAdvice;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.quiz.domain.QuizAttempt;
+import org.firstfolio.quiz.domain.QuizAttemptQuestion;
+import org.firstfolio.quiz.domain.QuizAttemptStartResult;
+import org.firstfolio.quiz.domain.QuizAttemptStatus;
+import org.firstfolio.quiz.domain.QuizChoice;
+import org.firstfolio.quiz.domain.QuizGenerationType;
+import org.firstfolio.quiz.domain.QuizQuestionType;
+import org.firstfolio.quiz.domain.QuizType;
+import org.firstfolio.quiz.service.QuizAttemptStartService;
+import org.firstfolio.user.domain.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class QuizAttemptControllerTest {
+
+    private static final long USER_ID = 11L;
+    private static final long SUB_CHAPTER_ID = 101L;
+
+    private QuizAttemptStartService service;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        service = mock(QuizAttemptStartService.class);
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new QuizAttemptController(service))
+                .setCustomArgumentResolvers(new CurrentUserArgumentResolver())
+                .setControllerAdvice(new CommonExceptionAdvice())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(
+                        ApiObjectMapperFactory.create()
+                ))
+                .build();
+    }
+
+    @Test
+    void startsSubChapterQuizWithoutExposingAnswerOrExplanation() throws Exception {
+        when(service.start(USER_ID, SUB_CHAPTER_ID)).thenReturn(result());
+
+        mockMvc.perform(authenticated(post(
+                        "/api/learning/sub-chapters/101/quiz-attempts")))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.attempt_id").value(3001))
+                .andExpect(jsonPath("$.data.quiz_type").value("SUB_CHAPTER"))
+                .andExpect(jsonPath("$.data.sub_chapter_id").value(101))
+                .andExpect(jsonPath("$.data.content_version_id").value(301))
+                .andExpect(jsonPath("$.data.status").value("IN_PROGRESS"))
+                .andExpect(jsonPath("$.data.question_count").value(1))
+                .andExpect(jsonPath("$.data.questions[0].question_id").value(1001))
+                .andExpect(jsonPath("$.data.questions[0].display_order").value(1))
+                .andExpect(jsonPath("$.data.questions[0].question_type")
+                        .value("SINGLE_CHOICE"))
+                .andExpect(jsonPath("$.data.questions[0].generation_type")
+                        .value("HUMAN"))
+                .andExpect(jsonPath("$.data.questions[0].prompt")
+                        .value("예금에 대한 설명으로 올바른 것은?"))
+                .andExpect(jsonPath("$.data.questions[0].scenario").isEmpty())
+                .andExpect(jsonPath("$.data.questions[0].choices[0].id")
+                        .value("A"))
+                .andExpect(jsonPath("$.data.questions[0].choices[0].text")
+                        .value("선택지 A"))
+                .andExpect(jsonPath("$.data.questions[0].correct_answer")
+                        .doesNotExist())
+                .andExpect(jsonPath("$.data.questions[0].explanation")
+                        .doesNotExist());
+
+        verify(service).start(USER_ID, SUB_CHAPTER_ID);
+    }
+
+    @Test
+    void rejectsUnauthenticatedRequest() throws Exception {
+        mockMvc.perform(post(
+                        "/api/learning/sub-chapters/101/quiz-attempts"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("UNAUTHORIZED"));
+
+        verify(service, never()).start(anyLong(), anyLong());
+    }
+
+    @Test
+    void returnsQuizNotAvailable() throws Exception {
+        when(service.start(USER_ID, SUB_CHAPTER_ID))
+                .thenThrow(new ApiException(ErrorCode.QUIZ_NOT_AVAILABLE));
+
+        mockMvc.perform(authenticated(post(
+                        "/api/learning/sub-chapters/101/quiz-attempts")))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code")
+                        .value("QUIZ_NOT_AVAILABLE"));
+    }
+
+    private QuizAttemptStartResult result() {
+        QuizAttempt attempt = new QuizAttempt();
+        attempt.setAttemptId(3001L);
+        attempt.setUserId(USER_ID);
+        attempt.setQuizType(QuizType.SUB_CHAPTER);
+        attempt.setSubChapterId(SUB_CHAPTER_ID);
+        attempt.setContentVersionId(301L);
+        attempt.setAttemptNo(1);
+        attempt.setStatus(QuizAttemptStatus.IN_PROGRESS);
+        attempt.setTotalCount(1);
+
+        QuizAttemptQuestion question = new QuizAttemptQuestion(
+                1001L,
+                1,
+                QuizQuestionType.SINGLE_CHOICE,
+                QuizGenerationType.HUMAN,
+                "예금에 대한 설명으로 올바른 것은?",
+                null,
+                List.of(
+                        new QuizChoice("A", "선택지 A"),
+                        new QuizChoice("B", "선택지 B")
+                )
+        );
+        return new QuizAttemptStartResult(attempt, List.of(question));
+    }
+
+    private static MockHttpServletRequestBuilder authenticated(
+            MockHttpServletRequestBuilder builder
+    ) {
+        return builder.requestAttr(
+                AuthenticationRequestAttributes.CURRENT_USER,
+                new AuthenticatedUser(
+                        USER_ID,
+                        "firebase-uid",
+                        "학습자",
+                        UserRole.USER
+                )
+        );
+    }
+}

--- a/src/test/java/org/firstfolio/quiz/mapper/QuizAttemptMapperXmlTest.java
+++ b/src/test/java/org/firstfolio/quiz/mapper/QuizAttemptMapperXmlTest.java
@@ -31,6 +31,7 @@ class QuizAttemptMapperXmlTest {
         }
 
         assertTrue(configuration.hasMapper(QuizAttemptMapper.class));
+        assertTrue(configuration.hasStatement(id("findByIdForUpdate")));
         assertTrue(configuration.hasStatement(id(
                 "findInProgressByUserIdAndSubChapterIdForUpdate"
         )));
@@ -38,8 +39,13 @@ class QuizAttemptMapperXmlTest {
                 "findMaxAttemptNoByUserIdAndSubChapterId"
         )));
         assertTrue(configuration.hasStatement(id("findAnswersByAttemptId")));
+        assertTrue(configuration.hasStatement(id(
+                "findAnswerByAttemptIdAndQuestionIdForUpdate"
+        )));
+        assertTrue(configuration.hasStatement(id("countAnsweredByAttemptId")));
         assertTrue(configuration.hasStatement(id("insertAttempt")));
         assertTrue(configuration.hasStatement(id("insertAnswer")));
+        assertTrue(configuration.hasStatement(id("gradeAnswerIfUnanswered")));
 
         BoundSql lockSql = configuration.getMappedStatement(id(
                         "findInProgressByUserIdAndSubChapterIdForUpdate"
@@ -55,6 +61,25 @@ class QuizAttemptMapperXmlTest {
                 .getBoundSql(Map.of("attemptId", 3001L));
         assertTrue(normalize(answersSql.getSql()).contains(
                 "WHERE attempt_id = ? ORDER BY display_order ASC"
+        ));
+
+        BoundSql answerLockSql = configuration.getMappedStatement(id(
+                        "findAnswerByAttemptIdAndQuestionIdForUpdate"
+                ))
+                .getBoundSql(Map.of(
+                        "attemptId", 3001L,
+                        "questionId", 1001L
+                ));
+        assertTrue(normalize(answerLockSql.getSql()).contains(
+                "WHERE attempt_id = ? AND question_id = ? FOR UPDATE"
+        ));
+
+        BoundSql gradeSql = configuration.getMappedStatement(
+                        id("gradeAnswerIfUnanswered")
+                )
+                .getBoundSql(new org.firstfolio.quiz.domain.QuizAnswer());
+        assertTrue(normalize(gradeSql.getSql()).contains(
+                "WHERE quiz_answer_id = ? AND user_answer_json IS NULL"
         ));
     }
 

--- a/src/test/java/org/firstfolio/quiz/mapper/QuizAttemptMapperXmlTest.java
+++ b/src/test/java/org/firstfolio/quiz/mapper/QuizAttemptMapperXmlTest.java
@@ -38,6 +38,12 @@ class QuizAttemptMapperXmlTest {
         assertTrue(configuration.hasStatement(id(
                 "findMaxAttemptNoByUserIdAndSubChapterId"
         )));
+        assertTrue(configuration.hasStatement(id(
+                "findInProgressByUserIdAndMainChapterIdForUpdate"
+        )));
+        assertTrue(configuration.hasStatement(id(
+                "findMaxAttemptNoByUserIdAndMainChapterId"
+        )));
         assertTrue(configuration.hasStatement(id("findAnswersByAttemptId")));
         assertTrue(configuration.hasStatement(id(
                 "findAnswerByAttemptIdAndQuestionIdForUpdate"
@@ -55,6 +61,14 @@ class QuizAttemptMapperXmlTest {
                 .getBoundSql(Map.of("userId", 11L, "subChapterId", 101L));
         assertTrue(normalize(lockSql.getSql()).contains(
                 "AND status = 'IN_PROGRESS' ORDER BY attempt_no DESC LIMIT 1 FOR UPDATE"
+        ));
+
+        BoundSql mainLockSql = configuration.getMappedStatement(id(
+                        "findInProgressByUserIdAndMainChapterIdForUpdate"
+                ))
+                .getBoundSql(Map.of("userId", 11L, "mainChapterId", 10L));
+        assertTrue(normalize(mainLockSql.getSql()).contains(
+                "quiz_type = 'MAIN_CHAPTER' AND main_chapter_id = ?"
         ));
 
         BoundSql answersSql = configuration.getMappedStatement(

--- a/src/test/java/org/firstfolio/quiz/mapper/QuizAttemptMapperXmlTest.java
+++ b/src/test/java/org/firstfolio/quiz/mapper/QuizAttemptMapperXmlTest.java
@@ -43,9 +43,11 @@ class QuizAttemptMapperXmlTest {
                 "findAnswerByAttemptIdAndQuestionIdForUpdate"
         )));
         assertTrue(configuration.hasStatement(id("countAnsweredByAttemptId")));
+        assertTrue(configuration.hasStatement(id("countCorrectByAttemptId")));
         assertTrue(configuration.hasStatement(id("insertAttempt")));
         assertTrue(configuration.hasStatement(id("insertAnswer")));
         assertTrue(configuration.hasStatement(id("gradeAnswerIfUnanswered")));
+        assertTrue(configuration.hasStatement(id("completeAttemptIfInProgress")));
 
         BoundSql lockSql = configuration.getMappedStatement(id(
                         "findInProgressByUserIdAndSubChapterIdForUpdate"
@@ -80,6 +82,17 @@ class QuizAttemptMapperXmlTest {
                 .getBoundSql(new org.firstfolio.quiz.domain.QuizAnswer());
         assertTrue(normalize(gradeSql.getSql()).contains(
                 "WHERE quiz_answer_id = ? AND user_answer_json IS NULL"
+        ));
+
+        BoundSql completeSql = configuration.getMappedStatement(
+                        id("completeAttemptIfInProgress")
+                )
+                .getBoundSql(new org.firstfolio.quiz.domain.QuizAttempt());
+        assertTrue(normalize(completeSql.getSql()).contains(
+                "reward_policy_id = ?, point_transaction_id = ?, submitted_at = ?"
+        ));
+        assertTrue(normalize(completeSql.getSql()).contains(
+                "WHERE attempt_id = ? AND status = 'IN_PROGRESS'"
         ));
     }
 

--- a/src/test/java/org/firstfolio/quiz/mapper/QuizAttemptMapperXmlTest.java
+++ b/src/test/java/org/firstfolio/quiz/mapper/QuizAttemptMapperXmlTest.java
@@ -1,0 +1,68 @@
+package org.firstfolio.quiz.mapper;
+
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.mapping.BoundSql;
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class QuizAttemptMapperXmlTest {
+
+    private static final String RESOURCE = "mappers/quiz/QuizAttemptMapper.xml";
+
+    @Test
+    void parsesAttemptAndAnswerStatements() throws IOException {
+        Configuration configuration = new Configuration();
+
+        try (InputStream input = Resources.getResourceAsStream(RESOURCE)) {
+            XMLMapperBuilder builder = new XMLMapperBuilder(
+                    input,
+                    configuration,
+                    RESOURCE,
+                    configuration.getSqlFragments()
+            );
+            builder.parse();
+        }
+
+        assertTrue(configuration.hasMapper(QuizAttemptMapper.class));
+        assertTrue(configuration.hasStatement(id(
+                "findInProgressByUserIdAndSubChapterIdForUpdate"
+        )));
+        assertTrue(configuration.hasStatement(id(
+                "findMaxAttemptNoByUserIdAndSubChapterId"
+        )));
+        assertTrue(configuration.hasStatement(id("findAnswersByAttemptId")));
+        assertTrue(configuration.hasStatement(id("insertAttempt")));
+        assertTrue(configuration.hasStatement(id("insertAnswer")));
+
+        BoundSql lockSql = configuration.getMappedStatement(id(
+                        "findInProgressByUserIdAndSubChapterIdForUpdate"
+                ))
+                .getBoundSql(Map.of("userId", 11L, "subChapterId", 101L));
+        assertTrue(normalize(lockSql.getSql()).contains(
+                "AND status = 'IN_PROGRESS' ORDER BY attempt_no DESC LIMIT 1 FOR UPDATE"
+        ));
+
+        BoundSql answersSql = configuration.getMappedStatement(
+                        id("findAnswersByAttemptId")
+                )
+                .getBoundSql(Map.of("attemptId", 3001L));
+        assertTrue(normalize(answersSql.getSql()).contains(
+                "WHERE attempt_id = ? ORDER BY display_order ASC"
+        ));
+    }
+
+    private String id(String statement) {
+        return QuizAttemptMapper.class.getName() + "." + statement;
+    }
+
+    private String normalize(String sql) {
+        return sql.replaceAll("\\s+", " ").trim();
+    }
+}

--- a/src/test/java/org/firstfolio/quiz/mapper/QuizQuestionMapperXmlTest.java
+++ b/src/test/java/org/firstfolio/quiz/mapper/QuizQuestionMapperXmlTest.java
@@ -46,6 +46,9 @@ class QuizQuestionMapperXmlTest {
         assertTrue(configuration.hasStatement(
                 QuizQuestionMapper.class.getName() + ".insert"
         ));
+        assertTrue(configuration.hasStatement(
+                QuizQuestionMapper.class.getName() + ".findAllByIds"
+        ));
         assertTrue(configuration.hasStatement(statementId));
 
         BoundSql boundSql = configuration.getMappedStatement(statementId)

--- a/src/test/java/org/firstfolio/quiz/mapper/QuizQuestionMapperXmlTest.java
+++ b/src/test/java/org/firstfolio/quiz/mapper/QuizQuestionMapperXmlTest.java
@@ -34,6 +34,18 @@ class QuizQuestionMapperXmlTest {
 
         String statementId = QuizQuestionMapper.class.getName() + ".findReferencesByIds";
         assertTrue(configuration.hasMapper(QuizQuestionMapper.class));
+        assertTrue(configuration.hasStatement(
+                QuizQuestionMapper.class.getName() + ".findById"
+        ));
+        assertTrue(configuration.hasStatement(
+                QuizQuestionMapper.class.getName() + ".findLatestByQuestionKeyForUpdate"
+        ));
+        assertTrue(configuration.hasStatement(
+                QuizQuestionMapper.class.getName() + ".countByQuestionKey"
+        ));
+        assertTrue(configuration.hasStatement(
+                QuizQuestionMapper.class.getName() + ".insert"
+        ));
         assertTrue(configuration.hasStatement(statementId));
 
         BoundSql boundSql = configuration.getMappedStatement(statementId)
@@ -41,6 +53,15 @@ class QuizQuestionMapperXmlTest {
         assertEquals(3, boundSql.getParameterMappings().size());
         assertTrue(normalize(boundSql.getSql()).contains(
                 "FROM quiz_questions WHERE question_id IN ( ? , ? , ? )"
+        ));
+
+        BoundSql lockSql = configuration.getMappedStatement(
+                        QuizQuestionMapper.class.getName()
+                                + ".findLatestByQuestionKeyForUpdate"
+                )
+                .getBoundSql(Map.of("questionKey", "deposit-basic-001"));
+        assertTrue(normalize(lockSql.getSql()).contains(
+                "WHERE question_key = ? ORDER BY version_no DESC LIMIT 1 FOR UPDATE"
         ));
     }
 

--- a/src/test/java/org/firstfolio/quiz/mapper/QuizQuestionMapperXmlTest.java
+++ b/src/test/java/org/firstfolio/quiz/mapper/QuizQuestionMapperXmlTest.java
@@ -49,6 +49,10 @@ class QuizQuestionMapperXmlTest {
         assertTrue(configuration.hasStatement(
                 QuizQuestionMapper.class.getName() + ".findAllByIds"
         ));
+        assertTrue(configuration.hasStatement(
+                QuizQuestionMapper.class.getName()
+                        + ".findLatestPublishedByMainChapterId"
+        ));
         assertTrue(configuration.hasStatement(statementId));
 
         BoundSql boundSql = configuration.getMappedStatement(statementId)
@@ -65,6 +69,22 @@ class QuizQuestionMapperXmlTest {
                 .getBoundSql(Map.of("questionKey", "deposit-basic-001"));
         assertTrue(normalize(lockSql.getSql()).contains(
                 "WHERE question_key = ? ORDER BY version_no DESC LIMIT 1 FOR UPDATE"
+        ));
+
+        BoundSql mainQuestionSql = configuration.getMappedStatement(
+                        QuizQuestionMapper.class.getName()
+                                + ".findLatestPublishedByMainChapterId"
+                )
+                .getBoundSql(Map.of("mainChapterId", 10L));
+        String normalizedMainQuestionSql = normalize(mainQuestionSql.getSql());
+        assertTrue(normalizedMainQuestionSql.contains(
+                "question.usage_type = 'MAIN_CHAPTER'"
+        ));
+        assertTrue(normalizedMainQuestionSql.contains(
+                "newer.version_no > question.version_no"
+        ));
+        assertTrue(normalizedMainQuestionSql.endsWith(
+                "ORDER BY question.display_order, question.question_id"
         ));
     }
 

--- a/src/test/java/org/firstfolio/quiz/service/MainChapterQuizAttemptStartServiceTest.java
+++ b/src/test/java/org/firstfolio/quiz/service/MainChapterQuizAttemptStartServiceTest.java
@@ -1,0 +1,228 @@
+package org.firstfolio.quiz.service;
+
+import org.firstfolio.curriculum.domain.ChapterType;
+import org.firstfolio.curriculum.domain.MainChapter;
+import org.firstfolio.curriculum.mapper.MainChapterMapper;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.learning.domain.UserCurriculumItem;
+import org.firstfolio.learning.mapper.MainChapterLearningMapper;
+import org.firstfolio.quiz.domain.QuizAnswer;
+import org.firstfolio.quiz.domain.QuizAttempt;
+import org.firstfolio.quiz.domain.QuizAttemptStartResult;
+import org.firstfolio.quiz.domain.QuizAttemptStatus;
+import org.firstfolio.quiz.domain.QuizGenerationType;
+import org.firstfolio.quiz.domain.QuizQuestion;
+import org.firstfolio.quiz.domain.QuizQuestionStatus;
+import org.firstfolio.quiz.domain.QuizQuestionType;
+import org.firstfolio.quiz.domain.QuizType;
+import org.firstfolio.quiz.domain.QuizUsageType;
+import org.firstfolio.quiz.mapper.QuizAttemptMapper;
+import org.firstfolio.quiz.mapper.QuizQuestionMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class MainChapterQuizAttemptStartServiceTest {
+
+    private static final long USER_ID = 11L;
+    private static final long MAIN_CHAPTER_ID = 10L;
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 8, 11, 2, 0);
+
+    private QuizAttemptMapper attemptMapper;
+    private QuizQuestionMapper questionMapper;
+    private MainChapterLearningMapper learningMapper;
+    private MainChapterMapper mainChapterMapper;
+    private MainChapterQuizAttemptStartService service;
+
+    @BeforeEach
+    void setUp() {
+        attemptMapper = mock(QuizAttemptMapper.class);
+        questionMapper = mock(QuizQuestionMapper.class);
+        learningMapper = mock(MainChapterLearningMapper.class);
+        mainChapterMapper = mock(MainChapterMapper.class);
+        service = new MainChapterQuizAttemptStartService(
+                attemptMapper,
+                questionMapper,
+                learningMapper,
+                mainChapterMapper,
+                Clock.fixed(
+                        Instant.parse("2026-08-11T02:00:00Z"),
+                        ZoneOffset.UTC
+                )
+        );
+        when(learningMapper.findActiveCurriculumItemForUpdate(
+                USER_ID,
+                MAIN_CHAPTER_ID
+        )).thenReturn(curriculumItem());
+        when(mainChapterMapper.findById(MAIN_CHAPTER_ID))
+                .thenReturn(mainChapter());
+    }
+
+    @Test
+    void startsWithAllLatestPublishedMainChapterQuestions() {
+        when(learningMapper.countActiveSubChapters(MAIN_CHAPTER_ID))
+                .thenReturn(2);
+        when(learningMapper.countIncompleteActiveSubChapters(
+                USER_ID,
+                MAIN_CHAPTER_ID
+        )).thenReturn(0);
+        when(questionMapper.findLatestPublishedByMainChapterId(MAIN_CHAPTER_ID))
+                .thenReturn(List.of(question(1001L), question(1002L)));
+        when(attemptMapper.findMaxAttemptNoByUserIdAndMainChapterId(
+                USER_ID,
+                MAIN_CHAPTER_ID
+        )).thenReturn(1);
+        when(attemptMapper.insertAttempt(any())).thenAnswer(invocation -> {
+            QuizAttempt attempt = invocation.getArgument(0);
+            attempt.setAttemptId(3001L);
+            return 1;
+        });
+        when(attemptMapper.insertAnswer(any())).thenReturn(1);
+
+        QuizAttemptStartResult result = service.start(USER_ID, MAIN_CHAPTER_ID);
+
+        assertEquals(QuizType.MAIN_CHAPTER, result.attempt().getQuizType());
+        assertEquals(MAIN_CHAPTER_ID, result.attempt().getMainChapterId());
+        assertNull(result.attempt().getSubChapterId());
+        assertNull(result.attempt().getContentVersionId());
+        assertEquals(2, result.attempt().getAttemptNo());
+        assertEquals(2, result.questions().size());
+        assertEquals(1001L, result.questions().get(0).questionId());
+        assertEquals(2, result.questions().get(1).displayOrder());
+
+        ArgumentCaptor<QuizAnswer> answers = ArgumentCaptor.forClass(
+                QuizAnswer.class
+        );
+        verify(attemptMapper, org.mockito.Mockito.times(2))
+                .insertAnswer(answers.capture());
+        assertEquals(NOW, answers.getAllValues().get(0).getCreatedAt());
+        assertEquals(QuizGenerationType.HUMAN,
+                result.questions().get(0).generationType());
+    }
+
+    @Test
+    void restoresExistingInProgressAttemptBeforeCheckingCompletionAgain() {
+        QuizAttempt attempt = new QuizAttempt();
+        attempt.setAttemptId(3001L);
+        attempt.setUserId(USER_ID);
+        attempt.setQuizType(QuizType.MAIN_CHAPTER);
+        attempt.setMainChapterId(MAIN_CHAPTER_ID);
+        attempt.setStatus(QuizAttemptStatus.IN_PROGRESS);
+        attempt.setTotalCount(1);
+        when(attemptMapper.findInProgressByUserIdAndMainChapterIdForUpdate(
+                USER_ID,
+                MAIN_CHAPTER_ID
+        )).thenReturn(attempt);
+        when(attemptMapper.findAnswersByAttemptId(3001L))
+                .thenReturn(List.of(snapshotAnswer()));
+
+        QuizAttemptStartResult result = service.start(USER_ID, MAIN_CHAPTER_ID);
+
+        assertEquals(3001L, result.attempt().getAttemptId());
+        assertEquals(1, result.questions().size());
+        verify(learningMapper, never()).countActiveSubChapters(MAIN_CHAPTER_ID);
+        verify(attemptMapper, never()).insertAttempt(any());
+    }
+
+    @Test
+    void rejectsWhenAnyActiveSubChapterIsIncomplete() {
+        when(learningMapper.countActiveSubChapters(MAIN_CHAPTER_ID))
+                .thenReturn(2);
+        when(learningMapper.countIncompleteActiveSubChapters(
+                USER_ID,
+                MAIN_CHAPTER_ID
+        )).thenReturn(1);
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.start(USER_ID, MAIN_CHAPTER_ID)
+        );
+
+        assertEquals(ErrorCode.SUB_CHAPTERS_INCOMPLETE, exception.getErrorCode());
+        verify(questionMapper, never())
+                .findLatestPublishedByMainChapterId(MAIN_CHAPTER_ID);
+    }
+
+    @Test
+    void rejectsUnavailableCurriculumOrQuestionSet() {
+        when(learningMapper.findActiveCurriculumItemForUpdate(
+                USER_ID,
+                MAIN_CHAPTER_ID
+        )).thenReturn(null);
+        ApiException missingCurriculum = assertThrows(
+                ApiException.class,
+                () -> service.start(USER_ID, MAIN_CHAPTER_ID)
+        );
+        assertEquals(ErrorCode.QUIZ_NOT_AVAILABLE,
+                missingCurriculum.getErrorCode());
+    }
+
+    private UserCurriculumItem curriculumItem() {
+        UserCurriculumItem item = new UserCurriculumItem();
+        item.setCurriculumItemId(100L);
+        item.setUserId(USER_ID);
+        item.setMainChapterId(MAIN_CHAPTER_ID);
+        item.setStatus("ACTIVE");
+        return item;
+    }
+
+    private MainChapter mainChapter() {
+        MainChapter chapter = new MainChapter();
+        chapter.setMainChapterId(MAIN_CHAPTER_ID);
+        chapter.setChapterType(ChapterType.ASSET);
+        chapter.setActive(true);
+        return chapter;
+    }
+
+    private QuizQuestion question(long questionId) {
+        QuizQuestion question = new QuizQuestion();
+        question.setQuestionId(questionId);
+        question.setUsageType(QuizUsageType.MAIN_CHAPTER);
+        question.setMainChapterId(MAIN_CHAPTER_ID);
+        question.setDisplayOrder((int) (questionId - 1000));
+        question.setQuestionType(QuizQuestionType.SCENARIO);
+        question.setPrompt("금리 변화 시나리오 문항");
+        question.setScenarioJson("{\"market\":\"금리 상승\"}");
+        question.setOptionsJson("[{\"key\":\"A\",\"label\":\"채권 가격 하락\"}]");
+        question.setCorrectAnswerJson("{\"key\":\"A\"}");
+        question.setExplanation("금리와 채권 가격은 반대로 움직입니다.");
+        question.setGenerationType(QuizGenerationType.HUMAN);
+        question.setStatus(QuizQuestionStatus.PUBLISHED);
+        return question;
+    }
+
+    private QuizAnswer snapshotAnswer() {
+        QuizAnswer answer = new QuizAnswer();
+        answer.setAttemptId(3001L);
+        answer.setQuestionId(1001L);
+        answer.setDisplayOrder(1);
+        answer.setQuestionSnapshotJson("""
+                {
+                  "question_type":"SCENARIO",
+                  "generation_type":"HUMAN",
+                  "prompt":"시나리오 문항",
+                  "scenario_json":{"market":"금리 상승"},
+                  "options_json":[{"key":"A","label":"채권 가격 하락"}],
+                  "correct_answer_json":{"key":"A"},
+                  "explanation":"해설"
+                }
+                """);
+        return answer;
+    }
+}

--- a/src/test/java/org/firstfolio/quiz/service/QuizAnswerGradingServiceTest.java
+++ b/src/test/java/org/firstfolio/quiz/service/QuizAnswerGradingServiceTest.java
@@ -1,0 +1,246 @@
+package org.firstfolio.quiz.service;
+
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.quiz.domain.QuizAnswer;
+import org.firstfolio.quiz.domain.QuizAnswerGradingResult;
+import org.firstfolio.quiz.domain.QuizAttempt;
+import org.firstfolio.quiz.domain.QuizAttemptStatus;
+import org.firstfolio.quiz.domain.QuizGenerationType;
+import org.firstfolio.quiz.domain.QuizType;
+import org.firstfolio.quiz.mapper.QuizAttemptMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class QuizAnswerGradingServiceTest {
+
+    private static final long USER_ID = 11L;
+    private static final long ATTEMPT_ID = 3001L;
+    private static final long QUESTION_ID = 1001L;
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 8, 11, 1, 30);
+
+    private QuizAttemptMapper quizAttemptMapper;
+    private QuizAnswerGradingService service;
+
+    @BeforeEach
+    void setUp() {
+        quizAttemptMapper = mock(QuizAttemptMapper.class);
+        service = new QuizAnswerGradingService(
+                quizAttemptMapper,
+                Clock.fixed(
+                        Instant.parse("2026-08-11T01:30:00Z"),
+                        ZoneOffset.UTC
+                )
+        );
+    }
+
+    @Test
+    void gradesFirstAnswerFromSnapshotAndStoresNormalizedKey() {
+        arrange(inProgressAttempt(3), unanswered());
+        when(quizAttemptMapper.gradeAnswerIfUnanswered(any())).thenReturn(1);
+        when(quizAttemptMapper.countAnsweredByAttemptId(ATTEMPT_ID)).thenReturn(1);
+
+        QuizAnswerGradingResult result = service.grade(
+                USER_ID,
+                ATTEMPT_ID,
+                QUESTION_ID,
+                " B "
+        );
+
+        assertEquals(QuizGenerationType.HUMAN, result.generationType());
+        assertEquals("B", result.selectedKey());
+        assertFalse(result.correct());
+        assertEquals("C", result.correctKey());
+        assertEquals("정기예금 해설", result.explanation());
+        assertEquals(QuizAttemptStatus.IN_PROGRESS, result.attemptStatus());
+        assertEquals(1, result.answeredCount());
+        assertEquals(3, result.totalCount());
+        assertFalse(result.allAnswered());
+
+        ArgumentCaptor<QuizAnswer> captor = ArgumentCaptor.forClass(QuizAnswer.class);
+        verify(quizAttemptMapper).gradeAnswerIfUnanswered(captor.capture());
+        assertEquals("{\"key\":\"B\"}", captor.getValue().getUserAnswerJson());
+        assertFalse(captor.getValue().getCorrect());
+        assertEquals(NOW, captor.getValue().getAnsweredAt());
+    }
+
+    @Test
+    void returnsExistingResultForSameAnswerEvenAfterAttemptWasGraded() {
+        QuizAttempt gradedAttempt = inProgressAttempt(3);
+        gradedAttempt.setStatus(QuizAttemptStatus.GRADED);
+        QuizAnswer answered = unanswered();
+        answered.setUserAnswerJson("{\"key\":\"B\"}");
+        answered.setCorrect(false);
+        answered.setAnsweredAt(NOW.minusMinutes(1));
+        arrange(gradedAttempt, answered);
+        when(quizAttemptMapper.countAnsweredByAttemptId(ATTEMPT_ID)).thenReturn(3);
+
+        QuizAnswerGradingResult result = service.grade(
+                USER_ID,
+                ATTEMPT_ID,
+                QUESTION_ID,
+                "B"
+        );
+
+        assertEquals(QuizAttemptStatus.GRADED, result.attemptStatus());
+        assertEquals(3, result.answeredCount());
+        assertTrue(result.allAnswered());
+        verify(quizAttemptMapper, never()).gradeAnswerIfUnanswered(any());
+    }
+
+    @Test
+    void rejectsChangingAnAlreadySubmittedAnswerBeforeAttemptStatusCheck() {
+        QuizAttempt gradedAttempt = inProgressAttempt(3);
+        gradedAttempt.setStatus(QuizAttemptStatus.GRADED);
+        QuizAnswer answered = unanswered();
+        answered.setUserAnswerJson("{\"key\":\"B\"}");
+        answered.setCorrect(false);
+        arrange(gradedAttempt, answered);
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.grade(USER_ID, ATTEMPT_ID, QUESTION_ID, "C")
+        );
+
+        assertEquals(ErrorCode.ANSWER_ALREADY_SUBMITTED, exception.getErrorCode());
+        verify(quizAttemptMapper, never()).gradeAnswerIfUnanswered(any());
+    }
+
+    @Test
+    void rejectsUnansweredQuestionWhenAttemptAlreadyEnded() {
+        QuizAttempt gradedAttempt = inProgressAttempt(3);
+        gradedAttempt.setStatus(QuizAttemptStatus.GRADED);
+        arrange(gradedAttempt, unanswered());
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.grade(USER_ID, ATTEMPT_ID, QUESTION_ID, "B")
+        );
+
+        assertEquals(ErrorCode.ATTEMPT_ALREADY_GRADED, exception.getErrorCode());
+    }
+
+    @Test
+    void rejectsKeyThatDoesNotExistInSnapshotOptions() {
+        arrange(inProgressAttempt(3), unanswered());
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.grade(USER_ID, ATTEMPT_ID, QUESTION_ID, "D")
+        );
+
+        assertEquals(ErrorCode.INVALID_SELECTED_CHOICE, exception.getErrorCode());
+        verify(quizAttemptMapper, never()).gradeAnswerIfUnanswered(any());
+    }
+
+    @Test
+    void keepsAttemptInProgressWhenAllAnswersAreStoredInThisPhase() {
+        arrange(inProgressAttempt(3), unanswered());
+        when(quizAttemptMapper.gradeAnswerIfUnanswered(any())).thenReturn(1);
+        when(quizAttemptMapper.countAnsweredByAttemptId(ATTEMPT_ID)).thenReturn(3);
+
+        QuizAnswerGradingResult result = service.grade(
+                USER_ID,
+                ATTEMPT_ID,
+                QUESTION_ID,
+                "C"
+        );
+
+        assertTrue(result.correct());
+        assertTrue(result.allAnswered());
+        assertEquals(QuizAttemptStatus.IN_PROGRESS, result.attemptStatus());
+    }
+
+    @Test
+    void validatesAttemptOwnershipBeforeLookingUpQuestion() {
+        QuizAttempt attempt = inProgressAttempt(3);
+        attempt.setUserId(99L);
+        when(quizAttemptMapper.findByIdForUpdate(ATTEMPT_ID)).thenReturn(attempt);
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.grade(USER_ID, ATTEMPT_ID, QUESTION_ID, "B")
+        );
+
+        assertEquals(ErrorCode.QUIZ_ATTEMPT_FORBIDDEN, exception.getErrorCode());
+        verify(quizAttemptMapper, never())
+                .findAnswerByAttemptIdAndQuestionIdForUpdate(ATTEMPT_ID, QUESTION_ID);
+    }
+
+    @Test
+    void returnsNotFoundForMissingAttemptAndMissingQuestion() {
+        ApiException missingAttempt = assertThrows(
+                ApiException.class,
+                () -> service.grade(USER_ID, ATTEMPT_ID, QUESTION_ID, "B")
+        );
+        assertEquals(ErrorCode.QUIZ_ATTEMPT_NOT_FOUND, missingAttempt.getErrorCode());
+
+        when(quizAttemptMapper.findByIdForUpdate(ATTEMPT_ID))
+                .thenReturn(inProgressAttempt(3));
+        ApiException missingQuestion = assertThrows(
+                ApiException.class,
+                () -> service.grade(USER_ID, ATTEMPT_ID, QUESTION_ID, "B")
+        );
+        assertEquals(ErrorCode.QUESTION_NOT_IN_ATTEMPT, missingQuestion.getErrorCode());
+    }
+
+    private void arrange(QuizAttempt attempt, QuizAnswer answer) {
+        when(quizAttemptMapper.findByIdForUpdate(ATTEMPT_ID)).thenReturn(attempt);
+        when(quizAttemptMapper.findAnswerByAttemptIdAndQuestionIdForUpdate(
+                ATTEMPT_ID,
+                QUESTION_ID
+        )).thenReturn(answer);
+    }
+
+    private QuizAttempt inProgressAttempt(int totalCount) {
+        QuizAttempt attempt = new QuizAttempt();
+        attempt.setAttemptId(ATTEMPT_ID);
+        attempt.setUserId(USER_ID);
+        attempt.setQuizType(QuizType.SUB_CHAPTER);
+        attempt.setSubChapterId(101L);
+        attempt.setContentVersionId(301L);
+        attempt.setAttemptNo(1);
+        attempt.setStatus(QuizAttemptStatus.IN_PROGRESS);
+        attempt.setTotalCount(totalCount);
+        return attempt;
+    }
+
+    private QuizAnswer unanswered() {
+        QuizAnswer answer = new QuizAnswer();
+        answer.setQuizAnswerId(5001L);
+        answer.setAttemptId(ATTEMPT_ID);
+        answer.setQuestionId(QUESTION_ID);
+        answer.setDisplayOrder(1);
+        answer.setQuestionSnapshotJson("""
+                {
+                  "question_type": "SINGLE_CHOICE",
+                  "generation_type": "HUMAN",
+                  "prompt": "정기예금에 대한 설명으로 알맞은 것은?",
+                  "scenario_json": null,
+                  "options_json": [
+                    {"key":"B","label":"선택지 B"},
+                    {"key":"C","label":"선택지 C"}
+                  ],
+                  "correct_answer_json": {"key":"C"},
+                  "explanation": "정기예금 해설"
+                }
+                """);
+        return answer;
+    }
+}

--- a/src/test/java/org/firstfolio/quiz/service/QuizAnswerGradingServiceTest.java
+++ b/src/test/java/org/firstfolio/quiz/service/QuizAnswerGradingServiceTest.java
@@ -1,7 +1,10 @@
 package org.firstfolio.quiz.service;
 
+import org.firstfolio.curriculum.domain.ChapterType;
 import org.firstfolio.exception.ApiException;
 import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.learning.domain.MainChapterCompletionResult;
+import org.firstfolio.learning.service.MainChapterCompletionService;
 import org.firstfolio.quiz.domain.QuizAnswer;
 import org.firstfolio.quiz.domain.QuizAnswerGradingResult;
 import org.firstfolio.quiz.domain.QuizAttempt;
@@ -39,19 +42,22 @@ class QuizAnswerGradingServiceTest {
 
     private QuizAttemptMapper quizAttemptMapper;
     private QuizRewardService quizRewardService;
+    private MainChapterCompletionService mainChapterCompletionService;
     private QuizAnswerGradingService service;
 
     @BeforeEach
     void setUp() {
         quizAttemptMapper = mock(QuizAttemptMapper.class);
         quizRewardService = mock(QuizRewardService.class);
+        mainChapterCompletionService = mock(MainChapterCompletionService.class);
         service = new QuizAnswerGradingService(
                 quizAttemptMapper,
                 Clock.fixed(
                         Instant.parse("2026-08-11T01:30:00Z"),
                         ZoneOffset.UTC
                 ),
-                quizRewardService
+                quizRewardService,
+                mainChapterCompletionService
         );
     }
 
@@ -93,6 +99,7 @@ class QuizAnswerGradingServiceTest {
         gradedAttempt.setScore(67);
         gradedAttempt.setRewardPolicyId(91L);
         gradedAttempt.setPointTransactionId(7001L);
+        gradedAttempt.setSubmittedAt(NOW);
         QuizAnswer answered = unanswered();
         answered.setUserAnswerJson("{\"key\":\"B\"}");
         answered.setCorrect(false);
@@ -233,6 +240,49 @@ class QuizAnswerGradingServiceTest {
 
         assertEquals(ErrorCode.INTERNAL_ERROR, exception.getErrorCode());
         verify(quizAttemptMapper, never()).completeAttemptIfInProgress(any());
+    }
+
+    @Test
+    void completesMainChapterAfterAllAnswersRegardlessOfScore() {
+        QuizAttempt attempt = inProgressAttempt(1);
+        attempt.setQuizType(QuizType.MAIN_CHAPTER);
+        attempt.setMainChapterId(10L);
+        attempt.setSubChapterId(null);
+        attempt.setContentVersionId(null);
+        arrange(attempt, unanswered());
+        when(quizAttemptMapper.gradeAnswerIfUnanswered(any())).thenReturn(1);
+        when(quizAttemptMapper.countAnsweredByAttemptId(ATTEMPT_ID)).thenReturn(1);
+        when(quizAttemptMapper.countCorrectByAttemptId(ATTEMPT_ID)).thenReturn(0);
+        when(quizRewardService.grantForCompletedAttempt(
+                USER_ID,
+                ATTEMPT_ID,
+                1,
+                0,
+                NOW
+        )).thenReturn(new QuizRewardResult(91L, 0, null));
+        MainChapterCompletionResult completion =
+                new MainChapterCompletionResult(
+                        ChapterType.ASSET,
+                        true,
+                        null
+                );
+        when(mainChapterCompletionService.complete(USER_ID, 10L, NOW))
+                .thenReturn(completion);
+        when(quizAttemptMapper.completeAttemptIfInProgress(any())).thenReturn(1);
+
+        QuizAnswerGradingResult result = service.grade(
+                USER_ID,
+                ATTEMPT_ID,
+                QUESTION_ID,
+                "B"
+        );
+
+        assertFalse(result.correct());
+        assertEquals(0, result.correctCount());
+        assertEquals(0, result.score());
+        assertEquals(completion, result.mainChapterCompletion());
+        assertEquals("NEXT_MAIN_CHAPTER", result.nextAction());
+        verify(mainChapterCompletionService).complete(USER_ID, 10L, NOW);
     }
 
     @Test

--- a/src/test/java/org/firstfolio/quiz/service/QuizAnswerGradingServiceTest.java
+++ b/src/test/java/org/firstfolio/quiz/service/QuizAnswerGradingServiceTest.java
@@ -9,6 +9,8 @@ import org.firstfolio.quiz.domain.QuizAttemptStatus;
 import org.firstfolio.quiz.domain.QuizGenerationType;
 import org.firstfolio.quiz.domain.QuizType;
 import org.firstfolio.quiz.mapper.QuizAttemptMapper;
+import org.firstfolio.reward.domain.QuizRewardResult;
+import org.firstfolio.reward.service.QuizRewardService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -36,17 +38,20 @@ class QuizAnswerGradingServiceTest {
     private static final LocalDateTime NOW = LocalDateTime.of(2026, 8, 11, 1, 30);
 
     private QuizAttemptMapper quizAttemptMapper;
+    private QuizRewardService quizRewardService;
     private QuizAnswerGradingService service;
 
     @BeforeEach
     void setUp() {
         quizAttemptMapper = mock(QuizAttemptMapper.class);
+        quizRewardService = mock(QuizRewardService.class);
         service = new QuizAnswerGradingService(
                 quizAttemptMapper,
                 Clock.fixed(
                         Instant.parse("2026-08-11T01:30:00Z"),
                         ZoneOffset.UTC
-                )
+                ),
+                quizRewardService
         );
     }
 
@@ -84,12 +89,18 @@ class QuizAnswerGradingServiceTest {
     void returnsExistingResultForSameAnswerEvenAfterAttemptWasGraded() {
         QuizAttempt gradedAttempt = inProgressAttempt(3);
         gradedAttempt.setStatus(QuizAttemptStatus.GRADED);
+        gradedAttempt.setCorrectCount(2);
+        gradedAttempt.setScore(67);
+        gradedAttempt.setRewardPolicyId(91L);
+        gradedAttempt.setPointTransactionId(7001L);
         QuizAnswer answered = unanswered();
         answered.setUserAnswerJson("{\"key\":\"B\"}");
         answered.setCorrect(false);
         answered.setAnsweredAt(NOW.minusMinutes(1));
         arrange(gradedAttempt, answered);
         when(quizAttemptMapper.countAnsweredByAttemptId(ATTEMPT_ID)).thenReturn(3);
+        when(quizRewardService.restore(USER_ID, ATTEMPT_ID, 91L, 7001L))
+                .thenReturn(new QuizRewardResult(91L, 200, 7001L));
 
         QuizAnswerGradingResult result = service.grade(
                 USER_ID,
@@ -101,6 +112,10 @@ class QuizAnswerGradingServiceTest {
         assertEquals(QuizAttemptStatus.GRADED, result.attemptStatus());
         assertEquals(3, result.answeredCount());
         assertTrue(result.allAnswered());
+        assertEquals(2, result.correctCount());
+        assertEquals(67, result.score());
+        assertEquals(200, result.reward().points());
+        assertEquals("NEXT_SUB_CHAPTER", result.nextAction());
         verify(quizAttemptMapper, never()).gradeAnswerIfUnanswered(any());
     }
 
@@ -150,10 +165,19 @@ class QuizAnswerGradingServiceTest {
     }
 
     @Test
-    void keepsAttemptInProgressWhenAllAnswersAreStoredInThisPhase() {
+    void completesAttemptAndGrantsRewardWhenLastAnswerIsStored() {
         arrange(inProgressAttempt(3), unanswered());
         when(quizAttemptMapper.gradeAnswerIfUnanswered(any())).thenReturn(1);
         when(quizAttemptMapper.countAnsweredByAttemptId(ATTEMPT_ID)).thenReturn(3);
+        when(quizAttemptMapper.countCorrectByAttemptId(ATTEMPT_ID)).thenReturn(2);
+        when(quizRewardService.grantForCompletedAttempt(
+                USER_ID,
+                ATTEMPT_ID,
+                1,
+                2,
+                NOW
+        )).thenReturn(new QuizRewardResult(91L, 200, 7001L));
+        when(quizAttemptMapper.completeAttemptIfInProgress(any())).thenReturn(1);
 
         QuizAnswerGradingResult result = service.grade(
                 USER_ID,
@@ -164,7 +188,51 @@ class QuizAnswerGradingServiceTest {
 
         assertTrue(result.correct());
         assertTrue(result.allAnswered());
-        assertEquals(QuizAttemptStatus.IN_PROGRESS, result.attemptStatus());
+        assertEquals(QuizAttemptStatus.GRADED, result.attemptStatus());
+        assertEquals(2, result.correctCount());
+        assertEquals(67, result.score());
+        assertEquals(200, result.reward().points());
+        assertEquals(7001L, result.reward().pointTransactionId());
+        assertEquals("NEXT_SUB_CHAPTER", result.nextAction());
+
+        ArgumentCaptor<QuizAttempt> captor = ArgumentCaptor.forClass(
+                QuizAttempt.class
+        );
+        verify(quizAttemptMapper).completeAttemptIfInProgress(captor.capture());
+        assertEquals(QuizAttemptStatus.GRADED, captor.getValue().getStatus());
+        assertEquals(2, captor.getValue().getCorrectCount());
+        assertEquals(67, captor.getValue().getScore());
+        assertEquals(91L, captor.getValue().getRewardPolicyId());
+        assertEquals(7001L, captor.getValue().getPointTransactionId());
+        assertEquals(NOW, captor.getValue().getSubmittedAt());
+    }
+
+    @Test
+    void doesNotCompleteAttemptWhenRewardProcessingFails() {
+        arrange(inProgressAttempt(3), unanswered());
+        when(quizAttemptMapper.gradeAnswerIfUnanswered(any())).thenReturn(1);
+        when(quizAttemptMapper.countAnsweredByAttemptId(ATTEMPT_ID)).thenReturn(3);
+        when(quizAttemptMapper.countCorrectByAttemptId(ATTEMPT_ID)).thenReturn(2);
+        when(quizRewardService.grantForCompletedAttempt(
+                USER_ID,
+                ATTEMPT_ID,
+                1,
+                2,
+                NOW
+        )).thenThrow(new ApiException(ErrorCode.INTERNAL_ERROR));
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.grade(
+                        USER_ID,
+                        ATTEMPT_ID,
+                        QUESTION_ID,
+                        "C"
+                )
+        );
+
+        assertEquals(ErrorCode.INTERNAL_ERROR, exception.getErrorCode());
+        verify(quizAttemptMapper, never()).completeAttemptIfInProgress(any());
     }
 
     @Test

--- a/src/test/java/org/firstfolio/quiz/service/QuizAttemptStartServiceTest.java
+++ b/src/test/java/org/firstfolio/quiz/service/QuizAttemptStartServiceTest.java
@@ -1,0 +1,338 @@
+package org.firstfolio.quiz.service;
+
+import org.firstfolio.content.domain.ContentVersion;
+import org.firstfolio.content.domain.ContentVersionStatus;
+import org.firstfolio.content.domain.StoredContent;
+import org.firstfolio.content.mapper.ContentVersionMapper;
+import org.firstfolio.content.service.StaticContentStorage;
+import org.firstfolio.curriculum.domain.SubChapter;
+import org.firstfolio.curriculum.mapper.SubChapterMapper;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.learning.domain.LearningProgress;
+import org.firstfolio.learning.domain.LearningProgressStatus;
+import org.firstfolio.learning.mapper.LearningProgressMapper;
+import org.firstfolio.quiz.domain.QuizAnswer;
+import org.firstfolio.quiz.domain.QuizAttempt;
+import org.firstfolio.quiz.domain.QuizAttemptStartResult;
+import org.firstfolio.quiz.domain.QuizAttemptStatus;
+import org.firstfolio.quiz.domain.QuizGenerationType;
+import org.firstfolio.quiz.domain.QuizQuestion;
+import org.firstfolio.quiz.domain.QuizQuestionStatus;
+import org.firstfolio.quiz.domain.QuizQuestionType;
+import org.firstfolio.quiz.domain.QuizType;
+import org.firstfolio.quiz.domain.QuizUsageType;
+import org.firstfolio.quiz.mapper.QuizAttemptMapper;
+import org.firstfolio.quiz.mapper.QuizQuestionMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class QuizAttemptStartServiceTest {
+
+    private static final long USER_ID = 11L;
+    private static final long SUB_CHAPTER_ID = 101L;
+    private static final long CONTENT_VERSION_ID = 301L;
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 8, 10, 6, 0);
+
+    private QuizAttemptMapper quizAttemptMapper;
+    private QuizQuestionMapper quizQuestionMapper;
+    private LearningProgressMapper learningProgressMapper;
+    private ContentVersionMapper contentVersionMapper;
+    private SubChapterMapper subChapterMapper;
+    private StaticContentStorage contentStorage;
+    private QuizAttemptStartService service;
+
+    @BeforeEach
+    void setUp() {
+        quizAttemptMapper = mock(QuizAttemptMapper.class);
+        quizQuestionMapper = mock(QuizQuestionMapper.class);
+        learningProgressMapper = mock(LearningProgressMapper.class);
+        contentVersionMapper = mock(ContentVersionMapper.class);
+        subChapterMapper = mock(SubChapterMapper.class);
+        contentStorage = mock(StaticContentStorage.class);
+        Clock clock = Clock.fixed(
+                Instant.parse("2026-08-10T06:00:00Z"),
+                ZoneOffset.UTC
+        );
+
+        service = new QuizAttemptStartService(
+                quizAttemptMapper,
+                quizQuestionMapper,
+                learningProgressMapper,
+                contentVersionMapper,
+                subChapterMapper,
+                contentStorage,
+                clock
+        );
+        when(subChapterMapper.findById(SUB_CHAPTER_ID))
+                .thenReturn(activeSubChapter());
+    }
+
+    @Test
+    void createsAttemptAndQuestionSnapshotsFromLearnedContentVersion() {
+        when(learningProgressMapper.findByUserIdAndSubChapterIdForUpdate(
+                USER_ID, SUB_CHAPTER_ID
+        )).thenReturn(completedProgress());
+        when(quizAttemptMapper.findInProgressByUserIdAndSubChapterIdForUpdate(
+                USER_ID, SUB_CHAPTER_ID
+        )).thenReturn(null);
+        when(contentVersionMapper.findById(CONTENT_VERSION_ID))
+                .thenReturn(contentVersion());
+        when(contentStorage.load(any())).thenReturn(lessonContent());
+        when(quizQuestionMapper.findAllByIds(List.of(1001L, 1002L)))
+                .thenReturn(List.of(
+                        question(1002L, QuizQuestionType.TRUE_FALSE),
+                        question(1001L, QuizQuestionType.SINGLE_CHOICE)
+                ));
+        when(quizAttemptMapper.findMaxAttemptNoByUserIdAndSubChapterId(
+                USER_ID, SUB_CHAPTER_ID
+        )).thenReturn(1);
+        when(quizAttemptMapper.insertAttempt(any())).thenAnswer(invocation -> {
+            QuizAttempt attempt = invocation.getArgument(0);
+            attempt.setAttemptId(3001L);
+            return 1;
+        });
+        when(quizAttemptMapper.insertAnswer(any())).thenReturn(1);
+
+        QuizAttemptStartResult result = service.start(USER_ID, SUB_CHAPTER_ID);
+
+        assertEquals(3001L, result.attempt().getAttemptId());
+        assertEquals(QuizType.SUB_CHAPTER, result.attempt().getQuizType());
+        assertEquals(2, result.attempt().getAttemptNo());
+        assertEquals(QuizAttemptStatus.IN_PROGRESS, result.attempt().getStatus());
+        assertEquals(2, result.attempt().getTotalCount());
+        assertEquals(List.of(1001L, 1002L), result.questions().stream()
+                .map(question -> question.questionId())
+                .toList());
+        assertEquals(List.of(1, 2), result.questions().stream()
+                .map(question -> question.displayOrder())
+                .toList());
+        assertEquals("1", result.questions().get(0).choices().get(0).id());
+        assertEquals("선택지 1", result.questions().get(0).choices().get(0).text());
+        assertNull(result.questions().get(0).scenario());
+
+        ArgumentCaptor<QuizAnswer> answerCaptor =
+                ArgumentCaptor.forClass(QuizAnswer.class);
+        verify(quizAttemptMapper, org.mockito.Mockito.times(2))
+                .insertAnswer(answerCaptor.capture());
+        QuizAnswer firstAnswer = answerCaptor.getAllValues().get(0);
+        assertEquals(3001L, firstAnswer.getAttemptId());
+        assertEquals(1001L, firstAnswer.getQuestionId());
+        assertTrue(firstAnswer.getQuestionSnapshotJson().contains(
+                "\"correct_answer_json\""
+        ));
+        assertTrue(firstAnswer.getQuestionSnapshotJson().contains(
+                "\"explanation\""
+        ));
+        assertNull(firstAnswer.getUserAnswerJson());
+        assertNull(firstAnswer.getCorrect());
+        assertNull(firstAnswer.getAnsweredAt());
+        assertEquals(NOW, firstAnswer.getCreatedAt());
+    }
+
+    @Test
+    void restoresInProgressAttemptFromStoredSnapshots() {
+        when(learningProgressMapper.findByUserIdAndSubChapterIdForUpdate(
+                USER_ID, SUB_CHAPTER_ID
+        )).thenReturn(completedProgress());
+        QuizAttempt attempt = inProgressAttempt();
+        when(quizAttemptMapper.findInProgressByUserIdAndSubChapterIdForUpdate(
+                USER_ID, SUB_CHAPTER_ID
+        )).thenReturn(attempt);
+        when(quizAttemptMapper.findAnswersByAttemptId(3001L))
+                .thenReturn(List.of(snapshotAnswer()));
+
+        QuizAttemptStartResult result = service.start(USER_ID, SUB_CHAPTER_ID);
+
+        assertEquals(3001L, result.attempt().getAttemptId());
+        assertEquals(1, result.questions().size());
+        assertEquals("복원된 문제", result.questions().get(0).prompt());
+        assertEquals(QuizGenerationType.HUMAN,
+                result.questions().get(0).generationType());
+        verify(contentStorage, never()).load(any());
+        verify(quizAttemptMapper, never()).insertAttempt(any());
+        verify(quizAttemptMapper, never()).insertAnswer(any());
+    }
+
+    @Test
+    void rejectsStartBeforeLessonCompletion() {
+        LearningProgress progress = completedProgress();
+        progress.setStatus(LearningProgressStatus.IN_PROGRESS);
+        when(learningProgressMapper.findByUserIdAndSubChapterIdForUpdate(
+                USER_ID, SUB_CHAPTER_ID
+        )).thenReturn(progress);
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.start(USER_ID, SUB_CHAPTER_ID)
+        );
+
+        assertEquals(ErrorCode.QUIZ_NOT_AVAILABLE, exception.getErrorCode());
+        verify(quizAttemptMapper, never())
+                .findInProgressByUserIdAndSubChapterIdForUpdate(anyLong(), anyLong());
+    }
+
+    @Test
+    void rejectsQuestionThatIsNoLongerPublished() {
+        arrangeNewAttempt();
+        QuizQuestion retired = question(1001L, QuizQuestionType.SINGLE_CHOICE);
+        retired.setStatus(QuizQuestionStatus.RETIRED);
+        when(quizQuestionMapper.findAllByIds(List.of(1001L, 1002L)))
+                .thenReturn(List.of(
+                        retired,
+                        question(1002L, QuizQuestionType.TRUE_FALSE)
+                ));
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.start(USER_ID, SUB_CHAPTER_ID)
+        );
+
+        assertEquals(ErrorCode.QUIZ_NOT_AVAILABLE, exception.getErrorCode());
+        verify(quizAttemptMapper, never()).insertAttempt(any());
+    }
+
+    @Test
+    void rejectsInactiveSubChapterWithoutLookingUpProgress() {
+        SubChapter inactive = activeSubChapter();
+        inactive.setActive(false);
+        when(subChapterMapper.findById(SUB_CHAPTER_ID)).thenReturn(inactive);
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.start(USER_ID, SUB_CHAPTER_ID)
+        );
+
+        assertEquals(ErrorCode.QUIZ_NOT_AVAILABLE, exception.getErrorCode());
+        verify(learningProgressMapper, never())
+                .findByUserIdAndSubChapterIdForUpdate(anyLong(), anyLong());
+    }
+
+    private void arrangeNewAttempt() {
+        when(learningProgressMapper.findByUserIdAndSubChapterIdForUpdate(
+                USER_ID, SUB_CHAPTER_ID
+        )).thenReturn(completedProgress());
+        when(quizAttemptMapper.findInProgressByUserIdAndSubChapterIdForUpdate(
+                USER_ID, SUB_CHAPTER_ID
+        )).thenReturn(null);
+        when(contentVersionMapper.findById(CONTENT_VERSION_ID))
+                .thenReturn(contentVersion());
+        when(contentStorage.load(any())).thenReturn(lessonContent());
+    }
+
+    private SubChapter activeSubChapter() {
+        SubChapter chapter = new SubChapter();
+        chapter.setSubChapterId(SUB_CHAPTER_ID);
+        chapter.setActive(true);
+        return chapter;
+    }
+
+    private LearningProgress completedProgress() {
+        LearningProgress progress = new LearningProgress();
+        progress.setProgressId(901L);
+        progress.setUserId(USER_ID);
+        progress.setSubChapterId(SUB_CHAPTER_ID);
+        progress.setContentVersionId(CONTENT_VERSION_ID);
+        progress.setStatus(LearningProgressStatus.COMPLETED);
+        return progress;
+    }
+
+    private ContentVersion contentVersion() {
+        ContentVersion version = new ContentVersion();
+        version.setContentVersionId(CONTENT_VERSION_ID);
+        version.setSubChapterId(SUB_CHAPTER_ID);
+        version.setSchemaVersion("1.0");
+        version.setStorageObjectKey("learning/sub-chapters/101/lesson.json");
+        version.setStorageVersionId("version-301");
+        version.setStatus(ContentVersionStatus.PUBLISHED);
+        return version;
+    }
+
+    private StoredContent lessonContent() {
+        return new StoredContent("""
+                {
+                  "schemaVersion": "1.0",
+                  "subChapterQuiz": {
+                    "questionIds": [1001, 1002]
+                  }
+                }
+                """.getBytes(StandardCharsets.UTF_8), "application/json");
+    }
+
+    private QuizQuestion question(long id, QuizQuestionType type) {
+        QuizQuestion question = new QuizQuestion();
+        question.setQuestionId(id);
+        question.setUsageType(QuizUsageType.SUB_CHAPTER);
+        question.setSubChapterId(SUB_CHAPTER_ID);
+        question.setQuestionType(type);
+        question.setGenerationType(QuizGenerationType.HUMAN);
+        question.setPrompt("문제 " + id);
+        question.setScenarioJson(null);
+        question.setOptionsJson("""
+                [
+                  {"key":"1","label":"선택지 1"},
+                  {"key":"2","label":"선택지 2"}
+                ]
+                """);
+        question.setCorrectAnswerJson("{\"key\":\"1\"}");
+        question.setExplanation("정답 해설");
+        question.setStatus(QuizQuestionStatus.PUBLISHED);
+        return question;
+    }
+
+    private QuizAttempt inProgressAttempt() {
+        QuizAttempt attempt = new QuizAttempt();
+        attempt.setAttemptId(3001L);
+        attempt.setUserId(USER_ID);
+        attempt.setQuizType(QuizType.SUB_CHAPTER);
+        attempt.setSubChapterId(SUB_CHAPTER_ID);
+        attempt.setContentVersionId(CONTENT_VERSION_ID);
+        attempt.setAttemptNo(1);
+        attempt.setStatus(QuizAttemptStatus.IN_PROGRESS);
+        attempt.setTotalCount(1);
+        attempt.setStartedAt(NOW);
+        return attempt;
+    }
+
+    private QuizAnswer snapshotAnswer() {
+        QuizAnswer answer = new QuizAnswer();
+        answer.setQuizAnswerId(5001L);
+        answer.setAttemptId(3001L);
+        answer.setQuestionId(1001L);
+        answer.setDisplayOrder(1);
+        answer.setQuestionSnapshotJson("""
+                {
+                  "question_type": "SINGLE_CHOICE",
+                  "generation_type": "HUMAN",
+                  "prompt": "복원된 문제",
+                  "scenario_json": null,
+                  "options_json": [
+                    {"key":"1","label":"선택지 1"},
+                    {"key":"2","label":"선택지 2"}
+                  ],
+                  "correct_answer_json": {"key":"1"},
+                  "explanation": "정답 해설"
+                }
+                """);
+        return answer;
+    }
+}

--- a/src/test/java/org/firstfolio/quiz/service/QuizQuestionRegistrationServiceTest.java
+++ b/src/test/java/org/firstfolio/quiz/service/QuizQuestionRegistrationServiceTest.java
@@ -1,0 +1,433 @@
+package org.firstfolio.quiz.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.firstfolio.curriculum.domain.AssetType;
+import org.firstfolio.curriculum.domain.ChapterType;
+import org.firstfolio.curriculum.domain.MainChapter;
+import org.firstfolio.curriculum.domain.SubChapter;
+import org.firstfolio.curriculum.mapper.AdminAuditLogMapper;
+import org.firstfolio.curriculum.mapper.MainChapterMapper;
+import org.firstfolio.curriculum.mapper.SubChapterMapper;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.quiz.domain.QuizDifficulty;
+import org.firstfolio.quiz.domain.QuizGenerationType;
+import org.firstfolio.quiz.domain.QuizQuestion;
+import org.firstfolio.quiz.domain.QuizQuestionStatus;
+import org.firstfolio.quiz.domain.QuizQuestionType;
+import org.firstfolio.quiz.domain.QuizUsageType;
+import org.firstfolio.quiz.dto.request.QuizQuestionCreateRequest;
+import org.firstfolio.quiz.dto.request.QuizQuestionVersionCreateRequest;
+import org.firstfolio.quiz.mapper.QuizQuestionMapper;
+import org.firstfolio.quiz.validation.QuizQuestionSchemaValidator;
+import org.firstfolio.quiz.validation.QuizQuestionValidationError;
+import org.firstfolio.quiz.validation.QuizQuestionValidationErrorCode;
+import org.firstfolio.quiz.validation.QuizQuestionValidationResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.dao.DuplicateKeyException;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class QuizQuestionRegistrationServiceTest {
+
+    private static final long ACTOR_ID = 900L;
+    private static final String REQUEST_ID = "req-quiz-create";
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 8, 10, 6, 0);
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private QuizQuestionSchemaValidator schemaValidator;
+    private QuizQuestionMapper questionMapper;
+    private MainChapterMapper mainChapterMapper;
+    private SubChapterMapper subChapterMapper;
+    private AdminAuditLogMapper auditLogMapper;
+    private QuizQuestionRegistrationService service;
+
+    @BeforeEach
+    void setUp() {
+        schemaValidator = mock(QuizQuestionSchemaValidator.class);
+        questionMapper = mock(QuizQuestionMapper.class);
+        mainChapterMapper = mock(MainChapterMapper.class);
+        subChapterMapper = mock(SubChapterMapper.class);
+        auditLogMapper = mock(AdminAuditLogMapper.class);
+        service = new QuizQuestionRegistrationService(
+                schemaValidator,
+                questionMapper,
+                mainChapterMapper,
+                subChapterMapper,
+                auditLogMapper,
+                Clock.fixed(Instant.parse("2026-08-10T06:00:00Z"), ZoneOffset.UTC)
+        );
+        when(schemaValidator.validate(any())).thenReturn(QuizQuestionValidationResult.valid());
+        doAnswer(invocation -> {
+            QuizQuestion question = invocation.getArgument(0);
+            question.setQuestionId(1201L);
+            return 1;
+        }).when(questionMapper).insert(any(QuizQuestion.class));
+    }
+
+    @Test
+    void createsFirstHumanDraftAndResolvesMainChapterFromSubChapter() throws Exception {
+        SubChapter subChapter = subChapter(101L, 2L);
+        MainChapter mainChapter = mainChapter(2L, ChapterType.ASSET);
+        when(subChapterMapper.findById(101L)).thenReturn(subChapter);
+        when(mainChapterMapper.findById(2L)).thenReturn(mainChapter);
+
+        QuizQuestion created = service.createQuestion(
+                subChapterRequest(),
+                ACTOR_ID,
+                REQUEST_ID
+        );
+
+        assertEquals(1201L, created.getQuestionId());
+        assertEquals("deposit-basic-001", created.getQuestionKey());
+        assertEquals(1, created.getVersionNo());
+        assertEquals(QuizGenerationType.HUMAN, created.getGenerationType());
+        assertEquals(QuizQuestionStatus.DRAFT, created.getStatus());
+        assertEquals(2L, created.getMainChapterId());
+        assertEquals(101L, created.getSubChapterId());
+        assertNull(created.getSourceRefsJson());
+        assertNull(created.getPublishedAt());
+        assertEquals(NOW, created.getCreatedAt());
+
+        ArgumentCaptor<byte[]> validationContent = ArgumentCaptor.forClass(byte[].class);
+        verify(schemaValidator).validate(validationContent.capture());
+        JsonNode validated = objectMapper.readTree(new String(
+                validationContent.getValue(),
+                StandardCharsets.UTF_8
+        ));
+        assertEquals("HUMAN", validated.path("generation_type").textValue());
+        assertEquals(true, validated.path("source_refs_json").isNull());
+
+        verify(auditLogMapper).insert(
+                eq(ACTOR_ID),
+                eq("CREATE"),
+                eq("QUIZ_QUESTION"),
+                eq(1201L),
+                isNull(),
+                anyString(),
+                eq(REQUEST_ID),
+                eq(NOW)
+        );
+    }
+
+    @Test
+    void rejectsSchemaFailureBeforeCheckingDatabaseReferences() throws Exception {
+        when(schemaValidator.validate(any())).thenReturn(
+                QuizQuestionValidationResult.invalid(new QuizQuestionValidationError(
+                        QuizQuestionValidationErrorCode.CORRECT_OPTION_NOT_FOUND,
+                        "/correct_answer_json/key",
+                        "정답 key가 선택지에 없습니다."
+                ))
+        );
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.createQuestion(subChapterRequest(), ACTOR_ID, REQUEST_ID)
+        );
+
+        assertEquals(ErrorCode.QUESTION_VALIDATION_FAILED, exception.getErrorCode());
+        verify(subChapterMapper, never()).findById(anyLong());
+        verify(questionMapper, never()).insert(any());
+    }
+
+    @Test
+    void rejectsExistingQuestionKey() throws Exception {
+        when(questionMapper.countByQuestionKey("deposit-basic-001")).thenReturn(1);
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.createQuestion(subChapterRequest(), ACTOR_ID, REQUEST_ID)
+        );
+
+        assertEquals(ErrorCode.QUESTION_KEY_CONFLICT, exception.getErrorCode());
+        verify(subChapterMapper, never()).findById(anyLong());
+        verify(questionMapper, never()).insert(any());
+    }
+
+    @Test
+    void rejectsMissingOrMismatchedSubChapterReference() throws Exception {
+        when(subChapterMapper.findById(101L)).thenReturn(null);
+        ApiException missing = assertThrows(
+                ApiException.class,
+                () -> service.createQuestion(subChapterRequest(), ACTOR_ID, REQUEST_ID)
+        );
+
+        SubChapter subChapter = subChapter(101L, 3L);
+        when(subChapterMapper.findById(101L)).thenReturn(subChapter);
+        QuizQuestionCreateRequest mismatched = new QuizQuestionCreateRequest(
+                "deposit-basic-002",
+                "SUB_CHAPTER",
+                2L,
+                101L,
+                "SINGLE_CHOICE",
+                "EASY",
+                "질문",
+                null,
+                options(),
+                correctAnswer(),
+                "해설"
+        );
+        ApiException mismatch = assertThrows(
+                ApiException.class,
+                () -> service.createQuestion(mismatched, ACTOR_ID, REQUEST_ID)
+        );
+
+        assertEquals(ErrorCode.QUESTION_VALIDATION_FAILED, missing.getErrorCode());
+        assertEquals(ErrorCode.QUESTION_VALIDATION_FAILED, mismatch.getErrorCode());
+        verify(questionMapper, never()).insert(any());
+    }
+
+    @Test
+    void allowsLevelTestOnlyForAssetMainChapter() throws Exception {
+        QuizQuestionCreateRequest levelTest = new QuizQuestionCreateRequest(
+                "foundation-level-001",
+                "LEVEL_TEST",
+                1L,
+                null,
+                "SINGLE_CHOICE",
+                "EASY",
+                "질문",
+                null,
+                options(),
+                correctAnswer(),
+                "해설"
+        );
+        when(mainChapterMapper.findById(1L))
+                .thenReturn(mainChapter(1L, ChapterType.FOUNDATION));
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.createQuestion(levelTest, ACTOR_ID, REQUEST_ID)
+        );
+
+        assertEquals(ErrorCode.QUESTION_VALIDATION_FAILED, exception.getErrorCode());
+        verify(questionMapper, never()).insert(any());
+    }
+
+    @Test
+    void createsNextDraftVersionAndInheritsImmutableMetadata() throws Exception {
+        QuizQuestion base = humanQuestion(1201L, 1);
+        QuizQuestion latest = humanQuestion(1202L, 2);
+        when(questionMapper.findById(1201L)).thenReturn(base);
+        when(questionMapper.findLatestByQuestionKeyForUpdate("deposit-basic-001"))
+                .thenReturn(latest);
+
+        QuizQuestion created = service.createVersion(
+                1201L,
+                versionRequest(),
+                ACTOR_ID,
+                REQUEST_ID
+        );
+
+        assertEquals(3, created.getVersionNo());
+        assertEquals(base.getQuestionKey(), created.getQuestionKey());
+        assertEquals(base.getUsageType(), created.getUsageType());
+        assertEquals(base.getMainChapterId(), created.getMainChapterId());
+        assertEquals(base.getSubChapterId(), created.getSubChapterId());
+        assertEquals(base.getQuestionType(), created.getQuestionType());
+        assertEquals(base.getDifficulty(), created.getDifficulty());
+        assertEquals(base.getGenerationType(), created.getGenerationType());
+        assertEquals("수정된 질문", created.getPrompt());
+        assertEquals(QuizQuestionStatus.DRAFT, created.getStatus());
+        verify(questionMapper).findLatestByQuestionKeyForUpdate("deposit-basic-001");
+    }
+
+    @Test
+    void keepsAiGenerationTypeAndNewSourceReferencesForNewVersion() throws Exception {
+        QuizQuestion base = humanQuestion(1301L, 1);
+        base.setGenerationType(QuizGenerationType.AI);
+        when(questionMapper.findById(1301L)).thenReturn(base);
+        when(questionMapper.findLatestByQuestionKeyForUpdate(base.getQuestionKey()))
+                .thenReturn(base);
+        JsonNode sources = objectMapper.readTree("""
+                [{
+                  "knowledge_content_id": 9001,
+                  "title": "근거",
+                  "publisher": null,
+                  "url": null,
+                  "reference_at": "2026-08-10T00:00:00Z"
+                }]
+                """);
+        QuizQuestionVersionCreateRequest request = new QuizQuestionVersionCreateRequest(
+                "수정된 질문",
+                null,
+                options(),
+                correctAnswer(),
+                "수정된 해설",
+                sources
+        );
+
+        QuizQuestion created = service.createVersion(
+                1301L,
+                request,
+                ACTOR_ID,
+                REQUEST_ID
+        );
+
+        assertEquals(QuizGenerationType.AI, created.getGenerationType());
+        assertEquals(sources, objectMapper.readTree(created.getSourceRefsJson()));
+    }
+
+    @Test
+    void rejectsVersionForMissingBaseQuestion() throws Exception {
+        when(questionMapper.findById(9999L)).thenReturn(null);
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.createVersion(9999L, versionRequest(), ACTOR_ID, REQUEST_ID)
+        );
+
+        assertEquals(ErrorCode.QUESTION_NOT_FOUND, exception.getErrorCode());
+        verify(questionMapper, never()).findLatestByQuestionKeyForUpdate(anyString());
+    }
+
+    @Test
+    void mapsConcurrentVersionInsertToConflict() throws Exception {
+        QuizQuestion base = humanQuestion(1201L, 1);
+        when(questionMapper.findById(1201L)).thenReturn(base);
+        when(questionMapper.findLatestByQuestionKeyForUpdate(base.getQuestionKey()))
+                .thenReturn(base);
+        doThrow(new DuplicateKeyException("duplicate version"))
+                .when(questionMapper).insert(any(QuizQuestion.class));
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.createVersion(1201L, versionRequest(), ACTOR_ID, REQUEST_ID)
+        );
+
+        assertEquals(ErrorCode.QUESTION_VERSION_CONFLICT, exception.getErrorCode());
+        verify(auditLogMapper, never()).insert(
+                anyLong(), anyString(), anyString(), any(), any(), any(), any(), any()
+        );
+    }
+
+    @Test
+    void rejectsMissingRequestBodyAsInvalidRequest() {
+        ApiException create = assertThrows(
+                ApiException.class,
+                () -> service.createQuestion(null, ACTOR_ID, REQUEST_ID)
+        );
+        ApiException version = assertThrows(
+                ApiException.class,
+                () -> service.createVersion(1201L, null, ACTOR_ID, REQUEST_ID)
+        );
+
+        assertEquals(ErrorCode.INVALID_REQUEST, create.getErrorCode());
+        assertEquals(ErrorCode.INVALID_REQUEST, version.getErrorCode());
+    }
+
+    private QuizQuestionCreateRequest subChapterRequest() throws Exception {
+        return new QuizQuestionCreateRequest(
+                "deposit-basic-001",
+                "SUB_CHAPTER",
+                null,
+                101L,
+                "SINGLE_CHOICE",
+                "EASY",
+                "예금의 특징으로 적절한 것은?",
+                null,
+                options(),
+                correctAnswer(),
+                "정답 해설"
+        );
+    }
+
+    private QuizQuestionVersionCreateRequest versionRequest() throws Exception {
+        return new QuizQuestionVersionCreateRequest(
+                "수정된 질문",
+                null,
+                options(),
+                correctAnswer(),
+                "수정된 해설",
+                null
+        );
+    }
+
+    private JsonNode options() throws Exception {
+        return objectMapper.readTree("""
+                [
+                  {"key": "1", "label": "선택지 1"},
+                  {"key": "2", "label": "선택지 2", "description": null}
+                ]
+                """);
+    }
+
+    private JsonNode correctAnswer() throws Exception {
+        return objectMapper.readTree("{\"key\":\"1\"}");
+    }
+
+    private MainChapter mainChapter(long id, ChapterType type) {
+        MainChapter chapter = MainChapter.create(
+                type,
+                type == ChapterType.ASSET ? AssetType.DEPOSIT_SAVINGS : null,
+                "대단원",
+                null,
+                1,
+                type == ChapterType.FOUNDATION,
+                true,
+                NOW
+        );
+        chapter.setMainChapterId(id);
+        return chapter;
+    }
+
+    private SubChapter subChapter(long id, long mainChapterId) {
+        SubChapter chapter = SubChapter.create(
+                mainChapterId,
+                "소단원",
+                null,
+                1,
+                true,
+                NOW
+        );
+        chapter.setSubChapterId(id);
+        return chapter;
+    }
+
+    private QuizQuestion humanQuestion(long id, int versionNo) throws Exception {
+        QuizQuestion question = QuizQuestion.draft(
+                "deposit-basic-001",
+                versionNo,
+                QuizUsageType.SUB_CHAPTER,
+                2L,
+                101L,
+                null,
+                QuizQuestionType.SINGLE_CHOICE,
+                QuizDifficulty.EASY,
+                "기존 질문",
+                null,
+                options().toString(),
+                correctAnswer().toString(),
+                "기존 해설",
+                QuizGenerationType.HUMAN,
+                null,
+                ACTOR_ID,
+                NOW.minusDays(1)
+        );
+        question.setQuestionId(id);
+        return question;
+    }
+}

--- a/src/test/java/org/firstfolio/quiz/validation/QuizQuestionSchemaValidatorTest.java
+++ b/src/test/java/org/firstfolio/quiz/validation/QuizQuestionSchemaValidatorTest.java
@@ -1,0 +1,215 @@
+package org.firstfolio.quiz.validation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class QuizQuestionSchemaValidatorTest {
+
+    private static final String HUMAN_SINGLE_CHOICE_RESOURCE =
+            "quiz/question/valid-human-single-choice.json";
+    private static final String AI_SCENARIO_RESOURCE =
+            "quiz/question/valid-ai-scenario.json";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final QuizQuestionSchemaValidator validator = new QuizQuestionSchemaValidator();
+
+    @Test
+    void acceptsValidHumanSingleChoiceQuestion() throws IOException {
+        QuizQuestionValidationResult result = validator.validate(
+                resourceBytes(HUMAN_SINGLE_CHOICE_RESOURCE)
+        );
+
+        assertTrue(result.isValid());
+        assertTrue(result.errors().isEmpty());
+    }
+
+    @Test
+    void acceptsValidAiScenarioQuestion() throws IOException {
+        QuizQuestionValidationResult result = validator.validate(
+                resourceBytes(AI_SCENARIO_RESOURCE)
+        );
+
+        assertTrue(result.isValid());
+        assertTrue(result.errors().isEmpty());
+    }
+
+    @Test
+    void acceptsTrueFalseQuestionWithOAndXOptions() throws IOException {
+        ObjectNode question = humanSingleChoice();
+        question.put("question_type", "TRUE_FALSE");
+        ArrayNode options = question.withArray("options_json");
+        ((ObjectNode) options.get(0)).put("key", "O");
+        ((ObjectNode) options.get(1)).put("key", "X");
+        question.withObject("/correct_answer_json").put("key", "O");
+
+        QuizQuestionValidationResult result = validate(question);
+
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    void rejectsMalformedEmptyAndTrailingJson() throws IOException {
+        QuizQuestionValidationResult malformed = validator.validate(
+                "{broken".getBytes(StandardCharsets.UTF_8)
+        );
+        QuizQuestionValidationResult nullContent = validator.validate(null);
+        QuizQuestionValidationResult empty = validator.validate(new byte[0]);
+        QuizQuestionValidationResult trailing = validator.validate(
+                (new String(resourceBytes(HUMAN_SINGLE_CHOICE_RESOURCE), StandardCharsets.UTF_8)
+                        + " {}")
+                        .getBytes(StandardCharsets.UTF_8)
+        );
+
+        assertInvalidJson(malformed);
+        assertInvalidJson(nullContent);
+        assertInvalidJson(empty);
+        assertInvalidJson(trailing);
+    }
+
+    @Test
+    void rejectsUnknownFieldAndRemovedMultipleChoiceType() throws IOException {
+        ObjectNode unknownField = humanSingleChoice();
+        unknownField.put("answer", "1");
+        ObjectNode multipleChoice = humanSingleChoice();
+        multipleChoice.put("question_type", "MULTIPLE_CHOICE");
+
+        assertSchemaViolation(validate(unknownField));
+        assertSchemaViolation(validate(multipleChoice));
+    }
+
+    @Test
+    void rejectsDuplicateOptionKeys() throws IOException {
+        ObjectNode question = humanSingleChoice();
+        ((ObjectNode) question.withArray("options_json").get(1)).put("key", "1");
+
+        QuizQuestionValidationResult result = validate(question);
+
+        assertFalse(result.isValid());
+        assertEquals(QuizQuestionValidationErrorCode.DUPLICATE_OPTION_KEY,
+                result.errors().get(0).code());
+        assertEquals("/options_json/1/key", result.errors().get(0).path());
+    }
+
+    @Test
+    void rejectsCorrectAnswerKeyMissingFromOptions() throws IOException {
+        ObjectNode question = humanSingleChoice();
+        question.withObject("/correct_answer_json").put("key", "3");
+
+        QuizQuestionValidationResult result = validate(question);
+
+        assertFalse(result.isValid());
+        assertEquals(QuizQuestionValidationErrorCode.CORRECT_OPTION_NOT_FOUND,
+                result.errors().get(0).code());
+        assertEquals("/correct_answer_json/key", result.errors().get(0).path());
+    }
+
+    @Test
+    void rejectsTrueFalseQuestionWithoutExactOAndXOptions() throws IOException {
+        ObjectNode question = humanSingleChoice();
+        question.put("question_type", "TRUE_FALSE");
+        ArrayNode options = question.withArray("options_json");
+        ((ObjectNode) options.get(0)).put("key", "O");
+        ((ObjectNode) options.get(1)).put("key", "Y");
+        question.withObject("/correct_answer_json").put("key", "O");
+
+        assertSchemaViolation(validate(question));
+    }
+
+    @Test
+    void rejectsScenarioPayloadThatDoesNotMatchQuestionType() throws IOException {
+        ObjectNode missingScenario = humanSingleChoice();
+        missingScenario.put("question_type", "SCENARIO");
+        ObjectNode unexpectedScenario = aiScenario();
+        unexpectedScenario.put("question_type", "SINGLE_CHOICE");
+
+        assertSchemaViolation(validate(missingScenario));
+        assertSchemaViolation(validate(unexpectedScenario));
+    }
+
+    @Test
+    void rejectsSourceReferencesThatDoNotMatchGenerationType() throws IOException {
+        ObjectNode aiWithoutSources = humanSingleChoice();
+        aiWithoutSources.put("generation_type", "AI");
+        ObjectNode humanWithSources = aiScenario();
+        humanWithSources.put("generation_type", "HUMAN");
+
+        assertSchemaViolation(validate(aiWithoutSources));
+        assertSchemaViolation(validate(humanWithSources));
+    }
+
+    @Test
+    void rejectsAiSourceWithoutKnowledgeContentIdOrUrl() throws IOException {
+        ObjectNode question = aiScenario();
+        ObjectNode source = (ObjectNode) question.withArray("source_refs_json").get(0);
+        source.remove("knowledge_content_id");
+
+        assertSchemaViolation(validate(question));
+    }
+
+    @Test
+    void rejectsChapterReferencesThatDoNotMatchUsageType() throws IOException {
+        ObjectNode subChapterWithoutId = humanSingleChoice();
+        subChapterWithoutId.putNull("sub_chapter_id");
+        ObjectNode mainChapterWithSubChapterId = aiScenario();
+        mainChapterWithSubChapterId.put("sub_chapter_id", 101);
+
+        assertSchemaViolation(validate(subChapterWithoutId));
+        assertSchemaViolation(validate(mainChapterWithSubChapterId));
+    }
+
+    @Test
+    void rejectsHtmlInQuestionText() throws IOException {
+        ObjectNode question = humanSingleChoice();
+        question.put("prompt", "예금은 <strong>안전한가요?</strong>");
+
+        assertSchemaViolation(validate(question));
+    }
+
+    private ObjectNode humanSingleChoice() throws IOException {
+        return resourceObject(HUMAN_SINGLE_CHOICE_RESOURCE);
+    }
+
+    private ObjectNode aiScenario() throws IOException {
+        return resourceObject(AI_SCENARIO_RESOURCE);
+    }
+
+    private ObjectNode resourceObject(String resource) throws IOException {
+        return (ObjectNode) objectMapper.readTree(resourceBytes(resource));
+    }
+
+    private byte[] resourceBytes(String resource) throws IOException {
+        try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(resource)) {
+            if (inputStream == null) {
+                throw new IllegalStateException("테스트 퀴즈 문항 JSON을 찾을 수 없습니다: " + resource);
+            }
+            return inputStream.readAllBytes();
+        }
+    }
+
+    private QuizQuestionValidationResult validate(ObjectNode question) throws IOException {
+        return validator.validate(objectMapper.writeValueAsBytes(question));
+    }
+
+    private void assertInvalidJson(QuizQuestionValidationResult result) {
+        assertFalse(result.isValid());
+        assertEquals(QuizQuestionValidationErrorCode.INVALID_JSON,
+                result.errors().get(0).code());
+    }
+
+    private void assertSchemaViolation(QuizQuestionValidationResult result) {
+        assertFalse(result.isValid());
+        assertTrue(result.errors().stream()
+                .anyMatch(error -> error.code()
+                        == QuizQuestionValidationErrorCode.SCHEMA_VIOLATION));
+    }
+}

--- a/src/test/java/org/firstfolio/reward/mapper/QuizRewardMapperXmlTest.java
+++ b/src/test/java/org/firstfolio/reward/mapper/QuizRewardMapperXmlTest.java
@@ -1,0 +1,82 @@
+package org.firstfolio.reward.mapper;
+
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.mapping.BoundSql;
+import org.apache.ibatis.session.Configuration;
+import org.firstfolio.reward.domain.PointTransaction;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class QuizRewardMapperXmlTest {
+
+    private static final String RESOURCE = "mappers/reward/QuizRewardMapper.xml";
+
+    @Test
+    void parsesPolicyBalanceAndLedgerStatements() throws IOException {
+        Configuration configuration = new Configuration();
+        try (InputStream input = Resources.getResourceAsStream(RESOURCE)) {
+            new XMLMapperBuilder(
+                    input,
+                    configuration,
+                    RESOURCE,
+                    configuration.getSqlFragments()
+            ).parse();
+        }
+
+        assertTrue(configuration.hasMapper(QuizRewardMapper.class));
+        assertTrue(configuration.hasStatement(id("findActivePolicyAt")));
+        assertTrue(configuration.hasStatement(id("findTransactionById")));
+        assertTrue(configuration.hasStatement(id("increasePointBalance")));
+        assertTrue(configuration.hasStatement(id("findPointBalance")));
+        assertTrue(configuration.hasStatement(id("insertTransaction")));
+
+        BoundSql policySql = configuration.getMappedStatement(
+                        id("findActivePolicyAt")
+                )
+                .getBoundSql(Map.of(
+                        "policyKey", "QUIZ_REWARD",
+                        "effectiveAt", LocalDateTime.of(2026, 8, 11, 1, 30)
+                ));
+        assertTrue(normalize(policySql.getSql()).contains(
+                "AND effective_from <= ? AND (effective_to IS NULL OR effective_to > ?)"
+        ));
+        assertTrue(normalize(policySql.getSql()).endsWith(
+                "ORDER BY version_no DESC LIMIT 1 FOR SHARE"
+        ));
+
+        BoundSql balanceSql = configuration.getMappedStatement(
+                        id("increasePointBalance")
+                )
+                .getBoundSql(Map.of(
+                        "userId", 11L,
+                        "amount", 200,
+                        "updatedAt", LocalDateTime.of(2026, 8, 11, 1, 30)
+                ));
+        assertTrue(normalize(balanceSql.getSql()).contains(
+                "SET point_balance = point_balance + ?, updated_at = ? WHERE user_id = ?"
+        ));
+
+        BoundSql insertSql = configuration.getMappedStatement(
+                        id("insertTransaction")
+                )
+                .getBoundSql(new PointTransaction());
+        assertTrue(normalize(insertSql.getSql()).contains(
+                "INSERT INTO point_transactions"
+        ));
+    }
+
+    private String id(String statement) {
+        return QuizRewardMapper.class.getName() + "." + statement;
+    }
+
+    private String normalize(String sql) {
+        return sql.replaceAll("\\s+", " ").trim();
+    }
+}

--- a/src/test/java/org/firstfolio/reward/service/QuizRewardServiceTest.java
+++ b/src/test/java/org/firstfolio/reward/service/QuizRewardServiceTest.java
@@ -1,0 +1,178 @@
+package org.firstfolio.reward.service;
+
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.reward.domain.PointTransaction;
+import org.firstfolio.reward.domain.QuizRewardResult;
+import org.firstfolio.reward.domain.RewardPolicy;
+import org.firstfolio.reward.mapper.QuizRewardMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class QuizRewardServiceTest {
+
+    private static final long USER_ID = 11L;
+    private static final long ATTEMPT_ID = 3001L;
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 8, 11, 1, 30);
+
+    private QuizRewardMapper mapper;
+    private QuizRewardService service;
+
+    @BeforeEach
+    void setUp() {
+        mapper = mock(QuizRewardMapper.class);
+        service = new QuizRewardService(mapper);
+    }
+
+    @Test
+    void grantsPointsPerCorrectForFirstAttemptAndWritesLedger() {
+        when(mapper.findActivePolicyAt("QUIZ_REWARD", NOW))
+                .thenReturn(policy("{\"points_per_correct\":100}"));
+        when(mapper.increasePointBalance(USER_ID, 200, NOW)).thenReturn(1);
+        when(mapper.findPointBalance(USER_ID)).thenReturn(1200);
+        when(mapper.insertTransaction(any())).thenAnswer(invocation -> {
+            PointTransaction transaction = invocation.getArgument(0);
+            transaction.setPointTransactionId(7001L);
+            return 1;
+        });
+
+        QuizRewardResult result = service.grantForCompletedAttempt(
+                USER_ID,
+                ATTEMPT_ID,
+                1,
+                2,
+                NOW
+        );
+
+        assertEquals(91L, result.policyId());
+        assertEquals(200, result.points());
+        assertEquals(7001L, result.pointTransactionId());
+
+        ArgumentCaptor<PointTransaction> captor = ArgumentCaptor.forClass(
+                PointTransaction.class
+        );
+        verify(mapper).insertTransaction(captor.capture());
+        PointTransaction transaction = captor.getValue();
+        assertEquals("EARN", transaction.getTransactionType());
+        assertEquals("QUIZ", transaction.getReasonType());
+        assertEquals(ATTEMPT_ID, transaction.getReasonId());
+        assertEquals(1200, transaction.getBalanceAfter());
+        assertEquals("quiz-reward:3001", transaction.getIdempotencyKey());
+        assertEquals(NOW, transaction.getOccurredAt());
+    }
+
+    @Test
+    void doesNotGrantPointsForRetryAttempt() {
+        when(mapper.findActivePolicyAt("QUIZ_REWARD", NOW))
+                .thenReturn(policy("{\"points_per_correct\":100}"));
+
+        QuizRewardResult result = service.grantForCompletedAttempt(
+                USER_ID,
+                ATTEMPT_ID,
+                2,
+                3,
+                NOW
+        );
+
+        assertEquals(0, result.points());
+        assertNull(result.pointTransactionId());
+        verify(mapper, never()).increasePointBalance(
+                USER_ID,
+                300,
+                NOW
+        );
+        verify(mapper, never()).insertTransaction(any());
+    }
+
+    @Test
+    void recordsPolicyButDoesNotCreateZeroAmountTransaction() {
+        when(mapper.findActivePolicyAt("QUIZ_REWARD", NOW))
+                .thenReturn(policy("{\"points_per_correct\":100}"));
+
+        QuizRewardResult result = service.grantForCompletedAttempt(
+                USER_ID,
+                ATTEMPT_ID,
+                1,
+                0,
+                NOW
+        );
+
+        assertEquals(91L, result.policyId());
+        assertEquals(0, result.points());
+        assertNull(result.pointTransactionId());
+        verify(mapper, never()).insertTransaction(any());
+    }
+
+    @Test
+    void restoresPersistedRewardForIdempotentAnswerRequest() {
+        PointTransaction transaction = new PointTransaction();
+        transaction.setPointTransactionId(7001L);
+        transaction.setUserId(USER_ID);
+        transaction.setTransactionType("EARN");
+        transaction.setReasonType("QUIZ");
+        transaction.setReasonId(ATTEMPT_ID);
+        transaction.setAmount(200);
+        when(mapper.findTransactionById(7001L)).thenReturn(transaction);
+
+        QuizRewardResult result = service.restore(
+                USER_ID,
+                ATTEMPT_ID,
+                91L,
+                7001L
+        );
+
+        assertEquals(91L, result.policyId());
+        assertEquals(200, result.points());
+        assertEquals(7001L, result.pointTransactionId());
+    }
+
+    @Test
+    void rejectsMissingOrInvalidRewardPolicy() {
+        ApiException missing = assertThrows(
+                ApiException.class,
+                () -> service.grantForCompletedAttempt(
+                        USER_ID,
+                        ATTEMPT_ID,
+                        1,
+                        2,
+                        NOW
+                )
+        );
+        assertEquals(ErrorCode.INTERNAL_ERROR, missing.getErrorCode());
+
+        when(mapper.findActivePolicyAt("QUIZ_REWARD", NOW))
+                .thenReturn(policy("{\"points_per_correct\":-1}"));
+        ApiException invalid = assertThrows(
+                ApiException.class,
+                () -> service.grantForCompletedAttempt(
+                        USER_ID,
+                        ATTEMPT_ID,
+                        1,
+                        2,
+                        NOW
+                )
+        );
+        assertEquals(ErrorCode.INTERNAL_ERROR, invalid.getErrorCode());
+    }
+
+    private RewardPolicy policy(String configJson) {
+        RewardPolicy policy = new RewardPolicy();
+        policy.setPolicyId(91L);
+        policy.setPolicyKey("QUIZ_REWARD");
+        policy.setVersionNo(1);
+        policy.setConfigJson(configJson);
+        return policy;
+    }
+}

--- a/src/test/resources/quiz/question/valid-ai-scenario.json
+++ b/src/test/resources/quiz/question/valid-ai-scenario.json
@@ -1,0 +1,60 @@
+{
+  "question_key": "fund-scenario-001",
+  "usage_type": "MAIN_CHAPTER",
+  "main_chapter_id": 5,
+  "sub_chapter_id": null,
+  "question_type": "SCENARIO",
+  "difficulty": "MEDIUM",
+  "prompt": "제시된 조건에 가장 적절한 선택은 무엇인가요?",
+  "scenario_json": {
+    "title": "금융상품 선택",
+    "narrative": "가상의 사용자가 조건에 맞는 금융상품을 고릅니다.",
+    "persona": {
+      "name": "민서",
+      "age": "18세",
+      "job": "고등학생"
+    },
+    "requirements": {
+      "assets": "소액의 저축 자금",
+      "risk": "위험을 분산하고 싶음",
+      "goal": "시장 흐름 학습"
+    },
+    "market": {
+      "title": "시장 정보",
+      "reference_at": "2026-08-10T00:00:00Z",
+      "bullets": [
+        "검증된 시장 정보"
+      ]
+    },
+    "constraints": [
+      "한 상품에 자금을 집중하지 않는다."
+    ],
+    "paper_title": "선택 보고서"
+  },
+  "options_json": [
+    {
+      "key": "1",
+      "label": "선택지 1",
+      "description": "선택지에 대한 추가 설명"
+    },
+    {
+      "key": "2",
+      "label": "선택지 2",
+      "description": "선택지에 대한 추가 설명"
+    }
+  ],
+  "correct_answer_json": {
+    "key": "1"
+  },
+  "explanation": "제시된 조건을 모두 충족하는 선택지입니다.",
+  "generation_type": "AI",
+  "source_refs_json": [
+    {
+      "knowledge_content_id": 9001,
+      "title": "근거 문서",
+      "publisher": "발행 기관",
+      "url": null,
+      "reference_at": "2026-08-10T00:00:00Z"
+    }
+  ]
+}

--- a/src/test/resources/quiz/question/valid-human-single-choice.json
+++ b/src/test/resources/quiz/question/valid-human-single-choice.json
@@ -1,0 +1,27 @@
+{
+  "question_key": "deposit-basic-001",
+  "usage_type": "SUB_CHAPTER",
+  "main_chapter_id": 2,
+  "sub_chapter_id": 101,
+  "question_type": "SINGLE_CHOICE",
+  "difficulty": "EASY",
+  "prompt": "예금의 특징으로 가장 적절한 것은?",
+  "scenario_json": null,
+  "options_json": [
+    {
+      "key": "1",
+      "label": "선택지 1"
+    },
+    {
+      "key": "2",
+      "label": "선택지 2",
+      "description": null
+    }
+  ],
+  "correct_answer_json": {
+    "key": "1"
+  },
+  "explanation": "정답에 대한 해설입니다.",
+  "generation_type": "HUMAN",
+  "source_refs_json": null
+}


### PR DESCRIPTION
## 사용자 학습 진행 및 퀴즈 흐름 구현

feat: 사용자 학습 진행 및 퀴즈 흐름 구현 #40 

## 작업 내용

### 학습 단원 및 진도

- 사용자용 공개 대단원·소단원 목록 조회 API 구현
- 소단원 학습 진도 생성·조회·갱신·완료 처리 구현
- 페이지 이동 및 최초 완료 변경 이력 저장
- 최근 미완료 학습 위치를 반환하는 학습 이어하기 API 구현
- 콘텐츠 버전과 저장소 객체 검증 및 오류 처리

### 퀴즈 문항 관리

- 퀴즈 문항 JSON Schema 및 검증 구현
- `HUMAN`, `AI` 문항 생성 방식 구분
- AI 생성 문항의 출처 정보 검증
- 단일 선택형·O/X형·상황판단형 문항 지원
- 관리자용 퀴즈 문항 등록 및 신규 버전 생성 API 구현
- 문항 버전 번호 생성 및 `DRAFT` 저장

### 소단원 퀴즈

- 공개 문항 검증 및 퀴즈 응시 생성
- 출제 당시 문항·선택지·정답·해설 스냅샷 저장
- 진행 중 응시 복원 및 완료 후 재응시 처리
- 문항별 답안 제출과 즉시 채점 API 구현
- 동일 답안 재요청 멱등 처리 및 답안 변경 차단
- 마지막 문항 제출 시 결과 확정과 포인트 지급 처리

### 대단원 퀴즈 및 완료

- 모든 활성 소단원 완료 여부 검증
- 최신 공개 대단원 문항을 이용한 응시 생성·복원
- 별도 합격 기준 점수 없이 모든 문항 제출 시 대단원 완료
- 최초 대단원 완료 일시 저장 및 재응시 중복 완료 방지
- `FOUNDATION` 완료 시 최초 포트폴리오 생성과 모의투자금 지급
- 완료 유형에 따른 `NEXT_MAIN_CHAPTER`, `PORTFOLIO_SETUP` 반환

### 포인트 지급

- 활성 `QUIZ_REWARD` 정책을 이용한 정답 수 기반 포인트 계산
- 동일 퀴즈의 최초 응시에만 포인트 지급
- 포인트 잔액 변경 및 원장 이력 저장
- 답안 저장·채점·포인트 지급·학습 완료를 하나의 트랜잭션으로 처리

### DB 및 문서

- 학습 진도 변경 이력 테이블 추가
- 퀴즈 문항 `generation_type`과 관련 제약조건 추가
- 퀴즈 응시에 보상 정책 및 포인트 원장 참조 추가
- Swagger/OpenAPI 응답 스키마 및 오류 명세 반영

## 주요 API

- `GET /api/learning/main-chapters`
- `GET /api/learning/main-chapters/{mainChapterId}/sub-chapters`
- `GET/PUT /api/learning/sub-chapters/{subChapterId}/progress`
- `GET /api/learning/continue`
- `POST /api/admin/quiz-questions`
- `POST /api/admin/quiz-questions/{questionId}/versions`
- `POST /api/learning/sub-chapters/{subChapterId}/quiz-attempts`
- `POST /api/learning/main-chapters/{mainChapterId}/quiz-attempts`
- `PUT /api/learning/quiz-attempts/{attemptId}/answers/{questionId}`

## 테스트

- JSON Schema 검증 테스트
- MyBatis Mapper XML 테스트
- 학습 진도 및 이어하기 서비스·API 테스트
- 퀴즈 문항 등록·응시·채점·보상 테스트
- 대단원 완료 및 초기 모의투자금 지급 테스트
- OpenAPI 문서 테스트
- 전체 테스트 통과
- WAR 빌드 성공

## 관련 이슈

- #43
- #44 
- #45
- #47
- #49
- #51
- #59
- #60
- #62 