### PR TITLE
feat: policy 패키지와 system_policies 조회 구현 #64

### DIFF
--- a/src/main/java/org/firstfolio/policy/domain/SystemPolicy.java
+++ b/src/main/java/org/firstfolio/policy/domain/SystemPolicy.java
@@ -1,0 +1,110 @@
+package org.firstfolio.policy.domain;
+
+import java.time.LocalDateTime;
+
+/**
+ * {@code system_policies} 한 행. <b>버전이 붙은 운영 정책</b>이다.
+ *
+ * <p>여덟 개 도메인이 {@code policy_key}로 나눠 쓴다 — {@code QUIZ_REWARD}, {@code ATTENDANCE},
+ * {@code LEADERBOARD}, {@code SIMULATION}, {@code TRADE}, {@code RESET}, {@code GIFTICON},
+ * {@code AI_REVIEW}. <b>내용({@code configJson})은 키마다 완전히 다르므로 해석은 각 도메인이 한다.</b>
+ * 이 클래스는 어느 행이 지금 유효한지까지만 다룬다.</p>
+ *
+ * <p>정책은 <b>고쳐 쓰지 않고 새 버전을 쌓는다.</b> 과거 거래가 어느 요율로 계산됐는지
+ * 나중에 확인할 수 있어야 하기 때문이다 (SIMULATION_POLICY_v3 3.3절).</p>
+ */
+public class SystemPolicy {
+
+    private Long policyId;
+
+    /** {@code TRADE} 등. 도메인이 자기 것만 읽는다. */
+    private String policyKey;
+
+    /** 같은 키 안에서 올라간다. {@code uq_system_policies_key_version}이 중복을 막는다. */
+    private Integer versionNo;
+
+    /** 정책 내용 원문. 해석은 도메인 몫이다. */
+    private String configJson;
+
+    private LocalDateTime effectiveFrom;
+
+    /** 종료 시각. <b>null이면 아직 끝나지 않은 정책</b>이다. */
+    private LocalDateTime effectiveTo;
+
+    private boolean active;
+
+    private Long createdBy;
+    private LocalDateTime createdAt;
+
+    public Long getPolicyId() {
+        return policyId;
+    }
+
+    public void setPolicyId(Long policyId) {
+        this.policyId = policyId;
+    }
+
+    public String getPolicyKey() {
+        return policyKey;
+    }
+
+    public void setPolicyKey(String policyKey) {
+        this.policyKey = policyKey;
+    }
+
+    public Integer getVersionNo() {
+        return versionNo;
+    }
+
+    public void setVersionNo(Integer versionNo) {
+        this.versionNo = versionNo;
+    }
+
+    public String getConfigJson() {
+        return configJson;
+    }
+
+    public void setConfigJson(String configJson) {
+        this.configJson = configJson;
+    }
+
+    public LocalDateTime getEffectiveFrom() {
+        return effectiveFrom;
+    }
+
+    public void setEffectiveFrom(LocalDateTime effectiveFrom) {
+        this.effectiveFrom = effectiveFrom;
+    }
+
+    public LocalDateTime getEffectiveTo() {
+        return effectiveTo;
+    }
+
+    public void setEffectiveTo(LocalDateTime effectiveTo) {
+        this.effectiveTo = effectiveTo;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
+    public Long getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(Long createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/org/firstfolio/policy/mapper/SystemPolicyMapper.java
+++ b/src/main/java/org/firstfolio/policy/mapper/SystemPolicyMapper.java
@@ -1,0 +1,30 @@
+package org.firstfolio.policy.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.firstfolio.policy.domain.SystemPolicy;
+
+import java.time.LocalDateTime;
+
+@Mapper
+public interface SystemPolicyMapper {
+
+    /**
+     * 그 시점에 유효한 정책 한 건. <b>없으면 null이다.</b>
+     *
+     * <p>유효 조건은 넷이다 — {@code is_active}가 참이고, {@code effective_from}이 지났고,
+     * {@code effective_to}가 아직 안 됐거나 없고, 그중 <b>가장 높은 버전</b>.
+     * <b>하나만 빠뜨려도 옛 정책으로 조용히 계산된다.</b> 도메인마다 따로 구현하지 않고
+     * 이 한 곳에 모아 둔 이유다.</p>
+     *
+     * <p>{@code idx_system_policies_active_period (policy_key, is_active, effective_from,
+     * effective_to)}를 그대로 탄다.</p>
+     *
+     * @param policyKey {@code TRADE} 등. 도메인이 자기 키만 넘긴다
+     * @param at        기준 시각(UTC)
+     */
+    SystemPolicy findActive(
+            @Param("policyKey") String policyKey,
+            @Param("at") LocalDateTime at
+    );
+}

--- a/src/main/java/org/firstfolio/policy/service/SystemPolicyReader.java
+++ b/src/main/java/org/firstfolio/policy/service/SystemPolicyReader.java
@@ -1,0 +1,93 @@
+package org.firstfolio.policy.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.firstfolio.common.json.ApiObjectMapperFactory;
+import org.firstfolio.policy.domain.SystemPolicy;
+import org.firstfolio.policy.mapper.SystemPolicyMapper;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+/**
+ * 지금 유효한 운영 정책을 읽는 <b>단 하나의 자리</b>.
+ *
+ * <p>{@code system_policies}는 여덟 도메인이 {@code policy_key}로 나눠 쓰는 공용 테이블이다.
+ * 내용은 키마다 다르지만 <b>"어느 버전이 지금 유효한가"를 고르는 규칙은 완전히 같다</b> —
+ * {@code is_active} · {@code effective_from} · {@code effective_to} · 최신 {@code version_no}.
+ * 조건이 넷이라 도메인마다 따로 구현하면 <b>하나만 빠뜨려도 옛 정책으로 조용히 계산된다.</b></p>
+ *
+ * <h3>쓰는 쪽에게</h3>
+ *
+ * <p>{@code policyKey}를 넘기면 되므로 다른 도메인도 그대로 재사용할 수 있다.
+ * <b>{@code config_json}의 해석은 각 도메인이 한다</b> — 정책 내용이 키마다 완전히 달라
+ * 여기서 공통으로 다룰 것이 없다. (예: {@code TRADE}는
+ * {@code org.firstfolio.portfolio.service.TradePolicy}가 읽는다.)</p>
+ *
+ * <h3>정책이 없는 것은 오류가 아니다</h3>
+ *
+ * <p>{@code null}을 돌려준다. 아직 아무도 정책 행을 넣지 않은 상태가 정상적으로 있고
+ * (이 테이블은 <b>쓰기 경로가 명세에 없어 SQL로 넣는다</b>), 그때 기능이 멈추면 안 된다.
+ * 호출한 쪽이 안전한 기본값으로 넘어가야 한다.</p>
+ *
+ * <h3>캐시를 두지 않는다</h3>
+ *
+ * <p>거래마다 부르지만 인덱스를 타는 1행 조회다. 캐시를 넣으면 정책을 바꿨을 때
+ * 언제 반영되는지가 불분명해지는데, 얻는 것이 없다.</p>
+ */
+@Component
+public class SystemPolicyReader {
+
+    private static final Logger log = LogManager.getLogger(SystemPolicyReader.class);
+
+    private final ObjectMapper objectMapper = ApiObjectMapperFactory.create();
+
+    private final SystemPolicyMapper systemPolicyMapper;
+
+    public SystemPolicyReader(SystemPolicyMapper systemPolicyMapper) {
+        this.systemPolicyMapper = systemPolicyMapper;
+    }
+
+    /**
+     * 그 시점에 유효한 정책. <b>없으면 null이다.</b>
+     *
+     * @param policyKey {@code TRADE} 등
+     * @param at        기준 시각(UTC)
+     */
+    public SystemPolicy findActive(String policyKey, LocalDateTime at) {
+        if (policyKey == null || policyKey.isBlank() || at == null) {
+            return null;
+        }
+
+        return systemPolicyMapper.findActive(policyKey, at);
+    }
+
+    /**
+     * 유효한 정책의 내용. <b>정책이 없거나 내용을 읽지 못하면 null이다.</b>
+     *
+     * <p>깨진 JSON에 예외를 던지지 않는다. 정책 하나가 잘못 들어갔다고 거래가 통째로 막히는 것보다
+     * <b>기본값으로 도는 편이 낫다.</b> 대신 경고를 남겨 추적할 수 있게 한다.</p>
+     */
+    public JsonNode findActiveConfig(String policyKey, LocalDateTime at) {
+        SystemPolicy policy = findActive(policyKey, at);
+
+        if (policy == null || policy.getConfigJson() == null) {
+            return null;
+        }
+
+        try {
+            return objectMapper.readTree(policy.getConfigJson());
+        } catch (Exception exception) {
+            log.warn(
+                    "정책 내용을 읽지 못했습니다. 기본값으로 계속합니다 key={} version={}",
+                    policyKey,
+                    policy.getVersionNo(),
+                    exception
+            );
+
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/firstfolio/portfolio/domain/TradePolicy.java
+++ b/src/main/java/org/firstfolio/portfolio/domain/TradePolicy.java
@@ -1,0 +1,83 @@
+package org.firstfolio.portfolio.domain;
+
+import java.math.BigDecimal;
+
+/**
+ * 거래에 적용할 수수료·세율 (SIMULATION_POLICY_v3 3.3절, D14).
+ *
+ * <table>
+ *   <tr><th>항목</th><th>확정값</th><th>근거</th></tr>
+ *   <tr><td>매수·매도 수수료</td><td>0.015%</td><td>v3 3.3절</td></tr>
+ *   <tr><td>증권거래세</td><td>0.20%</td><td>v3 3.3절 (코스피·코스닥 동일)</td></tr>
+ *   <tr><td>배당소득세</td><td>15.4%</td><td>v3 3.3절</td></tr>
+ *   <tr><td>이자소득세</td><td>15.4%</td><td>D14 (v3 반영 요청 중)</td></tr>
+ * </table>
+ *
+ * <p><b>비율이다.</b> 0.00015가 0.015%다. 퍼센트 값이 아니므로 100으로 나누지 않는다.</p>
+ *
+ * <p>{@code policyVersion}은 <b>이 값들이 어느 정책 버전에서 왔는지</b>다. 거래 이력에 함께
+ * 남겨 두면 나중에 요율이 바뀌어도 과거 거래를 검산할 수 있다. <b>정책 행이 없어 기본값으로
+ * 돈 경우에는 null</b>이며, 그 사실 자체가 이력에 남아야 한다.</p>
+ */
+public final class TradePolicy {
+
+    private final BigDecimal buyFeeRate;
+    private final BigDecimal sellFeeRate;
+    private final BigDecimal securitiesTransactionTaxRate;
+    private final BigDecimal dividendIncomeTaxRate;
+    private final BigDecimal interestIncomeTaxRate;
+
+    /** 적용된 정책 버전. <b>기본값으로 돌면 null이다.</b> */
+    private final Integer policyVersion;
+
+    public TradePolicy(
+            BigDecimal buyFeeRate,
+            BigDecimal sellFeeRate,
+            BigDecimal securitiesTransactionTaxRate,
+            BigDecimal dividendIncomeTaxRate,
+            BigDecimal interestIncomeTaxRate,
+            Integer policyVersion
+    ) {
+        this.buyFeeRate = buyFeeRate;
+        this.sellFeeRate = sellFeeRate;
+        this.securitiesTransactionTaxRate = securitiesTransactionTaxRate;
+        this.dividendIncomeTaxRate = dividendIncomeTaxRate;
+        this.interestIncomeTaxRate = interestIncomeTaxRate;
+        this.policyVersion = policyVersion;
+    }
+
+    /** 매수 수수료율. 0.00015 = 0.015% */
+    public BigDecimal getBuyFeeRate() {
+        return buyFeeRate;
+    }
+
+    /** 매도 수수료율. 0.00015 = 0.015% */
+    public BigDecimal getSellFeeRate() {
+        return sellFeeRate;
+    }
+
+    /** 증권거래세율. <b>매도에만 붙는다.</b> 0.0020 = 0.20% */
+    public BigDecimal getSecuritiesTransactionTaxRate() {
+        return securitiesTransactionTaxRate;
+    }
+
+    /** 배당소득세율. 0.154 = 15.4% */
+    public BigDecimal getDividendIncomeTaxRate() {
+        return dividendIncomeTaxRate;
+    }
+
+    /** 이자소득세율. 0.154 = 15.4% */
+    public BigDecimal getInterestIncomeTaxRate() {
+        return interestIncomeTaxRate;
+    }
+
+    /** 적용된 정책 버전. 기본값으로 돌면 null이다. */
+    public Integer getPolicyVersion() {
+        return policyVersion;
+    }
+
+    /** 저장된 정책에서 왔는지. 거짓이면 설정 기본값이다. */
+    public boolean isFromStoredPolicy() {
+        return policyVersion != null;
+    }
+}

--- a/src/main/java/org/firstfolio/portfolio/service/TradePolicyProvider.java
+++ b/src/main/java/org/firstfolio/portfolio/service/TradePolicyProvider.java
@@ -1,0 +1,187 @@
+package org.firstfolio.portfolio.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.firstfolio.policy.domain.SystemPolicy;
+import org.firstfolio.policy.service.SystemPolicyReader;
+import org.firstfolio.portfolio.domain.TradePolicy;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * 거래 수수료·세율을 가져온다. <b>저장된 정책이 있으면 그것, 없으면 설정 기본값.</b>
+ *
+ * <p>SIMULATION_POLICY_v3 3.3절이 <i>"실제 요율은 수시 변동되므로 {@code system_policies}의
+ * TRADE 정책 버전으로 관리하고 고정 상수로 하드코딩하지 않는다"</i>고 못박았다.</p>
+ *
+ * <h3>왜 기본값이 필요한가</h3>
+ *
+ * <p>{@code system_policies}는 <b>쓰기 경로가 명세에 없다</b> — 정책 관리 API가 없고 행은
+ * SQL로 넣는다. 즉 <b>아무도 안 넣은 상태가 정상적으로 존재</b>한다. 그때 거래를 막으면
+ * 정책을 넣기 전까지 서비스가 통째로 멈춘다.</p>
+ *
+ * <p>기본값을 자바 상수가 아니라 {@code application.properties}에 두는 것이 v3의 의도와도 맞는다 —
+ * <b>재배포 없이 바꿀 수 있어야 한다</b>는 요구는 지켜지고, 저장된 정책이 있으면 그쪽이 항상 이긴다.</p>
+ *
+ * <h3>일부만 있어도 돈다</h3>
+ *
+ * <p>정책 JSON에 키가 빠져 있거나 값이 이상하면 <b>그 항목만</b> 기본값으로 넘어간다.
+ * 오타 하나로 전체가 기본값이 되면 어느 요율이 적용됐는지 알기 어렵다.
+ * 대신 어떤 키가 넘어갔는지 경고에 남긴다.</p>
+ *
+ * <p>경고는 <b>같은 상황이 이어지는 동안 한 번만</b> 남긴다 — 거래마다 부르는 자리라
+ * 그냥 찍으면 로그가 거래 수만큼 쌓인다.</p>
+ */
+@Component
+public class TradePolicyProvider {
+
+    /** {@code system_policies.policy_key}. */
+    public static final String POLICY_KEY = "TRADE";
+
+    private static final BigDecimal MAX_RATE = BigDecimal.ONE;
+
+    private static final Logger log = LogManager.getLogger(TradePolicyProvider.class);
+
+    private final SystemPolicyReader systemPolicyReader;
+
+    private final BigDecimal defaultBuyFeeRate;
+    private final BigDecimal defaultSellFeeRate;
+    private final BigDecimal defaultSecuritiesTransactionTaxRate;
+    private final BigDecimal defaultDividendIncomeTaxRate;
+    private final BigDecimal defaultInterestIncomeTaxRate;
+
+    /** 직전에 남긴 경고. 같은 내용이 반복되면 다시 남기지 않는다. */
+    private final AtomicReference<String> lastWarning = new AtomicReference<>();
+
+    public TradePolicyProvider(
+            SystemPolicyReader systemPolicyReader,
+            @Value("${trade.policy.buy-fee-rate:0.00015}") BigDecimal defaultBuyFeeRate,
+            @Value("${trade.policy.sell-fee-rate:0.00015}") BigDecimal defaultSellFeeRate,
+            @Value("${trade.policy.securities-transaction-tax-rate:0.0020}")
+            BigDecimal defaultSecuritiesTransactionTaxRate,
+            @Value("${trade.policy.dividend-income-tax-rate:0.154}")
+            BigDecimal defaultDividendIncomeTaxRate,
+            @Value("${trade.policy.interest-income-tax-rate:0.154}")
+            BigDecimal defaultInterestIncomeTaxRate
+    ) {
+        this.systemPolicyReader = systemPolicyReader;
+        this.defaultBuyFeeRate = defaultBuyFeeRate;
+        this.defaultSellFeeRate = defaultSellFeeRate;
+        this.defaultSecuritiesTransactionTaxRate = defaultSecuritiesTransactionTaxRate;
+        this.defaultDividendIncomeTaxRate = defaultDividendIncomeTaxRate;
+        this.defaultInterestIncomeTaxRate = defaultInterestIncomeTaxRate;
+    }
+
+    /**
+     * 그 시점에 적용할 요율.
+     *
+     * @param at 기준 시각(UTC). 거래 시점이자 자산 이벤트 확정 시점이다
+     */
+    public TradePolicy findAt(LocalDateTime at) {
+        SystemPolicy policy = systemPolicyReader.findActive(POLICY_KEY, at);
+
+        if (policy == null) {
+            warnOnce("정책 없음", "TRADE 정책이 없어 설정 기본값으로 계산합니다. system_policies에 행을 넣어 주세요.");
+
+            return defaults(null);
+        }
+
+        JsonNode config = systemPolicyReader.findActiveConfig(POLICY_KEY, at);
+
+        if (config == null) {
+            warnOnce(
+                    "내용 없음 v" + policy.getVersionNo(),
+                    "TRADE 정책 내용을 읽지 못해 설정 기본값으로 계산합니다 version=" + policy.getVersionNo()
+            );
+
+            return defaults(null);
+        }
+
+        List<String> fellBack = new ArrayList<>();
+
+        TradePolicy resolved = new TradePolicy(
+                rate(config, "buy_fee_rate", defaultBuyFeeRate, fellBack),
+                rate(config, "sell_fee_rate", defaultSellFeeRate, fellBack),
+                rate(config, "securities_transaction_tax_rate", defaultSecuritiesTransactionTaxRate, fellBack),
+                rate(config, "dividend_income_tax_rate", defaultDividendIncomeTaxRate, fellBack),
+                rate(config, "interest_income_tax_rate", defaultInterestIncomeTaxRate, fellBack),
+                policy.getVersionNo()
+        );
+
+        if (!fellBack.isEmpty()) {
+            warnOnce(
+                    "일부 누락 v" + policy.getVersionNo() + fellBack,
+                    "TRADE 정책에서 읽지 못한 항목이 있어 그 항목만 기본값으로 계산합니다 "
+                            + "version=" + policy.getVersionNo() + " 항목=" + fellBack
+            );
+        }
+
+        return resolved;
+    }
+
+    /**
+     * JSON에서 비율 하나를 읽는다. <b>읽을 수 없으면 기본값</b>이고 어떤 키였는지 기록한다.
+     *
+     * <p>값은 문자열로 담기지만 숫자로 담겨도 읽는다 — {@code asText()}가 둘 다 처리한다.
+     * 부동소수점을 거치지 않으려고 {@link BigDecimal} 문자열 생성자를 쓴다
+     * (금액 계산에 float/double 금지, CLAUDE.md 2절).</p>
+     *
+     * <p>0 미만이거나 1을 넘으면 <b>비율로 성립하지 않으므로</b> 기본값으로 넘어간다.
+     * 100을 넣는 실수(퍼센트로 착각)가 그대로 반영되면 자산이 통째로 사라진다.</p>
+     */
+    private static BigDecimal rate(
+            JsonNode config,
+            String field,
+            BigDecimal fallback,
+            List<String> fellBack
+    ) {
+        JsonNode node = config.get(field);
+
+        if (node == null || node.isNull()) {
+            fellBack.add(field);
+
+            return fallback;
+        }
+
+        try {
+            BigDecimal value = new BigDecimal(node.asText().trim());
+
+            if (value.signum() < 0 || value.compareTo(MAX_RATE) > 0) {
+                fellBack.add(field);
+
+                return fallback;
+            }
+
+            return value;
+        } catch (NumberFormatException exception) {
+            fellBack.add(field);
+
+            return fallback;
+        }
+    }
+
+    private TradePolicy defaults(Integer policyVersion) {
+        return new TradePolicy(
+                defaultBuyFeeRate,
+                defaultSellFeeRate,
+                defaultSecuritiesTransactionTaxRate,
+                defaultDividendIncomeTaxRate,
+                defaultInterestIncomeTaxRate,
+                policyVersion
+        );
+    }
+
+    /** 같은 상황이 이어지는 동안은 한 번만 남긴다. 상황이 바뀌면 다시 남긴다. */
+    private void warnOnce(String signature, String message) {
+        if (!signature.equals(lastWarning.getAndSet(signature))) {
+            log.warn(message);
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,6 +40,12 @@ portfolio.event.batch.enabled=${PORTFOLIO_EVENT_BATCH_ENABLED:false}
 
 scheduling.pool-size=${SCHEDULING_POOL_SIZE:2}
 
+trade.policy.buy-fee-rate=${TRADE_BUY_FEE_RATE:0.00015}
+trade.policy.sell-fee-rate=${TRADE_SELL_FEE_RATE:0.00015}
+trade.policy.securities-transaction-tax-rate=${TRADE_SECURITIES_TRANSACTION_TAX_RATE:0.0020}
+trade.policy.dividend-income-tax-rate=${TRADE_DIVIDEND_INCOME_TAX_RATE:0.154}
+trade.policy.interest-income-tax-rate=${TRADE_INTEREST_INCOME_TAX_RATE:0.154}
+
 internal.call-token=${INTERNAL_CALL_TOKEN:}
 
 cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://127.0.0.1:5173}

--- a/src/main/resources/mappers/policy/SystemPolicyMapper.xml
+++ b/src/main/resources/mappers/policy/SystemPolicyMapper.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.firstfolio.policy.mapper.SystemPolicyMapper">
+
+    <!-- is_active(컬럼)와 active(프로퍼티) 이름이 달라 자동 매핑에 기대지 않고 명시한다. -->
+    <resultMap id="systemPolicyResult" type="org.firstfolio.policy.domain.SystemPolicy">
+        <id property="policyId" column="policy_id"/>
+        <result property="policyKey" column="policy_key"/>
+        <result property="versionNo" column="version_no"/>
+        <result property="configJson" column="config_json"/>
+        <result property="effectiveFrom" column="effective_from"/>
+        <result property="effectiveTo" column="effective_to"/>
+        <result property="active" column="is_active"/>
+        <result property="createdBy" column="created_by"/>
+        <result property="createdAt" column="created_at"/>
+    </resultMap>
+
+    <!--
+        idx_system_policies_active_period (policy_key, is_active, effective_from, effective_to)를 탄다.
+
+        effective_to IS NULL은 "아직 끝나지 않은 정책"이다. 이 조건을 빠뜨리면 종료 없는 정책이
+        전부 걸러져 아무것도 안 나온다.
+    -->
+    <select id="findActive" resultMap="systemPolicyResult">
+        SELECT policy_id,
+               policy_key,
+               version_no,
+               config_json,
+               effective_from,
+               effective_to,
+               is_active,
+               created_by,
+               created_at
+        FROM system_policies
+        WHERE policy_key = #{policyKey}
+          AND is_active = TRUE
+          AND effective_from &lt;= #{at}
+          AND (effective_to IS NULL OR effective_to &gt; #{at})
+        ORDER BY version_no DESC
+        LIMIT 1
+    </select>
+
+</mapper>

--- a/src/test/java/org/firstfolio/persistence/SystemPolicyJdbcTest.java
+++ b/src/test/java/org/firstfolio/persistence/SystemPolicyJdbcTest.java
@@ -1,0 +1,274 @@
+package org.firstfolio.persistence;
+
+import org.firstfolio.config.RootConfig;
+import org.firstfolio.policy.mapper.SystemPolicyMapper;
+import org.firstfolio.policy.service.SystemPolicyReader;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.DataSourceUtils;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * 정책 조회를 실제 MySQL에 붙여서 확인한다 (#64).
+ *
+ * <h3>왜 필요한가</h3>
+ *
+ * <p>활성 버전을 고르는 조건이 <b>넷</b>이다 — {@code is_active} · {@code effective_from} ·
+ * {@code effective_to}(null 허용) · 최신 {@code version_no}.
+ * <b>하나만 어긋나도 옛 정책으로 조용히 계산된다.</b> 값이 틀린 것이 아니라 다른 버전이 나오는
+ * 것이라 예외도 안 난다. 서비스 테스트는 매퍼를 모킹해 이 SQL을 한 줄도 읽지 않는다.</p>
+ *
+ * <h3>⚠️ 한 테스트 안에서 같은 파라미터로 두 번 묻지 않는다</h3>
+ *
+ * <p>조건별로 테스트를 쪼갠 것은 취향이 아니라 <b>MyBatis 1차 캐시 때문</b>이다.
+ * 트랜잭션 안에서는 {@code SqlSession}이 재사용되고 <b>같은 문장·같은 파라미터의 결과가
+ * 캐시된다.</b> 데이터를 raw JDBC로 넣으면 MyBatis는 그 사실을 몰라 캐시를 비우지 않는다.</p>
+ *
+ * <pre>
+ * findActive(key, NOW)  → null (캐시됨)
+ * INSERT (raw JDBC)     → MyBatis는 모른다
+ * findActive(key, NOW)  → 캐시 적중, 여전히 null   ← 실제로 겪었다
+ * </pre>
+ *
+ * <p>그래서 <b>데이터를 먼저 다 넣고 마지막에 한 번만 묻는다.</b></p>
+ *
+ * <p>넣은 데이터는 <b>전부 롤백</b>한다.</p>
+ *
+ * <pre>./gradlew jdbcTest</pre>
+ */
+@Tag("jdbc")
+class SystemPolicyJdbcTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 8, 11, 6, 0);
+
+    /**
+     * 기존 시드 정책과 섞이지 않도록 테스트 전용 키를 쓴다.
+     *
+     * <p><b>테스트마다 새로 만든다.</b> 클래스 상수로 두면 롤백이 실패했을 때 다음 테스트가
+     * 유니크 제약에 걸려 원인이 엉뚱한 곳으로 보인다.</p>
+     */
+    private final String testKey = "JDBC_TEST_" + UUID.randomUUID().toString().substring(0, 8);
+
+    // ------------------------------------------------------------- 버전 선택 네 조건
+
+    @Test
+    @DisplayName("여러 버전이 유효하면 가장 높은 버전을 고른다")
+    void picksHighestValidVersion() throws Exception {
+        withRollback((connection, context) -> {
+            long userId = PortfolioFixtures.insertUser(connection);
+
+            insert(connection, userId, 1, rate("0.001"), NOW.minusDays(10), null, true);
+            insert(connection, userId, 2, rate("0.002"), NOW.minusDays(5), null, true);
+
+            assertEquals(2, mapper(context).findActive(testKey, NOW).getVersionNo());
+        });
+    }
+
+    @Test
+    @DisplayName("is_active=false는 버전이 높아도 제외한다")
+    void excludesInactiveVersion() throws Exception {
+        withRollback((connection, context) -> {
+            long userId = PortfolioFixtures.insertUser(connection);
+
+            insert(connection, userId, 1, rate("0.001"), NOW.minusDays(10), null, true);
+            insert(connection, userId, 2, rate("0.002"), NOW.minusDays(5), null, false);
+
+            assertEquals(1, mapper(context).findActive(testKey, NOW).getVersionNo());
+        });
+    }
+
+    @Test
+    @DisplayName("effective_from이 아직 안 됐으면 제외한다")
+    void excludesNotYetEffectiveVersion() throws Exception {
+        withRollback((connection, context) -> {
+            long userId = PortfolioFixtures.insertUser(connection);
+
+            insert(connection, userId, 1, rate("0.001"), NOW.minusDays(10), null, true);
+            insert(connection, userId, 2, rate("0.002"), NOW.plusDays(1), null, true);
+
+            assertEquals(1, mapper(context).findActive(testKey, NOW).getVersionNo());
+        });
+    }
+
+    @Test
+    @DisplayName("effective_to가 지났으면 제외한다")
+    void excludesExpiredVersion() throws Exception {
+        withRollback((connection, context) -> {
+            long userId = PortfolioFixtures.insertUser(connection);
+
+            insert(connection, userId, 1, rate("0.001"), NOW.minusDays(10), null, true);
+            insert(connection, userId, 2, rate("0.002"), NOW.minusDays(9), NOW.minusDays(2), true);
+
+            assertEquals(1, mapper(context).findActive(testKey, NOW).getVersionNo());
+        });
+    }
+
+    @Test
+    @DisplayName("effective_to가 null이면 아직 끝나지 않은 정책이다")
+    void treatsNullEffectiveToAsOpenEnded() throws Exception {
+        withRollback((connection, context) -> {
+            long userId = PortfolioFixtures.insertUser(connection);
+
+            insert(connection, userId, 1, rate("0.001"), NOW.minusYears(1), null, true);
+
+            // IS NULL 조건을 빠뜨리면 여기서 null이 나온다.
+            assertNotNull(mapper(context).findActive(testKey, NOW.plusYears(5)));
+        });
+    }
+
+    // ------------------------------------------------------------- 경계·격리
+
+    @Test
+    @DisplayName("경계 — effective_from 정각은 포함, effective_to 정각은 제외")
+    void handlesBoundaries() throws Exception {
+        withRollback((connection, context) -> {
+            long userId = PortfolioFixtures.insertUser(connection);
+            LocalDateTime from = NOW;
+            LocalDateTime to = NOW.plusDays(1);
+
+            insert(connection, userId, 1, rate("0.001"), from, to, true);
+
+            SystemPolicyMapper mapper = mapper(context);
+
+            // 네 번 묻지만 파라미터가 모두 달라 1차 캐시에 걸리지 않는다.
+            assertNotNull(mapper.findActive(testKey, from), "시작 정각은 유효");
+            assertNull(mapper.findActive(testKey, from.minusSeconds(1)), "시작 1초 전은 무효");
+            assertNotNull(mapper.findActive(testKey, to.minusSeconds(1)), "종료 1초 전은 유효");
+            assertNull(mapper.findActive(testKey, to), "종료 정각은 무효");
+        });
+    }
+
+    @Test
+    @DisplayName("다른 키의 정책은 섞이지 않는다")
+    void isolatesByPolicyKey() throws Exception {
+        withRollback((connection, context) -> {
+            long userId = PortfolioFixtures.insertUser(connection);
+
+            insert(connection, userId, 1, rate("0.001"), NOW.minusDays(1), null, true);
+
+            assertNull(mapper(context).findActive(testKey + "_OTHER", NOW));
+        });
+    }
+
+    @Test
+    @DisplayName("정책이 없으면 null이다 — 오류가 아니다")
+    void returnsNullWhenNoPolicy() throws Exception {
+        withRollback((connection, context) ->
+                assertNull(mapper(context).findActive(testKey, NOW)));
+    }
+
+    // ------------------------------------------------------------- Reader
+
+    @Test
+    @DisplayName("SystemPolicyReader가 config_json을 JSON으로 돌려준다")
+    void readerParsesConfigJson() throws Exception {
+        withRollback((connection, context) -> {
+            long userId = PortfolioFixtures.insertUser(connection);
+
+            insert(connection, userId, 1, rate("0.00015"), NOW.minusDays(1), null, true);
+
+            assertEquals(
+                    "0.00015",
+                    context.getBean(SystemPolicyReader.class)
+                            .findActiveConfig(testKey, NOW)
+                            .get("buy_fee_rate")
+                            .asText()
+            );
+        });
+    }
+
+    @Test
+    @DisplayName("정책이 없으면 Reader도 null을 준다 — 호출한 쪽이 기본값으로 넘어간다")
+    void readerReturnsNullWhenNoPolicy() throws Exception {
+        withRollback((connection, context) ->
+                assertNull(context.getBean(SystemPolicyReader.class).findActiveConfig(testKey, NOW)));
+    }
+
+    // ------------------------------------------------------------- 도구
+
+    /** 시나리오를 트랜잭션 안에서 돌리고 반드시 롤백한다. */
+    private void withRollback(Scenario scenario) throws Exception {
+        try (AnnotationConfigApplicationContext context = context()) {
+            DataSource dataSource = context.getBean(DataSource.class);
+            DataSourceTransactionManager transactionManager =
+                    context.getBean(DataSourceTransactionManager.class);
+
+            TransactionStatus transaction =
+                    transactionManager.getTransaction(new DefaultTransactionDefinition());
+
+            try {
+                // 트랜잭션에 묶인 커넥션이어야 롤백된다. dataSource.getConnection()은 별개 커넥션이다.
+                scenario.run(DataSourceUtils.getConnection(dataSource), context);
+            } finally {
+                transactionManager.rollback(transaction);
+            }
+        }
+    }
+
+    @FunctionalInterface
+    private interface Scenario {
+        void run(Connection connection, AnnotationConfigApplicationContext context) throws Exception;
+    }
+
+    private static SystemPolicyMapper mapper(AnnotationConfigApplicationContext context) {
+        return context.getBean(SystemPolicyMapper.class);
+    }
+
+    private static String rate(String buyFeeRate) {
+        return "{\"buy_fee_rate\": \"" + buyFeeRate + "\"}";
+    }
+
+    /** 시각은 UTC로 넣는다. MySQL의 {@code NOW()}는 KST라 9시간 어긋난다. */
+    private void insert(
+            Connection connection,
+            long userId,
+            int versionNo,
+            String configJson,
+            LocalDateTime effectiveFrom,
+            LocalDateTime effectiveTo,
+            boolean active
+    ) throws Exception {
+        String sql = "INSERT INTO system_policies ("
+                + "policy_key, version_no, config_json, effective_from, effective_to,"
+                + " is_active, created_by, created_at"
+                + ") VALUES (?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP())";
+
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, testKey);
+            statement.setInt(2, versionNo);
+            statement.setString(3, configJson);
+            statement.setObject(4, effectiveFrom);
+            statement.setObject(5, effectiveTo);
+            statement.setBoolean(6, active);
+            statement.setLong(7, userId);
+            statement.executeUpdate();
+        }
+    }
+
+    private static AnnotationConfigApplicationContext context() throws Exception {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+
+        context.getEnvironment().getPropertySources().addFirst(
+                new MapPropertySource("systemPolicyJdbcTest", LocalDatabaseProperties.load())
+        );
+        context.register(RootConfig.class);
+        context.refresh();
+
+        return context;
+    }
+}

--- a/src/test/java/org/firstfolio/portfolio/service/TradePolicyProviderTest.java
+++ b/src/test/java/org/firstfolio/portfolio/service/TradePolicyProviderTest.java
@@ -1,0 +1,199 @@
+package org.firstfolio.portfolio.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.firstfolio.common.json.ApiObjectMapperFactory;
+import org.firstfolio.policy.domain.SystemPolicy;
+import org.firstfolio.policy.service.SystemPolicyReader;
+import org.firstfolio.portfolio.domain.TradePolicy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TradePolicyProviderTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 8, 11, 6, 0);
+
+    /** v3 3.3절 확정값 + D14. 설정 기본값과 같아야 한다. */
+    private static final BigDecimal DEFAULT_FEE = new BigDecimal("0.00015");
+    private static final BigDecimal DEFAULT_TRANSACTION_TAX = new BigDecimal("0.0020");
+    private static final BigDecimal DEFAULT_INCOME_TAX = new BigDecimal("0.154");
+
+    private static final ObjectMapper OBJECT_MAPPER = ApiObjectMapperFactory.create();
+
+    private SystemPolicyReader systemPolicyReader;
+    private TradePolicyProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        systemPolicyReader = mock(SystemPolicyReader.class);
+
+        provider = new TradePolicyProvider(
+                systemPolicyReader,
+                DEFAULT_FEE,
+                DEFAULT_FEE,
+                DEFAULT_TRANSACTION_TAX,
+                DEFAULT_INCOME_TAX,
+                DEFAULT_INCOME_TAX
+        );
+    }
+
+    /** 저장된 정책이 있는 상황을 만든다. */
+    private void givenPolicy(int versionNo, String configJson) {
+        SystemPolicy policy = new SystemPolicy();
+
+        policy.setPolicyKey("TRADE");
+        policy.setVersionNo(versionNo);
+        policy.setConfigJson(configJson);
+        policy.setActive(true);
+
+        when(systemPolicyReader.findActive(anyString(), any())).thenReturn(policy);
+
+        try {
+            JsonNode config = configJson == null ? null : OBJECT_MAPPER.readTree(configJson);
+
+            when(systemPolicyReader.findActiveConfig(anyString(), any())).thenReturn(config);
+        } catch (Exception exception) {
+            when(systemPolicyReader.findActiveConfig(anyString(), any())).thenReturn(null);
+        }
+    }
+
+    private static String fullConfig() {
+        return "{"
+                + "\"buy_fee_rate\": \"0.0001\","
+                + "\"sell_fee_rate\": \"0.0002\","
+                + "\"securities_transaction_tax_rate\": \"0.003\","
+                + "\"dividend_income_tax_rate\": \"0.11\","
+                + "\"interest_income_tax_rate\": \"0.12\""
+                + "}";
+    }
+
+    // ------------------------------------------------------------- 저장된 정책
+
+    @Test
+    @DisplayName("저장된 정책이 있으면 그 값을 쓴다 — 설정 기본값이 아니다")
+    void usesStoredPolicyWhenPresent() {
+        givenPolicy(3, fullConfig());
+
+        TradePolicy policy = provider.findAt(NOW);
+
+        assertEquals(new BigDecimal("0.0001"), policy.getBuyFeeRate());
+        assertEquals(new BigDecimal("0.0002"), policy.getSellFeeRate());
+        assertEquals(new BigDecimal("0.003"), policy.getSecuritiesTransactionTaxRate());
+        assertEquals(new BigDecimal("0.11"), policy.getDividendIncomeTaxRate());
+        assertEquals(new BigDecimal("0.12"), policy.getInterestIncomeTaxRate());
+    }
+
+    @Test
+    @DisplayName("적용된 정책 버전을 남긴다 — 나중에 과거 거래를 검산해야 한다")
+    void keepsPolicyVersion() {
+        givenPolicy(3, fullConfig());
+
+        TradePolicy policy = provider.findAt(NOW);
+
+        assertEquals(3, policy.getPolicyVersion());
+        assertTrue(policy.isFromStoredPolicy());
+    }
+
+    @Test
+    @DisplayName("숫자로 담겨 있어도 읽는다 — 문자열이 권장이지만 강제는 아니다")
+    void readsNumericJsonValues() {
+        givenPolicy(1, "{\"buy_fee_rate\": 0.00025}");
+
+        assertEquals(new BigDecimal("0.00025"), provider.findAt(NOW).getBuyFeeRate());
+    }
+
+    // ------------------------------------------------------------- 폴백
+
+    @Test
+    @DisplayName("정책이 없으면 설정 기본값으로 돈다 — 거래가 멈추면 안 된다")
+    void fallsBackWhenNoPolicy() {
+        when(systemPolicyReader.findActive(anyString(), any())).thenReturn(null);
+
+        TradePolicy policy = provider.findAt(NOW);
+
+        assertEquals(DEFAULT_FEE, policy.getBuyFeeRate());
+        assertEquals(DEFAULT_INCOME_TAX, policy.getInterestIncomeTaxRate());
+        assertNull(policy.getPolicyVersion(), "기본값으로 돌았다는 사실이 드러나야 합니다.");
+        assertFalse(policy.isFromStoredPolicy());
+    }
+
+    @Test
+    @DisplayName("내용을 못 읽으면 전부 기본값이다")
+    void fallsBackWhenConfigUnreadable() {
+        givenPolicy(2, null);
+        when(systemPolicyReader.findActiveConfig(anyString(), any())).thenReturn(null);
+
+        TradePolicy policy = provider.findAt(NOW);
+
+        assertEquals(DEFAULT_FEE, policy.getBuyFeeRate());
+        assertNull(policy.getPolicyVersion());
+    }
+
+    @Test
+    @DisplayName("빠진 항목만 기본값으로 넘어간다 — 오타 하나로 전체가 넘어가면 안 된다")
+    void fallsBackPerMissingField() {
+        givenPolicy(4, "{\"buy_fee_rate\": \"0.0009\"}");
+
+        TradePolicy policy = provider.findAt(NOW);
+
+        assertEquals(new BigDecimal("0.0009"), policy.getBuyFeeRate(), "있는 값은 그대로");
+        assertEquals(DEFAULT_FEE, policy.getSellFeeRate(), "빠진 값만 기본값");
+        assertEquals(DEFAULT_INCOME_TAX, policy.getInterestIncomeTaxRate());
+        assertEquals(4, policy.getPolicyVersion(), "일부가 넘어가도 정책 버전은 그 정책이다.");
+    }
+
+    @Test
+    @DisplayName("숫자로 해석되지 않는 값은 기본값으로 넘어간다")
+    void fallsBackOnUnparsableValue() {
+        givenPolicy(5, "{\"buy_fee_rate\": \"영점영일오\"}");
+
+        assertEquals(DEFAULT_FEE, provider.findAt(NOW).getBuyFeeRate());
+    }
+
+    @Test
+    @DisplayName("비율 범위를 벗어나면 기본값으로 넘어간다 — 퍼센트로 착각한 값이 그대로 들어가면 자산이 사라진다")
+    void rejectsRatesOutsideZeroToOne() {
+        givenPolicy(6, "{\"buy_fee_rate\": \"15.4\", \"sell_fee_rate\": \"-0.1\"}");
+
+        TradePolicy policy = provider.findAt(NOW);
+
+        assertEquals(DEFAULT_FEE, policy.getBuyFeeRate(), "1을 넘는 비율은 거부");
+        assertEquals(DEFAULT_FEE, policy.getSellFeeRate(), "음수 비율은 거부");
+    }
+
+    @Test
+    @DisplayName("0과 1은 유효한 비율이다 — 무료 수수료 이벤트와 전액 과세가 경계다")
+    void acceptsBoundaryRates() {
+        givenPolicy(7, "{\"buy_fee_rate\": \"0\", \"sell_fee_rate\": \"1\"}");
+
+        TradePolicy policy = provider.findAt(NOW);
+
+        assertEquals(BigDecimal.ZERO, policy.getBuyFeeRate().stripTrailingZeros());
+        assertEquals(0, policy.getSellFeeRate().compareTo(BigDecimal.ONE));
+    }
+
+    // ------------------------------------------------------------- 조회 규약
+
+    @Test
+    @DisplayName("TRADE 키와 넘겨받은 시각으로 조회한다")
+    void queriesWithTradeKeyAndGivenTime() {
+        when(systemPolicyReader.findActive(anyString(), any())).thenReturn(null);
+
+        provider.findAt(NOW);
+
+        org.mockito.Mockito.verify(systemPolicyReader).findActive(TradePolicyProvider.POLICY_KEY, NOW);
+    }
+}


### PR DESCRIPTION
## 개요

* 고정 상수 하드코딩을 제거하고, TRADE 정책 버전에 따른 수수료·세율 조회 기반 마련
* 연관 작업 #24(수수료, 증권·배당·이자소득세)가 이 시스템 위에서 작동함

## 핵심 구현 및 방어 설계

### 1. 공용 system_policies 구조화

* 패키지 공통화: 8개 도메인이 공유하는 구조를 반영해 최상위 policy 패키지로 신설
* 오계산 방지: 4대 활성 조건 검증을 일원화하여 구버전 정책이 잘못 적용되는 버그 원천 차단
* 역할 분리: 공통 영역은 유효 행 추출만 담당, 내부 config_json 파싱은 각 도메인에 위임

### 2. TRADE 정책 해석 및 안전장치(폴백)

* 항목별 독립 폴백: 오타로 전체 요율이 오염되는 것을 막기 위해 항목별로 프로퍼티 기본값 적용 (폴백 시 이력 추적용 null 명시)
* 자산 보호: 퍼센트 착각 입력 등 비정상 데이터 방지를 위해 요율 비율 범위(0 ~ 1) 거부 로직 추가

## 참고사항

* 스키마 변경 없음: 기존 테이블 활용, 매퍼 질의만 1개 추가
* 후속 작업: #24 