### PR TITLE
feat: 대시보드 집계 API 구현 #74

### DIFF
--- a/src/main/java/org/firstfolio/config/OpenApiResponseSchemas.java
+++ b/src/main/java/org/firstfolio/config/OpenApiResponseSchemas.java
@@ -7,6 +7,7 @@ import org.firstfolio.admin.dto.response.ProductImportResponse;
 import org.firstfolio.auth.dto.response.LoginResponse;
 import org.firstfolio.auth.dto.response.SignupResponse;
 import org.firstfolio.content.dto.response.ContentVersionCreateResponse;
+import org.firstfolio.dashboard.dto.response.DashboardResponse;
 import org.firstfolio.content.dto.response.ContentVersionListResponse;
 import org.firstfolio.content.dto.response.ContentVersionPublishResponse;
 import org.firstfolio.curriculum.dto.response.MainChapterCreateResponse;
@@ -150,4 +151,7 @@ public final class OpenApiResponseSchemas {
 
     @Schema(name = "AdminProductApiResponse")
     public record AdminProduct(AdminProductResponse data) { }
+
+    @Schema(name = "DashboardApiResponse")
+    public record Dashboard(DashboardResponse data) { }
 }

--- a/src/main/java/org/firstfolio/dashboard/controller/DashboardController.java
+++ b/src/main/java/org/firstfolio/dashboard/controller/DashboardController.java
@@ -1,0 +1,49 @@
+package org.firstfolio.dashboard.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.firstfolio.auth.annotation.CurrentUser;
+import org.firstfolio.auth.domain.AuthenticatedUser;
+import org.firstfolio.common.response.ApiResponse;
+import org.firstfolio.config.OpenApiResponseSchemas;
+import org.firstfolio.dashboard.dto.response.DashboardResponse;
+import org.firstfolio.dashboard.service.DashboardService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/dashboard")
+@Tag(name = "대시보드", description = "홈 화면 집계 조회 API")
+public class DashboardController {
+
+    private final DashboardService dashboardService;
+
+    public DashboardController(DashboardService dashboardService) {
+        this.dashboardService = dashboardService;
+    }
+
+    @GetMapping
+    @Operation(
+            summary = "대시보드 조회",
+            description = "포트폴리오·학습·예정 자산 이벤트·일일 퀘스트·최신 뉴스 5개 섹션을 한 번에 반환합니다. "
+                    + "섹션별로 조회 불가 사유가 있으면 해당 섹션만 available:false로 표시되고, 전체 응답은 항상 200입니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            description = "대시보드 조회 성공",
+                            content = @io.swagger.v3.oas.annotations.media.Content(
+                                    mediaType = "application/json",
+                                    schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                            implementation = OpenApiResponseSchemas.Dashboard.class
+                                    )
+                            )
+                    )
+            }
+    )
+    public ApiResponse<DashboardResponse> getDashboard(
+            @CurrentUser AuthenticatedUser currentUser
+    ) {
+        return ApiResponse.of(dashboardService.getDashboard(currentUser.userId()));
+    }
+}

--- a/src/main/java/org/firstfolio/dashboard/dto/response/DailyQuestSummaryResponse.java
+++ b/src/main/java/org/firstfolio/dashboard/dto/response/DailyQuestSummaryResponse.java
@@ -1,0 +1,57 @@
+package org.firstfolio.dashboard.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+// 일일퀘스트 섹션
+@Schema(description = "대시보드 daily_quest 섹션")
+public final class DailyQuestSummaryResponse {
+
+    @Schema(description = "조회 가능 여부")
+    private final boolean available;
+    @Schema(description = "available=false일 때의 사유", example = "NOT_IMPLEMENTED", allowableValues = {"NOT_IMPLEMENTED"})
+    private final String reason;
+    @Schema(description = "퀘스트 상태", example = "IN_PROGRESS", allowableValues = {"ASSIGNED", "IN_PROGRESS", "COMPLETED"})
+    private final String status;
+    @Schema(description = "답안 제출 완료 문항 수", example = "2")
+    private final Integer answeredCount;
+    @Schema(description = "전체 문항 수", example = "5")
+    private final Integer totalCount;
+
+    public DailyQuestSummaryResponse(
+        boolean available,
+        String reason,
+        String status,
+        Integer answeredCount,
+        Integer totalCount
+    ) {
+        this.available = available;
+        this.reason = reason;
+        this.status = status;
+        this.answeredCount = answeredCount;
+        this.totalCount = totalCount;
+    }
+
+    public static DailyQuestSummaryResponse notImplemented() {
+        return new DailyQuestSummaryResponse(false, "NOT_IMPLEMENTED", null, null, null);
+    }
+
+    public boolean isAvailable() {
+        return available;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public Integer getAnsweredCount() {
+        return answeredCount;
+    }
+
+    public Integer getTotalCount() {
+        return totalCount;
+    }
+}

--- a/src/main/java/org/firstfolio/dashboard/dto/response/DashboardResponse.java
+++ b/src/main/java/org/firstfolio/dashboard/dto/response/DashboardResponse.java
@@ -1,0 +1,55 @@
+package org.firstfolio.dashboard.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+// 다른 5개 섹션을 조합한 최종 대시보드 집계 섹션
+@Schema(description = "대시보드 5개 섹션 집계 응답")
+public final class DashboardResponse {
+
+    @Schema(description = "포트폴리오 요약")
+    private final PortfolioSummaryResponse portfolio;
+    @Schema(description = "일일 퀘스트 요약")
+    private final DailyQuestSummaryResponse dailyQuest;
+    @Schema(description = "학습 이어하기 요약")
+    private final LearningSummaryResponse learning;
+    @Schema(description = "예정 자산 이벤트 목록")
+    private final List<UpcomingEventResponse> upcomingEvents;
+    @Schema(description = "최신 뉴스 목록")
+    private final List<LatestNewsResponse> latestNews;
+
+    public DashboardResponse(
+        PortfolioSummaryResponse portfolio,
+        DailyQuestSummaryResponse dailyQuest,
+        LearningSummaryResponse learning,
+        List<UpcomingEventResponse> upcomingEvents,
+        List<LatestNewsResponse> latestNews
+    ) {
+        this.portfolio = portfolio;
+        this.dailyQuest = dailyQuest;
+        this.learning = learning;
+        this.upcomingEvents = upcomingEvents;
+        this.latestNews = latestNews;
+    }
+
+    public PortfolioSummaryResponse getPortfolio() {
+        return portfolio;
+    }
+
+    public DailyQuestSummaryResponse getDailyQuest() {
+        return dailyQuest;
+    }
+
+    public LearningSummaryResponse getLearning() {
+        return learning;
+    }
+
+    public List<UpcomingEventResponse> getUpcomingEvents() {
+        return upcomingEvents;
+    }
+
+    public List<LatestNewsResponse> getLatestNews() {
+        return latestNews;
+    }
+}

--- a/src/main/java/org/firstfolio/dashboard/dto/response/LatestNewsResponse.java
+++ b/src/main/java/org/firstfolio/dashboard/dto/response/LatestNewsResponse.java
@@ -1,0 +1,46 @@
+package org.firstfolio.dashboard.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+/**
+ * 대시보드 latest_news 섹션 한 건.
+ *
+ * <p>FE {@code dashboardService.js}가 이 섹션을 배열 그대로 기대하고 바로 {@code .map()}을
+ * 호출하기 때문에, {@code available}/{@code reason} 래핑 없이 JSON 최상위에 배열로 나간다
+ * (뉴스 도메인이 없어 지금은 항상 빈 배열).</p>
+ *
+ * <p>{@code knowledgeContentId} 필드명은 FE mock을 잠정 사용한 것이다. 실제 식별자 체계는
+ * AI↔BE 연동 트랙에서 확정한다 — 이 트랙 단독으로 정하지 않는다.</p>
+ */
+@Schema(description = "뉴스 한 건")
+public final class LatestNewsResponse {
+
+    @Schema(description = "잠정 식별자명 — 이름 확정 전", example = "1001")
+    private final Long knowledgeContentId;
+    @Schema(description = "제목")
+    private final String title;
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    @Schema(description = "기준 일시")
+    private final LocalDateTime referenceAt;
+
+    public LatestNewsResponse(Long knowledgeContentId, String title, LocalDateTime referenceAt) {
+        this.knowledgeContentId = knowledgeContentId;
+        this.title = title;
+        this.referenceAt = referenceAt;
+    }
+
+    public Long getKnowledgeContentId() {
+        return knowledgeContentId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public LocalDateTime getReferenceAt() {
+        return referenceAt;
+    }
+}

--- a/src/main/java/org/firstfolio/dashboard/dto/response/LearningSummaryResponse.java
+++ b/src/main/java/org/firstfolio/dashboard/dto/response/LearningSummaryResponse.java
@@ -1,0 +1,57 @@
+package org.firstfolio.dashboard.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+// 학습 진행상황 요약
+@Schema(description = "대시보드 learning 섹션")
+public final class LearningSummaryResponse {
+
+    @Schema(description = "이어갈 학습 위치 존재 여부")
+    private final boolean available;
+    @Schema(description = "available=false일 때의 사유", example = "NOT_STARTED", allowableValues = {"NOT_STARTED"})
+    private final String reason;
+    @Schema(description = "대단원 ID", example = "3")
+    private final Long mainChapterId;
+    @Schema(description = "소단원 ID", example = "12")
+    private final Long subChapterId;
+    @Schema(description = "현재 소단원 내 읽기 진행률(%)", example = "50")
+    private final Integer progressPercent;
+
+    public LearningSummaryResponse(
+        boolean available,
+        String reason,
+        Long mainChapterId,
+        Long subChapterId,
+        Integer progressPercent
+    ) {
+        this.available = available;
+        this.reason = reason;
+        this.mainChapterId = mainChapterId;
+        this.subChapterId = subChapterId;
+        this.progressPercent = progressPercent;
+    }
+
+    public static LearningSummaryResponse unavailable(String reason) {
+        return new LearningSummaryResponse(false, reason, null, null, null);
+    }
+
+    public boolean isAvailable() {
+        return available;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public Long getMainChapterId() {
+        return mainChapterId;
+    }
+
+    public Long getSubChapterId() {
+        return subChapterId;
+    }
+
+    public Integer getProgressPercent() {
+        return progressPercent;
+    }
+}

--- a/src/main/java/org/firstfolio/dashboard/dto/response/PortfolioSummaryResponse.java
+++ b/src/main/java/org/firstfolio/dashboard/dto/response/PortfolioSummaryResponse.java
@@ -1,0 +1,93 @@
+package org.firstfolio.dashboard.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+// 포트폴리오 요약
+@Schema(description = "대시보드 portfolio 섹션")
+public final class PortfolioSummaryResponse {
+
+    @Schema(description = "포트폴리오 보유 여부")
+    private final boolean available;
+    @Schema(description = "available=false일 때의 사유", example = "NO_PORTFOLIO", allowableValues = {"NO_PORTFOLIO"})
+    private final String reason;
+    @Schema(description = "총자산", type = "string", example = "31250000.00")
+    private final BigDecimal totalAssets;
+    @Schema(description = "최초 지급 모의투자금 대비 손익", type = "string", example = "1250000.00")
+    private final BigDecimal profitLoss;
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER_FLOAT)
+    @Schema(description = "손익률(%)", example = "4.17")
+    private final BigDecimal profitRate;
+    @Schema(description = "자산군별 비중. 합계의 나머지는 현금 비중")
+    private final List<Allocation> allocation;
+
+    public PortfolioSummaryResponse(
+        boolean available,
+        String reason,
+        BigDecimal totalAssets,
+        BigDecimal profitLoss,
+        BigDecimal profitRate,
+        List<Allocation> allocation
+    ) {
+        this.available = available;
+        this.reason = reason;
+        this.totalAssets = totalAssets;
+        this.profitLoss = profitLoss;
+        this.profitRate = profitRate;
+        this.allocation = allocation;
+    }
+
+    public static PortfolioSummaryResponse unavailable(String reason) {
+        return new PortfolioSummaryResponse(false, reason, null, null, null, null);
+    }
+
+    public boolean isAvailable() {
+        return available;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public BigDecimal getTotalAssets() {
+        return totalAssets;
+    }
+
+    public BigDecimal getProfitLoss() {
+        return profitLoss;
+    }
+
+    public BigDecimal getProfitRate() {
+        return profitRate;
+    }
+
+    public List<Allocation> getAllocation() {
+        return allocation;
+    }
+
+    @Schema(description = "자산군별 평가 비중")
+    public static final class Allocation {
+
+        @Schema(description = "자산군", example = "DEPOSIT_SAVINGS")
+        private final String assetType;
+        @JsonFormat(shape = JsonFormat.Shape.NUMBER_FLOAT)
+        @Schema(description = "총자산 대비 비중(%)", example = "33.38")
+        private final BigDecimal ratio;
+
+        public Allocation(String assetType, BigDecimal ratio) {
+            this.assetType = assetType;
+            this.ratio = ratio;
+        }
+
+        public String getAssetType() {
+            return assetType;
+        }
+
+        public BigDecimal getRatio() {
+            return ratio;
+        }
+    }
+}

--- a/src/main/java/org/firstfolio/dashboard/dto/response/UpcomingEventResponse.java
+++ b/src/main/java/org/firstfolio/dashboard/dto/response/UpcomingEventResponse.java
@@ -1,0 +1,36 @@
+package org.firstfolio.dashboard.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+/**
+ * 대시보드 upcoming_events 섹션 한 건.
+ *
+ * <p>FE {@code dashboardService.js}가 이 섹션을 배열 그대로 기대하고 바로 {@code .map()}을
+ * 호출하기 때문에, {@code available}/{@code reason} 래핑 없이 JSON 최상위에 배열로 나간다
+ * (포트폴리오가 없으면 빈 배열).</p>
+ */
+@Schema(description = "예정 자산 이벤트 한 건")
+public final class UpcomingEventResponse {
+
+    @Schema(description = "이벤트 유형", example = "MATURITY", allowableValues = {"INTEREST", "DIVIDEND", "MATURITY"})
+    private final String type;
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    @Schema(description = "예정 일시", example = "2026-09-01T00:00:00")
+    private final LocalDateTime scheduledAt;
+
+    public UpcomingEventResponse(String type, LocalDateTime scheduledAt) {
+        this.type = type;
+        this.scheduledAt = scheduledAt;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public LocalDateTime getScheduledAt() {
+        return scheduledAt;
+    }
+}

--- a/src/main/java/org/firstfolio/dashboard/mapper/DashboardMapper.java
+++ b/src/main/java/org/firstfolio/dashboard/mapper/DashboardMapper.java
@@ -1,0 +1,17 @@
+package org.firstfolio.dashboard.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.firstfolio.portfolio.domain.PortfolioTransaction;
+
+import java.util.List;
+
+@Mapper
+public interface DashboardMapper {
+
+    /** portfolio_id 기준, 아직 도래하지 않은 예정 이벤트를 가까운 순으로 최대 limit건. */
+    List<PortfolioTransaction> findUpcomingEvents(
+            @Param("portfolioId") Long portfolioId,
+            @Param("limit") int limit
+    );
+}

--- a/src/main/java/org/firstfolio/dashboard/service/DashboardService.java
+++ b/src/main/java/org/firstfolio/dashboard/service/DashboardService.java
@@ -1,0 +1,131 @@
+// service/DashboardService.java
+package org.firstfolio.dashboard.service;
+
+import org.firstfolio.dashboard.dto.response.DailyQuestSummaryResponse;
+import org.firstfolio.dashboard.dto.response.DashboardResponse;
+import org.firstfolio.dashboard.dto.response.LatestNewsResponse;
+import org.firstfolio.dashboard.dto.response.LearningSummaryResponse;
+import org.firstfolio.dashboard.dto.response.PortfolioSummaryResponse;
+import org.firstfolio.dashboard.dto.response.UpcomingEventResponse;
+import org.firstfolio.dashboard.mapper.DashboardMapper;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.learning.domain.LearningContinueResult;
+import org.firstfolio.learning.service.LearningContinueService;
+import org.firstfolio.portfolio.domain.AssetAllocation;
+import org.firstfolio.portfolio.domain.Portfolio;
+import org.firstfolio.portfolio.domain.PortfolioTransaction;
+import org.firstfolio.portfolio.domain.PortfolioValuation;
+import org.firstfolio.portfolio.mapper.PortfolioMapper;
+import org.firstfolio.portfolio.service.PortfolioValuationService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * 대시보드 5개 섹션을 조립한다.
+ *
+ * <p>daily_quest·latest_news는 의존 도메인 코드가 없어 항상 NOT_IMPLEMENTED다.</p>
+ *
+ * <p>이 메서드 자체에는 {@code @Transactional}을 붙이지 않는다. learningContinueService가
+ * 자기 트랜잭션 안에서 던지는 예외를 여기서 잡아 정상 흐름으로 바꾸는데, 같은 트랜잭션으로
+ * 묶으면 그 예외가 트랜잭션을 rollback-only로 표시해 버려 이후 커밋 시점에
+ * {@code UnexpectedRollbackException}이 난다. 각 하위 호출은 이미 스스로 세션을 관리한다.</p>
+ */
+@Service
+public class DashboardService {
+
+    private static final int UPCOMING_EVENTS_LIMIT = 5;
+
+    private final PortfolioMapper portfolioMapper;
+    private final PortfolioValuationService portfolioValuationService;
+    private final LearningContinueService learningContinueService;
+    private final DashboardMapper dashboardMapper;
+
+    public DashboardService(
+        PortfolioMapper portfolioMapper,
+        PortfolioValuationService portfolioValuationService,
+        LearningContinueService learningContinueService,
+        DashboardMapper dashboardMapper
+    ) {
+        this.portfolioMapper = portfolioMapper;
+        this.portfolioValuationService = portfolioValuationService;
+        this.learningContinueService = learningContinueService;
+        this.dashboardMapper = dashboardMapper;
+    }
+
+    public DashboardResponse getDashboard(long userId) {
+        Portfolio portfolio = portfolioMapper.findActiveByUserId(userId);
+
+        return new DashboardResponse(
+            buildPortfolio(portfolio),
+            DailyQuestSummaryResponse.notImplemented(),
+            buildLearning(userId),
+            buildUpcomingEvents(portfolio),
+            List.of()
+        );
+    }
+
+    private PortfolioSummaryResponse buildPortfolio(Portfolio portfolio) {
+        if (portfolio == null) {
+            return PortfolioSummaryResponse.unavailable("NO_PORTFOLIO");
+        }
+
+        PortfolioValuation valuation = portfolioValuationService.valuate(portfolio);
+
+        List<PortfolioSummaryResponse.Allocation> allocation = valuation.getAllocations().stream()
+            .map(this::toAllocation)
+            .toList();
+
+        return new PortfolioSummaryResponse(
+            true,
+            null,
+            valuation.getTotalAssets(),
+            valuation.getProfitLoss(),
+            valuation.getProfitRate(),
+            allocation
+        );
+    }
+
+    private PortfolioSummaryResponse.Allocation toAllocation(AssetAllocation allocation) {
+        return new PortfolioSummaryResponse.Allocation(
+            allocation.getAssetType().name(),
+            allocation.getRatio()
+        );
+    }
+
+    private LearningSummaryResponse buildLearning(long userId) {
+        try {
+            LearningContinueResult result = learningContinueService.getContinuePosition(userId);
+            return new LearningSummaryResponse(
+                true,
+                null,
+                result.mainChapterId(),
+                result.subChapterId(),
+                result.progressPercent()
+            );
+        } catch (ApiException exception) {
+            return LearningSummaryResponse.unavailable("NOT_STARTED");
+        }
+    }
+
+    private List<UpcomingEventResponse> buildUpcomingEvents(Portfolio portfolio) {
+        if (portfolio == null) {
+            return List.of();
+        }
+
+        List<PortfolioTransaction> transactions = dashboardMapper.findUpcomingEvents(
+            portfolio.getPortfolioId(), UPCOMING_EVENTS_LIMIT
+        );
+
+        return transactions.stream()
+            .map(this::toEvent)
+            .toList();
+    }
+
+    private UpcomingEventResponse toEvent(PortfolioTransaction transaction) {
+        return new UpcomingEventResponse(
+            transaction.getTransactionType().name(),
+            transaction.getScheduledAt()
+        );
+    }
+}

--- a/src/main/resources/mappers/dashboard/DashboardMapper.xml
+++ b/src/main/resources/mappers/dashboard/DashboardMapper.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.firstfolio.dashboard.mapper.DashboardMapper">
+
+    <!--
+        대시보드 화면 표시용이라 유형과 예정 시각만 읽는다. portfolio_transactions의
+        나머지 컬럼(금액, 상태 등)은 이 화면에 필요 없어 SELECT하지 않는다.
+    -->
+    <resultMap id="upcomingEventResult" type="org.firstfolio.portfolio.domain.PortfolioTransaction">
+        <result property="transactionType" column="transaction_type"/>
+        <result property="scheduledAt" column="scheduled_at"/>
+    </resultMap>
+
+    <select id="findUpcomingEvents" resultMap="upcomingEventResult">
+        SELECT transaction_type, scheduled_at
+        FROM portfolio_transactions
+        WHERE portfolio_id = #{portfolioId}
+          AND status = 'SCHEDULED'
+          AND scheduled_at &gt;= NOW()
+        ORDER BY scheduled_at
+        LIMIT #{limit}
+    </select>
+
+</mapper>

--- a/src/test/java/org/firstfolio/dashboard/controller/DashboardControllerTest.java
+++ b/src/test/java/org/firstfolio/dashboard/controller/DashboardControllerTest.java
@@ -1,0 +1,108 @@
+package org.firstfolio.dashboard.controller;
+
+import org.firstfolio.auth.domain.AuthenticatedUser;
+import org.firstfolio.auth.web.AuthenticationRequestAttributes;
+import org.firstfolio.auth.web.CurrentUserArgumentResolver;
+import org.firstfolio.common.json.ApiObjectMapperFactory;
+import org.firstfolio.dashboard.dto.response.DailyQuestSummaryResponse;
+import org.firstfolio.dashboard.dto.response.DashboardResponse;
+import org.firstfolio.dashboard.dto.response.LatestNewsResponse;
+import org.firstfolio.dashboard.dto.response.LearningSummaryResponse;
+import org.firstfolio.dashboard.dto.response.PortfolioSummaryResponse;
+import org.firstfolio.dashboard.dto.response.UpcomingEventResponse;
+import org.firstfolio.dashboard.service.DashboardService;
+import org.firstfolio.exception.CommonExceptionAdvice;
+import org.firstfolio.user.domain.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class DashboardControllerTest {
+
+    private static final long USER_ID = 11L;
+
+    private DashboardService service;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        service = mock(DashboardService.class);
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new DashboardController(service))
+                .setCustomArgumentResolvers(new CurrentUserArgumentResolver())
+                .setControllerAdvice(new CommonExceptionAdvice())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(
+                        ApiObjectMapperFactory.create()
+                ))
+                .build();
+    }
+
+    @Test
+    void returnsDashboardForCurrentUser() throws Exception {
+        when(service.getDashboard(USER_ID)).thenReturn(new DashboardResponse(
+                new PortfolioSummaryResponse(
+                        true, null,
+                        new BigDecimal("31250000.00"),
+                        new BigDecimal("1250000.00"),
+                        new BigDecimal("4.17"),
+                        List.of(new PortfolioSummaryResponse.Allocation(
+                                "STOCK", new BigDecimal("33.38")
+                        ))
+                ),
+                DailyQuestSummaryResponse.notImplemented(),
+                new LearningSummaryResponse(true, null, 2L, 101L, 50),
+                List.of(new UpcomingEventResponse("MATURITY", null)),
+                List.of()
+        ));
+
+        mockMvc.perform(authenticated(get("/api/dashboard")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.portfolio.available").value(true))
+                .andExpect(jsonPath("$.data.portfolio.total_assets").value("31250000.00"))
+                .andExpect(jsonPath("$.data.learning.progress_percent").value(50))
+                .andExpect(jsonPath("$.data.daily_quest.available").value(false))
+                .andExpect(jsonPath("$.data.daily_quest.reason").value("NOT_IMPLEMENTED"))
+                .andExpect(jsonPath("$.data.upcoming_events[0].type").value("MATURITY"))
+                .andExpect(jsonPath("$.data.latest_news").isArray());
+
+        verify(service).getDashboard(USER_ID);
+    }
+
+    @Test
+    void rejectsUnauthenticatedRequest() throws Exception {
+        mockMvc.perform(get("/api/dashboard"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("UNAUTHORIZED"));
+
+        verify(service, never()).getDashboard(anyLong());
+    }
+
+    private static MockHttpServletRequestBuilder authenticated(
+            MockHttpServletRequestBuilder builder
+    ) {
+        return builder.requestAttr(
+                AuthenticationRequestAttributes.CURRENT_USER,
+                new AuthenticatedUser(
+                        USER_ID,
+                        "firebase-uid",
+                        "테스터",
+                        UserRole.USER
+                )
+        );
+    }
+}

--- a/src/test/java/org/firstfolio/dashboard/service/DashboardServiceTest.java
+++ b/src/test/java/org/firstfolio/dashboard/service/DashboardServiceTest.java
@@ -1,0 +1,142 @@
+package org.firstfolio.dashboard.service;
+
+import org.firstfolio.dashboard.dto.response.DashboardResponse;
+import org.firstfolio.dashboard.dto.response.UpcomingEventResponse;
+import org.firstfolio.dashboard.mapper.DashboardMapper;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.learning.domain.LearningContinueResult;
+import org.firstfolio.learning.service.LearningContinueService;
+import org.firstfolio.portfolio.domain.AssetAllocation;
+import org.firstfolio.portfolio.domain.Portfolio;
+import org.firstfolio.portfolio.domain.PortfolioTransaction;
+import org.firstfolio.portfolio.domain.PortfolioValuation;
+import org.firstfolio.portfolio.domain.TransactionType;
+import org.firstfolio.portfolio.mapper.PortfolioMapper;
+import org.firstfolio.portfolio.service.PortfolioValuationService;
+import org.firstfolio.simulation.domain.AssetType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DashboardServiceTest {
+
+    private static final long USER_ID = 11L;
+    private static final long PORTFOLIO_ID = 8001L;
+
+    private PortfolioMapper portfolioMapper;
+    private PortfolioValuationService portfolioValuationService;
+    private LearningContinueService learningContinueService;
+    private DashboardMapper dashboardMapper;
+    private DashboardService service;
+
+    @BeforeEach
+    void setUp() {
+        portfolioMapper = mock(PortfolioMapper.class);
+        portfolioValuationService = mock(PortfolioValuationService.class);
+        learningContinueService = mock(LearningContinueService.class);
+        dashboardMapper = mock(DashboardMapper.class);
+        service = new DashboardService(
+                portfolioMapper,
+                portfolioValuationService,
+                learningContinueService,
+                dashboardMapper
+        );
+    }
+
+    @Test
+    void assemblesAllAvailableSectionsWhenPortfolioAndLearningExist() {
+        Portfolio portfolio = portfolio();
+        when(portfolioMapper.findActiveByUserId(USER_ID)).thenReturn(portfolio);
+        when(portfolioValuationService.valuate(portfolio)).thenReturn(valuation());
+        when(learningContinueService.getContinuePosition(USER_ID)).thenReturn(
+                new LearningContinueResult(
+                        502L, 2L, 101L, 301L, "page-2", 50,
+                        "/learning/sub-chapters/101?page=page-2"
+                )
+        );
+        when(dashboardMapper.findUpcomingEvents(PORTFOLIO_ID, 5))
+                .thenReturn(List.of(upcomingTransaction()));
+
+        DashboardResponse response = service.getDashboard(USER_ID);
+
+        assertTrue(response.getPortfolio().isAvailable());
+        assertEquals(0, new BigDecimal("31250000.00").compareTo(response.getPortfolio().getTotalAssets()));
+        assertEquals(1, response.getPortfolio().getAllocation().size());
+        assertEquals("STOCK", response.getPortfolio().getAllocation().get(0).getAssetType());
+
+        assertTrue(response.getLearning().isAvailable());
+        assertEquals(2L, response.getLearning().getMainChapterId());
+        assertEquals(50, response.getLearning().getProgressPercent());
+
+        assertEquals(1, response.getUpcomingEvents().size());
+        UpcomingEventResponse event = response.getUpcomingEvents().get(0);
+        assertEquals("MATURITY", event.getType());
+
+        assertFalse(response.getDailyQuest().isAvailable());
+        assertEquals("NOT_IMPLEMENTED", response.getDailyQuest().getReason());
+        assertTrue(response.getLatestNews().isEmpty());
+    }
+
+    @Test
+    void marksPortfolioAndUpcomingEventsUnavailableWhenNoActivePortfolio() {
+        when(portfolioMapper.findActiveByUserId(USER_ID)).thenReturn(null);
+        when(learningContinueService.getContinuePosition(USER_ID)).thenThrow(
+                new ApiException(ErrorCode.CONTINUE_POSITION_NOT_FOUND)
+        );
+
+        DashboardResponse response = service.getDashboard(USER_ID);
+
+        assertFalse(response.getPortfolio().isAvailable());
+        assertEquals("NO_PORTFOLIO", response.getPortfolio().getReason());
+
+        assertTrue(response.getUpcomingEvents().isEmpty());
+        verify(dashboardMapper, never()).findUpcomingEvents(anyLong(), org.mockito.ArgumentMatchers.anyInt());
+
+        assertFalse(response.getLearning().isAvailable());
+        assertEquals("NOT_STARTED", response.getLearning().getReason());
+    }
+
+    private Portfolio portfolio() {
+        Portfolio portfolio = new Portfolio();
+        portfolio.setPortfolioId(PORTFOLIO_ID);
+        return portfolio;
+    }
+
+    private PortfolioValuation valuation() {
+        return new PortfolioValuation(
+                portfolio(),
+                List.of(),
+                List.of(new AssetAllocation(
+                        AssetType.STOCK,
+                        new BigDecimal("10080000.00"),
+                        new BigDecimal("33.38")
+                )),
+                new BigDecimal("2000000.00"),
+                new BigDecimal("10080000.00"),
+                new BigDecimal("31250000.00"),
+                new BigDecimal("1250000.00"),
+                new BigDecimal("4.17"),
+                LocalDateTime.now()
+        );
+    }
+
+    private PortfolioTransaction upcomingTransaction() {
+        PortfolioTransaction transaction = new PortfolioTransaction();
+        transaction.setTransactionType(TransactionType.MATURITY);
+        transaction.setScheduledAt(LocalDateTime.now().plusDays(3));
+        return transaction;
+    }
+}


### PR DESCRIPTION
## Summary
- `GET /api/dashboard` 신규 구현 — 포트폴리오·학습·예정 자산 이벤트·일일 퀘스트·최신 뉴스 5개 섹션을 한 번에 반환
- portfolio, learning, upcoming_events는 실제 데이터 연동, daily_quest·latest_news는 의존 도메인 코드가 없어 스텁 처리

## 변경 파일
- `dashboard/controller/DashboardController.java` — `GET /api/dashboard` 엔드포인트
- `dashboard/service/DashboardService.java` — 5개 섹션 조립
- `dashboard/mapper/DashboardMapper.java` + `mappers/dashboard/DashboardMapper.xml` — 예정 자산 이벤트 조회 신규 쿼리
- `dashboard/dto/response/*` — 응답 DTO 6개
- `config/OpenApiResponseSchemas.java` — Swagger 문서용 스키마 등록 4줄 추가 (유일한 기존 파일 수정)
- `test/.../dashboard/*` — 서비스·컨트롤러 단위 테스트

## 신규 파일 생성 이유
포트폴리오 도메인이 최근 대량 merge로 활발히 바뀌는 중이라, 기존 매퍼(`PortfolioTransactionMapper` 등)에 메서드를 얹으면 다른 작업자와 충돌 위험이 커질 것을 대비해 `DashboardMapper`를 새로 만들어 필요한 쿼리를 여기서 직접 처리했고, `PortfolioValuationService`·`LearningContinueService`는 기존 코드를 그대로 재사용(재사용이라 매퍼 수정과는 성격이 다름)만 했습니다. `OpenApiResponseSchemas.java`는 모든 도메인이 공유하는 Swagger 스키마 등록 파일이라 예외적으로 4줄만 추가했습니다.

## 테스트 결과
- `./gradlew test` 전체 통과
- 로컬 Tomcat + 팀 공용 DB로 실제 화면 연동 확인 — 포트폴리오 없는 계정(NO_PORTFOLIO 정상 응답), 있는 계정(실제 값 응답) 둘 다 확인