### PR TITLE
feat: 퀴즈 문항 공개 및 폐기 API 구현  #100

### DIFF
--- a/src/main/java/org/firstfolio/config/OpenApiResponseSchemas.java
+++ b/src/main/java/org/firstfolio/config/OpenApiResponseSchemas.java
@@ -41,6 +41,7 @@ import org.firstfolio.quiz.dto.response.LevelTestSubmitResponse;
 import org.firstfolio.quiz.dto.response.QuizAttemptStartResponse;
 import org.firstfolio.quiz.dto.response.QuizAnswerGradingResponse;
 import org.firstfolio.quiz.dto.response.QuizQuestionCreateResponse;
+import org.firstfolio.quiz.dto.response.QuizQuestionStatusResponse;
 import org.firstfolio.simulation.dto.response.PriceRefreshResponse;
 import org.firstfolio.simulation.dto.response.ProductDetailResponse;
 import org.firstfolio.simulation.dto.response.ProductPageResponse;
@@ -131,6 +132,9 @@ public final class OpenApiResponseSchemas {
 
     @Schema(name = "QuizQuestionCreateApiResponse")
     public record QuizQuestionCreate(QuizQuestionCreateResponse data) { }
+
+    @Schema(name = "QuizQuestionStatusApiResponse")
+    public record QuizQuestionStatus(QuizQuestionStatusResponse data) { }
 
     @Schema(name = "QuizAttemptStartApiResponse")
     public record QuizAttemptStart(QuizAttemptStartResponse data) { }

--- a/src/main/java/org/firstfolio/exception/ErrorCode.java
+++ b/src/main/java/org/firstfolio/exception/ErrorCode.java
@@ -39,6 +39,8 @@ public enum ErrorCode {
     QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "퀴즈 문항을 찾을 수 없습니다."),
     QUESTION_KEY_CONFLICT(HttpStatus.CONFLICT, "이미 존재하는 퀴즈 문항 논리 키입니다."),
     QUESTION_VERSION_CONFLICT(HttpStatus.CONFLICT, "퀴즈 문항 버전을 생성할 수 없습니다."),
+    QUESTION_NOT_PUBLISHABLE(HttpStatus.CONFLICT, "공개할 수 없는 퀴즈 문항 버전입니다."),
+    QUESTION_NOT_RETIRABLE(HttpStatus.CONFLICT, "폐기할 수 없는 퀴즈 문항 버전입니다."),
     QUESTION_VALIDATION_FAILED(HttpStatus.UNPROCESSABLE_ENTITY, "퀴즈 문항 검증에 실패했습니다."),
 
     // 퀴즈 응시

--- a/src/main/java/org/firstfolio/quiz/controller/AdminQuizQuestionController.java
+++ b/src/main/java/org/firstfolio/quiz/controller/AdminQuizQuestionController.java
@@ -11,6 +11,8 @@ import org.firstfolio.config.OpenApiResponseSchemas;
 import org.firstfolio.quiz.dto.request.QuizQuestionCreateRequest;
 import org.firstfolio.quiz.dto.request.QuizQuestionVersionCreateRequest;
 import org.firstfolio.quiz.dto.response.QuizQuestionCreateResponse;
+import org.firstfolio.quiz.dto.response.QuizQuestionStatusResponse;
+import org.firstfolio.quiz.service.QuizQuestionPublicationService;
 import org.firstfolio.quiz.service.QuizQuestionRegistrationService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -28,11 +30,14 @@ import javax.servlet.http.HttpServletRequest;
 public class AdminQuizQuestionController {
 
     private final QuizQuestionRegistrationService registrationService;
+    private final QuizQuestionPublicationService publicationService;
 
     public AdminQuizQuestionController(
-            QuizQuestionRegistrationService registrationService
+            QuizQuestionRegistrationService registrationService,
+            QuizQuestionPublicationService publicationService
     ) {
         this.registrationService = registrationService;
+        this.publicationService = publicationService;
     }
 
     @PostMapping
@@ -117,6 +122,83 @@ public class AdminQuizQuestionController {
                 registrationService.createVersion(
                         questionId,
                         request,
+                        currentUser.userId(),
+                        RequestIdFilter.currentRequestId(servletRequest)
+                )
+        ));
+    }
+
+    @PostMapping("/{questionId}/publish")
+    @Operation(
+            summary = "퀴즈 문항 버전 공개",
+            description = "최신 DRAFT 문항 버전을 PUBLISHED로 전환합니다. 같은 논리 키의 기존 공개 버전은 RETIRED로 보존하고 모든 상태 변경을 하나의 트랜잭션으로 처리합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200", description = "퀴즈 문항 공개 성공",
+                            content = @io.swagger.v3.oas.annotations.media.Content(
+                                    mediaType = "application/json",
+                                    schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                            implementation = OpenApiResponseSchemas.QuizQuestionStatus.class
+                                    )
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "404", description = "QUESTION_NOT_FOUND - 문항을 찾을 수 없음"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "409", description = "QUESTION_NOT_PUBLISHABLE - 최신 DRAFT가 아니거나 공개할 수 없는 상태"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "422", description = "QUESTION_VALIDATION_FAILED - 문항 또는 단원 참조 재검증 실패"
+                    )
+            }
+    )
+    public ApiResponse<QuizQuestionStatusResponse> publishQuestion(
+            @Parameter(description = "공개할 문항 버전 ID", example = "1201", required = true)
+            @PathVariable long questionId,
+            @CurrentUser AuthenticatedUser currentUser,
+            HttpServletRequest servletRequest
+    ) {
+        return ApiResponse.of(QuizQuestionStatusResponse.from(
+                publicationService.publish(
+                        questionId,
+                        currentUser.userId(),
+                        RequestIdFilter.currentRequestId(servletRequest)
+                )
+        ));
+    }
+
+    @PostMapping("/{questionId}/retire")
+    @Operation(
+            summary = "퀴즈 문항 버전 폐기",
+            description = "PUBLISHED 문항을 RETIRED로 전환해 신규 퀴즈 배정과 새 강좌 참조 대상에서 제외합니다. 기존 강좌와 응시가 고정 참조한 문항 이력은 보존합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200", description = "퀴즈 문항 폐기 성공",
+                            content = @io.swagger.v3.oas.annotations.media.Content(
+                                    mediaType = "application/json",
+                                    schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                            implementation = OpenApiResponseSchemas.QuizQuestionStatus.class
+                                    )
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "404", description = "QUESTION_NOT_FOUND - 문항을 찾을 수 없음"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "409", description = "QUESTION_NOT_RETIRABLE - 공개 상태가 아닌 문항"
+                    )
+            }
+    )
+    public ApiResponse<QuizQuestionStatusResponse> retireQuestion(
+            @Parameter(description = "폐기할 문항 버전 ID", example = "1201", required = true)
+            @PathVariable long questionId,
+            @CurrentUser AuthenticatedUser currentUser,
+            HttpServletRequest servletRequest
+    ) {
+        return ApiResponse.of(QuizQuestionStatusResponse.from(
+                publicationService.retire(
+                        questionId,
                         currentUser.userId(),
                         RequestIdFilter.currentRequestId(servletRequest)
                 )

--- a/src/main/java/org/firstfolio/quiz/domain/QuizQuestion.java
+++ b/src/main/java/org/firstfolio/quiz/domain/QuizQuestion.java
@@ -217,6 +217,15 @@ public class QuizQuestion {
         this.status = status;
     }
 
+    public void publish(LocalDateTime publishedAt) {
+        this.status = QuizQuestionStatus.PUBLISHED;
+        this.publishedAt = publishedAt;
+    }
+
+    public void retire() {
+        this.status = QuizQuestionStatus.RETIRED;
+    }
+
     public long getCreatedBy() {
         return createdBy;
     }

--- a/src/main/java/org/firstfolio/quiz/dto/response/QuizQuestionStatusResponse.java
+++ b/src/main/java/org/firstfolio/quiz/dto/response/QuizQuestionStatusResponse.java
@@ -1,0 +1,28 @@
+package org.firstfolio.quiz.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.firstfolio.quiz.domain.QuizQuestion;
+import org.firstfolio.quiz.domain.QuizQuestionStatus;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "퀴즈 문항 버전 상태 변경 결과")
+public record QuizQuestionStatusResponse(
+        @Schema(description = "문항 버전 ID", example = "1201") long questionId,
+        @Schema(description = "논리 문항 키", example = "deposit-basic-001") String questionKey,
+        @Schema(description = "문항 버전 번호", example = "2") int versionNo,
+        @Schema(description = "변경 후 상태", example = "PUBLISHED") QuizQuestionStatus status,
+        @Schema(description = "최초 공개 시각", nullable = true, example = "2026-08-14T03:00:00Z")
+        LocalDateTime publishedAt
+) {
+
+    public static QuizQuestionStatusResponse from(QuizQuestion question) {
+        return new QuizQuestionStatusResponse(
+                question.getQuestionId(),
+                question.getQuestionKey(),
+                question.getVersionNo(),
+                question.getStatus(),
+                question.getPublishedAt()
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/mapper/QuizQuestionMapper.java
+++ b/src/main/java/org/firstfolio/quiz/mapper/QuizQuestionMapper.java
@@ -13,7 +13,13 @@ public interface QuizQuestionMapper {
 
     QuizQuestion findById(@Param("questionId") long questionId);
 
+    QuizQuestion findByIdForUpdate(@Param("questionId") long questionId);
+
     QuizQuestion findLatestByQuestionKeyForUpdate(
+            @Param("questionKey") String questionKey
+    );
+
+    List<QuizQuestion> findPublishedByQuestionKeyForUpdate(
             @Param("questionKey") String questionKey
     );
 
@@ -38,6 +44,13 @@ public interface QuizQuestionMapper {
     QuizQuestion findLatestPublishedDailyNewsByQuestDate(
             @Param("questDate") LocalDate questDate
     );
+
+    int publishDraft(
+            @Param("questionId") long questionId,
+            @Param("publishedAt") java.time.LocalDateTime publishedAt
+    );
+
+    int retirePublished(@Param("questionId") long questionId);
 
     int insert(QuizQuestion question);
 }

--- a/src/main/java/org/firstfolio/quiz/service/QuizAttemptStartService.java
+++ b/src/main/java/org/firstfolio/quiz/service/QuizAttemptStartService.java
@@ -227,11 +227,16 @@ public class QuizAttemptStartService {
             if (question == null
                     || question.getUsageType() != QuizUsageType.SUB_CHAPTER
                     || !Objects.equals(question.getSubChapterId(), subChapterId)
-                    || question.getStatus() != QuizQuestionStatus.PUBLISHED) {
+                    || !isUsablePinnedQuestion(question.getStatus())) {
                 throw new ApiException(ErrorCode.QUIZ_NOT_AVAILABLE);
             }
         }
         return questions;
+    }
+
+    private boolean isUsablePinnedQuestion(QuizQuestionStatus status) {
+        return status == QuizQuestionStatus.PUBLISHED
+                || status == QuizQuestionStatus.RETIRED;
     }
 
     private QuizAttempt createAttempt(

--- a/src/main/java/org/firstfolio/quiz/service/QuizQuestionPublicationService.java
+++ b/src/main/java/org/firstfolio/quiz/service/QuizQuestionPublicationService.java
@@ -1,0 +1,334 @@
+package org.firstfolio.quiz.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.firstfolio.common.json.ApiObjectMapperFactory;
+import org.firstfolio.curriculum.domain.ChapterType;
+import org.firstfolio.curriculum.domain.MainChapter;
+import org.firstfolio.curriculum.domain.SubChapter;
+import org.firstfolio.curriculum.mapper.AdminAuditLogMapper;
+import org.firstfolio.curriculum.mapper.MainChapterMapper;
+import org.firstfolio.curriculum.mapper.SubChapterMapper;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.quiz.domain.QuizQuestion;
+import org.firstfolio.quiz.domain.QuizQuestionStatus;
+import org.firstfolio.quiz.domain.QuizUsageType;
+import org.firstfolio.quiz.mapper.QuizQuestionMapper;
+import org.firstfolio.quiz.validation.QuizQuestionSchemaValidator;
+import org.firstfolio.quiz.validation.QuizQuestionValidationError;
+import org.firstfolio.quiz.validation.QuizQuestionValidationResult;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+@Service
+public class QuizQuestionPublicationService {
+
+    private static final String AUDIT_ENTITY_TYPE = "QUIZ_QUESTION";
+
+    private final QuizQuestionSchemaValidator schemaValidator;
+    private final QuizQuestionMapper questionMapper;
+    private final MainChapterMapper mainChapterMapper;
+    private final SubChapterMapper subChapterMapper;
+    private final AdminAuditLogMapper auditLogMapper;
+    private final Clock clock;
+    private final ObjectMapper objectMapper;
+
+    public QuizQuestionPublicationService(
+            QuizQuestionSchemaValidator schemaValidator,
+            QuizQuestionMapper questionMapper,
+            MainChapterMapper mainChapterMapper,
+            SubChapterMapper subChapterMapper,
+            AdminAuditLogMapper auditLogMapper,
+            Clock clock
+    ) {
+        this.schemaValidator = schemaValidator;
+        this.questionMapper = questionMapper;
+        this.mainChapterMapper = mainChapterMapper;
+        this.subChapterMapper = subChapterMapper;
+        this.auditLogMapper = auditLogMapper;
+        this.clock = clock;
+        this.objectMapper = ApiObjectMapperFactory.create();
+    }
+
+    @Transactional
+    public QuizQuestion publish(
+            long questionId,
+            long actorUserId,
+            String requestId
+    ) {
+        QuizQuestion reference = questionMapper.findById(questionId);
+        if (reference == null) {
+            throw new ApiException(ErrorCode.QUESTION_NOT_FOUND);
+        }
+
+        QuizQuestion target = questionMapper.findLatestByQuestionKeyForUpdate(
+                reference.getQuestionKey()
+        );
+        if (target == null) {
+            throw new ApiException(ErrorCode.QUESTION_NOT_FOUND);
+        }
+        if (!Objects.equals(target.getQuestionId(), questionId)
+                || target.getStatus() != QuizQuestionStatus.DRAFT) {
+            throw new ApiException(ErrorCode.QUESTION_NOT_PUBLISHABLE);
+        }
+
+        requireValidForPublication(target);
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        retirePublishedVersions(
+                target.getQuestionKey(),
+                actorUserId,
+                requestId,
+                now
+        );
+
+        String before = snapshot(target);
+        if (questionMapper.publishDraft(questionId, now) != 1) {
+            throw new ApiException(ErrorCode.QUESTION_NOT_PUBLISHABLE);
+        }
+        target.publish(now);
+        insertAuditLog(
+                actorUserId,
+                "PUBLISH",
+                target,
+                before,
+                requestId,
+                now
+        );
+        return target;
+    }
+
+    @Transactional
+    public QuizQuestion retire(
+            long questionId,
+            long actorUserId,
+            String requestId
+    ) {
+        QuizQuestion target = questionMapper.findByIdForUpdate(questionId);
+        if (target == null) {
+            throw new ApiException(ErrorCode.QUESTION_NOT_FOUND);
+        }
+        if (target.getStatus() != QuizQuestionStatus.PUBLISHED) {
+            throw new ApiException(ErrorCode.QUESTION_NOT_RETIRABLE);
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        String before = snapshot(target);
+        if (questionMapper.retirePublished(questionId) != 1) {
+            throw new ApiException(ErrorCode.QUESTION_NOT_RETIRABLE);
+        }
+        target.retire();
+        insertAuditLog(
+                actorUserId,
+                "RETIRE",
+                target,
+                before,
+                requestId,
+                now
+        );
+        return target;
+    }
+
+    private void retirePublishedVersions(
+            String questionKey,
+            long actorUserId,
+            String requestId,
+            LocalDateTime now
+    ) {
+        List<QuizQuestion> publishedVersions =
+                questionMapper.findPublishedByQuestionKeyForUpdate(questionKey);
+        for (QuizQuestion published : publishedVersions) {
+            String before = snapshot(published);
+            if (questionMapper.retirePublished(published.getQuestionId()) != 1) {
+                throw new IllegalStateException("기존 공개 퀴즈 문항을 폐기하지 못했습니다.");
+            }
+            published.retire();
+            insertAuditLog(
+                    actorUserId,
+                    "RETIRE",
+                    published,
+                    before,
+                    requestId,
+                    now
+            );
+        }
+    }
+
+    private void requireValidForPublication(QuizQuestion question) {
+        ObjectNode candidate = objectMapper.createObjectNode();
+        candidate.put("question_key", question.getQuestionKey());
+        candidate.put("usage_type", question.getUsageType().name());
+        putLong(candidate, "main_chapter_id", question.getMainChapterId());
+        putLong(candidate, "sub_chapter_id", question.getSubChapterId());
+        candidate.put("question_type", question.getQuestionType().name());
+        if (question.getDifficulty() == null) {
+            candidate.putNull("difficulty");
+        } else {
+            candidate.put("difficulty", question.getDifficulty().name());
+        }
+        candidate.put("prompt", question.getPrompt());
+        setStoredJson(candidate, "scenario_json", question.getScenarioJson());
+        setStoredJson(candidate, "options_json", question.getOptionsJson());
+        setStoredJson(candidate, "correct_answer_json", question.getCorrectAnswerJson());
+        candidate.put("explanation", question.getExplanation());
+        candidate.put("generation_type", question.getGenerationType().name());
+        if (question.getQuestDate() == null) {
+            candidate.putNull("quest_date");
+        } else {
+            candidate.put("quest_date", question.getQuestDate().toString());
+        }
+        setStoredJson(candidate, "source_refs_json", question.getSourceRefsJson());
+
+        QuizQuestionValidationResult result = schemaValidator.validate(
+                candidate.toString().getBytes(StandardCharsets.UTF_8)
+        );
+        if (!result.isValid()) {
+            QuizQuestionValidationError error = result.errors().get(0);
+            throw validationFailure(error.path(), error.message());
+        }
+
+        validateChapterReferences(question);
+    }
+
+    private void validateChapterReferences(QuizQuestion question) {
+        SubChapter subChapter = null;
+        if (question.getSubChapterId() != null) {
+            subChapter = subChapterMapper.findById(question.getSubChapterId());
+            if (subChapter == null) {
+                throw validationFailure(
+                        "/sub_chapter_id",
+                        "참조한 소단원을 찾을 수 없습니다: " + question.getSubChapterId()
+                );
+            }
+            if (!Objects.equals(
+                    question.getMainChapterId(),
+                    subChapter.getMainChapterId()
+            )) {
+                throw validationFailure(
+                        "/main_chapter_id",
+                        "대단원과 소단원의 소속 관계가 일치하지 않습니다."
+                );
+            }
+        }
+
+        MainChapter mainChapter = null;
+        if (question.getMainChapterId() != null) {
+            mainChapter = mainChapterMapper.findById(question.getMainChapterId());
+            if (mainChapter == null) {
+                throw validationFailure(
+                        "/main_chapter_id",
+                        "참조한 대단원을 찾을 수 없습니다: " + question.getMainChapterId()
+                );
+            }
+        }
+
+        if (question.getUsageType() == QuizUsageType.LEVEL_TEST
+                && (mainChapter == null
+                || mainChapter.getChapterType() != ChapterType.ASSET)) {
+            throw validationFailure(
+                    "/main_chapter_id",
+                    "레벨 테스트는 ASSET 대단원만 참조할 수 있습니다."
+            );
+        }
+    }
+
+    private void insertAuditLog(
+            long actorUserId,
+            String action,
+            QuizQuestion question,
+            String before,
+            String requestId,
+            LocalDateTime now
+    ) {
+        if (auditLogMapper.insert(
+                actorUserId,
+                action,
+                AUDIT_ENTITY_TYPE,
+                question.getQuestionId(),
+                before,
+                snapshot(question),
+                requestId,
+                now
+        ) != 1) {
+            throw new IllegalStateException("퀴즈 문항 상태 변경 감사 이력을 저장하지 못했습니다.");
+        }
+    }
+
+    private String snapshot(QuizQuestion question) {
+        Map<String, Object> snapshot = new LinkedHashMap<>();
+        snapshot.put("question_id", question.getQuestionId());
+        snapshot.put("question_key", question.getQuestionKey());
+        snapshot.put("version_no", question.getVersionNo());
+        snapshot.put("usage_type", question.getUsageType());
+        snapshot.put("main_chapter_id", question.getMainChapterId());
+        snapshot.put("sub_chapter_id", question.getSubChapterId());
+        snapshot.put("display_order", question.getDisplayOrder());
+        snapshot.put("question_type", question.getQuestionType());
+        snapshot.put("difficulty", question.getDifficulty());
+        snapshot.put("prompt", question.getPrompt());
+        snapshot.put("scenario_json", parseStoredJson(question.getScenarioJson()));
+        snapshot.put("options_json", parseStoredJson(question.getOptionsJson()));
+        snapshot.put("correct_answer_json", parseStoredJson(question.getCorrectAnswerJson()));
+        snapshot.put("explanation", question.getExplanation());
+        snapshot.put("generation_type", question.getGenerationType());
+        snapshot.put("quest_date", question.getQuestDate());
+        snapshot.put("source_refs_json", parseStoredJson(question.getSourceRefsJson()));
+        snapshot.put("status", question.getStatus());
+        snapshot.put("published_at", question.getPublishedAt());
+        snapshot.put("created_by", question.getCreatedBy());
+        snapshot.put("created_at", question.getCreatedAt());
+
+        try {
+            return objectMapper.writeValueAsString(snapshot);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("퀴즈 문항 감사 이력을 직렬화할 수 없습니다.", exception);
+        }
+    }
+
+    private void setStoredJson(ObjectNode target, String field, String json) {
+        if (json == null) {
+            target.putNull(field);
+            return;
+        }
+        target.set(field, parseStoredJson(json));
+    }
+
+    private JsonNode parseStoredJson(String json) {
+        if (json == null) {
+            return null;
+        }
+        try {
+            return objectMapper.readTree(json);
+        } catch (JsonProcessingException exception) {
+            throw validationFailure("", "저장된 문항 JSON이 올바르지 않습니다.");
+        }
+    }
+
+    private void putLong(ObjectNode target, String field, Long value) {
+        if (value == null) {
+            target.putNull(field);
+        } else {
+            target.put(field, value);
+        }
+    }
+
+    private ApiException validationFailure(String path, String message) {
+        String location = path == null || path.isBlank() ? "" : " (" + path + ")";
+        return new ApiException(
+                ErrorCode.QUESTION_VALIDATION_FAILED,
+                ErrorCode.QUESTION_VALIDATION_FAILED.getDefaultMessage()
+                        + location + " " + message
+        );
+    }
+}

--- a/src/main/resources/mappers/quiz/QuizQuestionMapper.xml
+++ b/src/main/resources/mappers/quiz/QuizQuestionMapper.xml
@@ -68,6 +68,13 @@
         WHERE question_id = #{questionId}
     </select>
 
+    <select id="findByIdForUpdate" resultMap="questionResultMap">
+        SELECT <include refid="questionColumns" />
+        FROM quiz_questions
+        WHERE question_id = #{questionId}
+        FOR UPDATE
+    </select>
+
     <select id="findLatestByQuestionKeyForUpdate"
             resultMap="questionResultMap">
         SELECT <include refid="questionColumns" />
@@ -75,6 +82,16 @@
         WHERE question_key = #{questionKey}
         ORDER BY version_no DESC
         LIMIT 1
+        FOR UPDATE
+    </select>
+
+    <select id="findPublishedByQuestionKeyForUpdate"
+            resultMap="questionResultMap">
+        SELECT <include refid="questionColumns" />
+        FROM quiz_questions
+        WHERE question_key = #{questionKey}
+          AND status = 'PUBLISHED'
+        ORDER BY version_no, question_id
         FOR UPDATE
     </select>
 
@@ -125,8 +142,8 @@
               SELECT 1
               FROM quiz_questions newer
               WHERE newer.question_key = question.question_key
-                AND newer.status = 'PUBLISHED'
                 AND newer.version_no &gt; question.version_no
+                AND newer.status IN ('PUBLISHED', 'RETIRED')
           )
         ORDER BY question.display_order, question.question_id
     </select>
@@ -208,6 +225,21 @@
         ORDER BY question.published_at DESC, question.question_id DESC
         LIMIT 1
     </select>
+
+    <update id="publishDraft">
+        UPDATE quiz_questions
+        SET status = 'PUBLISHED',
+            published_at = #{publishedAt}
+        WHERE question_id = #{questionId}
+          AND status = 'DRAFT'
+    </update>
+
+    <update id="retirePublished">
+        UPDATE quiz_questions
+        SET status = 'RETIRED'
+        WHERE question_id = #{questionId}
+          AND status = 'PUBLISHED'
+    </update>
 
     <insert id="insert"
             parameterType="org.firstfolio.quiz.domain.QuizQuestion"

--- a/src/test/java/org/firstfolio/quiz/controller/AdminQuizQuestionControllerTest.java
+++ b/src/test/java/org/firstfolio/quiz/controller/AdminQuizQuestionControllerTest.java
@@ -14,6 +14,7 @@ import org.firstfolio.quiz.domain.QuizQuestion;
 import org.firstfolio.quiz.domain.QuizQuestionType;
 import org.firstfolio.quiz.domain.QuizUsageType;
 import org.firstfolio.quiz.service.QuizQuestionRegistrationService;
+import org.firstfolio.quiz.service.QuizQuestionPublicationService;
 import org.firstfolio.user.domain.UserRole;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,15 +47,20 @@ class AdminQuizQuestionControllerTest {
     );
 
     private QuizQuestionRegistrationService service;
+    private QuizQuestionPublicationService publicationService;
     private MockMvc mockMvc;
 
     @BeforeEach
     void setUp() {
         service = mock(QuizQuestionRegistrationService.class);
+        publicationService = mock(QuizQuestionPublicationService.class);
         MappingJackson2HttpMessageConverter converter =
                 new MappingJackson2HttpMessageConverter(ApiObjectMapperFactory.create());
         mockMvc = MockMvcBuilders
-                .standaloneSetup(new AdminQuizQuestionController(service))
+                .standaloneSetup(new AdminQuizQuestionController(
+                        service,
+                        publicationService
+                ))
                 .setControllerAdvice(new CommonExceptionAdvice())
                 .setCustomArgumentResolvers(new CurrentUserArgumentResolver())
                 .setMessageConverters(converter)
@@ -161,6 +167,65 @@ class AdminQuizQuestionControllerTest {
                         .content(versionRequestBody()))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.error.code").value("QUESTION_NOT_FOUND"));
+    }
+
+    @Test
+    void publishesLatestDraftQuestionVersion() throws Exception {
+        QuizQuestion published = question(1202L, 2);
+        published.publish(LocalDateTime.of(2026, 8, 14, 6, 0));
+        when(publicationService.publish(eq(1202L), eq(900L), anyString()))
+                .thenReturn(published);
+
+        mockMvc.perform(post("/api/admin/quiz-questions/1202/publish")
+                        .requestAttr(AuthenticationRequestAttributes.CURRENT_USER, ADMIN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.question_id").value(1202))
+                .andExpect(jsonPath("$.data.question_key").value("deposit-basic-001"))
+                .andExpect(jsonPath("$.data.version_no").value(2))
+                .andExpect(jsonPath("$.data.status").value("PUBLISHED"))
+                .andExpect(jsonPath("$.data.published_at")
+                        .value("2026-08-14T06:00:00Z"));
+
+        verify(publicationService).publish(eq(1202L), eq(900L), anyString());
+    }
+
+    @Test
+    void retiresPublishedQuestionVersion() throws Exception {
+        QuizQuestion retired = question(1201L, 1);
+        retired.publish(LocalDateTime.of(2026, 8, 13, 6, 0));
+        retired.retire();
+        when(publicationService.retire(eq(1201L), eq(900L), anyString()))
+                .thenReturn(retired);
+
+        mockMvc.perform(post("/api/admin/quiz-questions/1201/retire")
+                        .requestAttr(AuthenticationRequestAttributes.CURRENT_USER, ADMIN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.question_id").value(1201))
+                .andExpect(jsonPath("$.data.status").value("RETIRED"))
+                .andExpect(jsonPath("$.data.published_at")
+                        .value("2026-08-13T06:00:00Z"));
+
+        verify(publicationService).retire(eq(1201L), eq(900L), anyString());
+    }
+
+    @Test
+    void returnsQuestionStateTransitionErrors() throws Exception {
+        when(publicationService.publish(eq(1201L), eq(900L), anyString()))
+                .thenThrow(new ApiException(ErrorCode.QUESTION_NOT_PUBLISHABLE));
+        when(publicationService.retire(eq(1202L), eq(900L), anyString()))
+                .thenThrow(new ApiException(ErrorCode.QUESTION_NOT_RETIRABLE));
+
+        mockMvc.perform(post("/api/admin/quiz-questions/1201/publish")
+                        .requestAttr(AuthenticationRequestAttributes.CURRENT_USER, ADMIN))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code")
+                        .value("QUESTION_NOT_PUBLISHABLE"));
+
+        mockMvc.perform(post("/api/admin/quiz-questions/1202/retire")
+                        .requestAttr(AuthenticationRequestAttributes.CURRENT_USER, ADMIN))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code")
+                        .value("QUESTION_NOT_RETIRABLE"));
     }
 
     private QuizQuestion question(long id, int versionNo) {

--- a/src/test/java/org/firstfolio/quiz/mapper/QuizQuestionMapperXmlTest.java
+++ b/src/test/java/org/firstfolio/quiz/mapper/QuizQuestionMapperXmlTest.java
@@ -38,13 +38,26 @@ class QuizQuestionMapperXmlTest {
                 QuizQuestionMapper.class.getName() + ".findById"
         ));
         assertTrue(configuration.hasStatement(
+                QuizQuestionMapper.class.getName() + ".findByIdForUpdate"
+        ));
+        assertTrue(configuration.hasStatement(
                 QuizQuestionMapper.class.getName() + ".findLatestByQuestionKeyForUpdate"
+        ));
+        assertTrue(configuration.hasStatement(
+                QuizQuestionMapper.class.getName()
+                        + ".findPublishedByQuestionKeyForUpdate"
         ));
         assertTrue(configuration.hasStatement(
                 QuizQuestionMapper.class.getName() + ".countByQuestionKey"
         ));
         assertTrue(configuration.hasStatement(
                 QuizQuestionMapper.class.getName() + ".insert"
+        ));
+        assertTrue(configuration.hasStatement(
+                QuizQuestionMapper.class.getName() + ".publishDraft"
+        ));
+        assertTrue(configuration.hasStatement(
+                QuizQuestionMapper.class.getName() + ".retirePublished"
         ));
         assertTrue(configuration.hasStatement(
                 QuizQuestionMapper.class.getName() + ".findAllByIds"
@@ -95,8 +108,43 @@ class QuizQuestionMapperXmlTest {
         assertTrue(normalizedMainQuestionSql.contains(
                 "newer.version_no > question.version_no"
         ));
+        assertTrue(normalizedMainQuestionSql.contains(
+                "newer.status IN ('PUBLISHED', 'RETIRED')"
+        ));
         assertTrue(normalizedMainQuestionSql.endsWith(
                 "ORDER BY question.display_order, question.question_id"
+        ));
+
+        BoundSql publishedLockSql = configuration.getMappedStatement(
+                        QuizQuestionMapper.class.getName()
+                                + ".findPublishedByQuestionKeyForUpdate"
+                )
+                .getBoundSql(Map.of("questionKey", "deposit-basic-001"));
+        assertTrue(normalize(publishedLockSql.getSql()).contains(
+                "WHERE question_key = ? AND status = 'PUBLISHED'"
+        ));
+        assertTrue(normalize(publishedLockSql.getSql()).endsWith("FOR UPDATE"));
+
+        BoundSql publishSql = configuration.getMappedStatement(
+                        QuizQuestionMapper.class.getName() + ".publishDraft"
+                )
+                .getBoundSql(Map.of(
+                        "questionId", 1202L,
+                        "publishedAt", java.time.LocalDateTime.of(2026, 8, 14, 6, 0)
+                ));
+        assertTrue(normalize(publishSql.getSql()).contains(
+                "SET status = 'PUBLISHED', published_at = ?"
+        ));
+        assertTrue(normalize(publishSql.getSql()).endsWith(
+                "WHERE question_id = ? AND status = 'DRAFT'"
+        ));
+
+        BoundSql retireSql = configuration.getMappedStatement(
+                        QuizQuestionMapper.class.getName() + ".retirePublished"
+                )
+                .getBoundSql(Map.of("questionId", 1201L));
+        assertTrue(normalize(retireSql.getSql()).endsWith(
+                "WHERE question_id = ? AND status = 'PUBLISHED'"
         ));
 
         BoundSql levelTestSql = configuration.getMappedStatement(

--- a/src/test/java/org/firstfolio/quiz/service/QuizAttemptStartServiceTest.java
+++ b/src/test/java/org/firstfolio/quiz/service/QuizAttemptStartServiceTest.java
@@ -192,7 +192,7 @@ class QuizAttemptStartServiceTest {
     }
 
     @Test
-    void rejectsQuestionThatIsNoLongerPublished() {
+    void allowsRetiredQuestionPinnedByAlreadyPublishedLessonVersion() {
         arrangeNewAttempt();
         QuizQuestion retired = question(1001L, QuizQuestionType.SINGLE_CHOICE);
         retired.setStatus(QuizQuestionStatus.RETIRED);
@@ -202,13 +202,23 @@ class QuizAttemptStartServiceTest {
                         question(1002L, QuizQuestionType.TRUE_FALSE)
                 ));
 
-        ApiException exception = assertThrows(
-                ApiException.class,
-                () -> service.start(USER_ID, SUB_CHAPTER_ID)
-        );
+        when(quizAttemptMapper.findMaxAttemptNoByUserIdAndSubChapterId(
+                USER_ID, SUB_CHAPTER_ID
+        )).thenReturn(0);
+        when(quizAttemptMapper.insertAttempt(any())).thenAnswer(invocation -> {
+            QuizAttempt attempt = invocation.getArgument(0);
+            attempt.setAttemptId(3001L);
+            return 1;
+        });
+        when(quizAttemptMapper.insertAnswer(any())).thenReturn(1);
 
-        assertEquals(ErrorCode.QUIZ_NOT_AVAILABLE, exception.getErrorCode());
-        verify(quizAttemptMapper, never()).insertAttempt(any());
+        QuizAttemptStartResult result = service.start(USER_ID, SUB_CHAPTER_ID);
+
+        assertEquals(3001L, result.attempt().getAttemptId());
+        assertEquals(List.of(1001L, 1002L), result.questions().stream()
+                .map(question -> question.questionId())
+                .toList());
+        verify(quizAttemptMapper, org.mockito.Mockito.times(2)).insertAnswer(any());
     }
 
     @Test

--- a/src/test/java/org/firstfolio/quiz/service/QuizQuestionPublicationServiceTest.java
+++ b/src/test/java/org/firstfolio/quiz/service/QuizQuestionPublicationServiceTest.java
@@ -1,0 +1,208 @@
+package org.firstfolio.quiz.service;
+
+import org.firstfolio.curriculum.domain.ChapterType;
+import org.firstfolio.curriculum.domain.MainChapter;
+import org.firstfolio.curriculum.domain.SubChapter;
+import org.firstfolio.curriculum.mapper.AdminAuditLogMapper;
+import org.firstfolio.curriculum.mapper.MainChapterMapper;
+import org.firstfolio.curriculum.mapper.SubChapterMapper;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.quiz.domain.QuizDifficulty;
+import org.firstfolio.quiz.domain.QuizGenerationType;
+import org.firstfolio.quiz.domain.QuizQuestion;
+import org.firstfolio.quiz.domain.QuizQuestionStatus;
+import org.firstfolio.quiz.domain.QuizQuestionType;
+import org.firstfolio.quiz.domain.QuizUsageType;
+import org.firstfolio.quiz.mapper.QuizQuestionMapper;
+import org.firstfolio.quiz.validation.QuizQuestionSchemaValidator;
+import org.firstfolio.quiz.validation.QuizQuestionValidationResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class QuizQuestionPublicationServiceTest {
+
+    private static final long ACTOR_ID = 900L;
+    private static final String REQUEST_ID = "req-question-publication";
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 8, 14, 6, 0);
+
+    private QuizQuestionSchemaValidator schemaValidator;
+    private QuizQuestionMapper questionMapper;
+    private MainChapterMapper mainChapterMapper;
+    private SubChapterMapper subChapterMapper;
+    private AdminAuditLogMapper auditLogMapper;
+    private QuizQuestionPublicationService service;
+
+    @BeforeEach
+    void setUp() {
+        schemaValidator = mock(QuizQuestionSchemaValidator.class);
+        questionMapper = mock(QuizQuestionMapper.class);
+        mainChapterMapper = mock(MainChapterMapper.class);
+        subChapterMapper = mock(SubChapterMapper.class);
+        auditLogMapper = mock(AdminAuditLogMapper.class);
+        service = new QuizQuestionPublicationService(
+                schemaValidator,
+                questionMapper,
+                mainChapterMapper,
+                subChapterMapper,
+                auditLogMapper,
+                Clock.fixed(Instant.parse("2026-08-14T06:00:00Z"), ZoneOffset.UTC)
+        );
+
+        when(schemaValidator.validate(any()))
+                .thenReturn(QuizQuestionValidationResult.valid());
+        when(subChapterMapper.findById(101L)).thenReturn(subChapter());
+        when(mainChapterMapper.findById(2L)).thenReturn(mainChapter());
+        when(auditLogMapper.insert(
+                anyLong(), anyString(), anyString(), anyLong(),
+                anyString(), anyString(), anyString(), any()
+        )).thenReturn(1);
+    }
+
+    @Test
+    void publishesLatestDraftAndRetiresPreviouslyPublishedVersion() {
+        QuizQuestion previous = question(1201L, 1);
+        previous.publish(LocalDateTime.of(2026, 8, 10, 6, 0));
+        QuizQuestion target = question(1202L, 2);
+        when(questionMapper.findById(1202L)).thenReturn(target);
+        when(questionMapper.findLatestByQuestionKeyForUpdate(
+                "deposit-basic-001"
+        )).thenReturn(target);
+        when(questionMapper.findPublishedByQuestionKeyForUpdate(
+                "deposit-basic-001"
+        )).thenReturn(List.of(previous));
+        when(questionMapper.retirePublished(1201L)).thenReturn(1);
+        when(questionMapper.publishDraft(1202L, NOW)).thenReturn(1);
+
+        QuizQuestion result = service.publish(1202L, ACTOR_ID, REQUEST_ID);
+
+        assertEquals(QuizQuestionStatus.RETIRED, previous.getStatus());
+        assertEquals(QuizQuestionStatus.PUBLISHED, result.getStatus());
+        assertEquals(NOW, result.getPublishedAt());
+        verify(schemaValidator).validate(any());
+        InOrder stateChanges = inOrder(questionMapper);
+        stateChanges.verify(questionMapper).retirePublished(1201L);
+        stateChanges.verify(questionMapper).publishDraft(1202L, NOW);
+        verify(auditLogMapper).insert(
+                eq(ACTOR_ID), eq("RETIRE"), eq("QUIZ_QUESTION"), eq(1201L),
+                anyString(), anyString(), eq(REQUEST_ID), eq(NOW)
+        );
+        verify(auditLogMapper).insert(
+                eq(ACTOR_ID), eq("PUBLISH"), eq("QUIZ_QUESTION"), eq(1202L),
+                anyString(), anyString(), eq(REQUEST_ID), eq(NOW)
+        );
+    }
+
+    @Test
+    void rejectsPublishingNonLatestDraft() {
+        QuizQuestion requested = question(1201L, 1);
+        QuizQuestion latest = question(1202L, 2);
+        when(questionMapper.findById(1201L)).thenReturn(requested);
+        when(questionMapper.findLatestByQuestionKeyForUpdate(
+                "deposit-basic-001"
+        )).thenReturn(latest);
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.publish(1201L, ACTOR_ID, REQUEST_ID)
+        );
+
+        assertEquals(ErrorCode.QUESTION_NOT_PUBLISHABLE, exception.getErrorCode());
+        verify(schemaValidator, never()).validate(any());
+        verify(questionMapper, never()).publishDraft(anyLong(), any());
+        verify(auditLogMapper, never()).insert(
+                anyLong(), anyString(), anyString(), anyLong(),
+                anyString(), anyString(), anyString(), any()
+        );
+    }
+
+    @Test
+    void manuallyRetiresPublishedQuestionAndKeepsPublishedTimestamp() {
+        LocalDateTime publishedAt = LocalDateTime.of(2026, 8, 10, 6, 0);
+        QuizQuestion target = question(1201L, 1);
+        target.publish(publishedAt);
+        when(questionMapper.findByIdForUpdate(1201L)).thenReturn(target);
+        when(questionMapper.retirePublished(1201L)).thenReturn(1);
+
+        QuizQuestion result = service.retire(1201L, ACTOR_ID, REQUEST_ID);
+
+        assertEquals(QuizQuestionStatus.RETIRED, result.getStatus());
+        assertEquals(publishedAt, result.getPublishedAt());
+        verify(auditLogMapper).insert(
+                eq(ACTOR_ID), eq("RETIRE"), eq("QUIZ_QUESTION"), eq(1201L),
+                anyString(), anyString(), eq(REQUEST_ID), eq(NOW)
+        );
+    }
+
+    @Test
+    void rejectsRetiringQuestionThatIsNotPublished() {
+        QuizQuestion target = question(1201L, 1);
+        when(questionMapper.findByIdForUpdate(1201L)).thenReturn(target);
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.retire(1201L, ACTOR_ID, REQUEST_ID)
+        );
+
+        assertEquals(ErrorCode.QUESTION_NOT_RETIRABLE, exception.getErrorCode());
+        verify(questionMapper, never()).retirePublished(anyLong());
+    }
+
+    private QuizQuestion question(long questionId, int versionNo) {
+        QuizQuestion question = QuizQuestion.draft(
+                "deposit-basic-001",
+                versionNo,
+                QuizUsageType.SUB_CHAPTER,
+                2L,
+                101L,
+                1,
+                QuizQuestionType.SINGLE_CHOICE,
+                QuizDifficulty.EASY,
+                "예금의 특징으로 적절한 것은?",
+                null,
+                "[{\"key\":\"1\",\"label\":\"선택지 1\"},{\"key\":\"2\",\"label\":\"선택지 2\"}]",
+                "{\"key\":\"1\"}",
+                "정답 해설",
+                QuizGenerationType.HUMAN,
+                null,
+                null,
+                ACTOR_ID,
+                LocalDateTime.of(2026, 8, 10, 6, 0)
+        );
+        question.setQuestionId(questionId);
+        return question;
+    }
+
+    private SubChapter subChapter() {
+        SubChapter subChapter = new SubChapter();
+        subChapter.setSubChapterId(101L);
+        subChapter.setMainChapterId(2L);
+        return subChapter;
+    }
+
+    private MainChapter mainChapter() {
+        MainChapter mainChapter = new MainChapter();
+        mainChapter.setMainChapterId(2L);
+        mainChapter.setChapterType(ChapterType.ASSET);
+        return mainChapter;
+    }
+}


### PR DESCRIPTION
- POST /api/admin/quiz-questions/{questionId}/publish
   - 최신 DRAFT만 공개
   - 같은 question_key의 기존 공개 버전 자동 RETIRED
- POST /api/admin/quiz-questions/{questionId}/retire
   - 현재 PUBLISHED 문항 수동 폐기
- 공개·폐기 및 관리자 감사 이력을 하나의 트랜잭션으로 처리
- 폐기 문항은 신규 출제·새 강좌 참조에서 제외
- 이미 공개된 강좌가 고정 참조한 폐기 문항은 계속 응시 가능
- QUESTION_NOT_PUBLISHABLE, QUESTION_NOT_RETIRABLE 오류 추가
- DB 변경 없음