### PR TITLE
feat: 강좌 콘텐츠 수동 비공개 API 구현  #101

### DIFF
--- a/src/main/java/org/firstfolio/config/OpenApiResponseSchemas.java
+++ b/src/main/java/org/firstfolio/config/OpenApiResponseSchemas.java
@@ -10,6 +10,7 @@ import org.firstfolio.content.dto.response.ContentVersionCreateResponse;
 import org.firstfolio.dashboard.dto.response.DashboardResponse;
 import org.firstfolio.content.dto.response.ContentVersionListResponse;
 import org.firstfolio.content.dto.response.ContentVersionPublishResponse;
+import org.firstfolio.content.dto.response.ContentVersionRetireResponse;
 import org.firstfolio.curriculum.dto.response.CurriculumConfirmResponse;
 import org.firstfolio.curriculum.dto.response.CurriculumDraftEditResponse;
 import org.firstfolio.curriculum.dto.response.CurriculumDraftResponse;
@@ -129,6 +130,9 @@ public final class OpenApiResponseSchemas {
 
     @Schema(name = "ContentVersionPublishApiResponse")
     public record ContentVersionPublish(ContentVersionPublishResponse data) { }
+
+    @Schema(name = "ContentVersionRetireApiResponse")
+    public record ContentVersionRetire(ContentVersionRetireResponse data) { }
 
     @Schema(name = "QuizQuestionCreateApiResponse")
     public record QuizQuestionCreate(QuizQuestionCreateResponse data) { }

--- a/src/main/java/org/firstfolio/content/controller/AdminContentVersionController.java
+++ b/src/main/java/org/firstfolio/content/controller/AdminContentVersionController.java
@@ -12,6 +12,7 @@ import org.firstfolio.content.dto.request.LessonContentUploadRequest;
 import org.firstfolio.content.dto.response.ContentVersionCreateResponse;
 import org.firstfolio.content.dto.response.ContentVersionListResponse;
 import org.firstfolio.content.dto.response.ContentVersionPublishResponse;
+import org.firstfolio.content.dto.response.ContentVersionRetireResponse;
 import org.firstfolio.content.service.ContentVersionService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -26,7 +27,7 @@ import javax.servlet.http.HttpServletRequest;
 
 @RestController
 @RequestMapping("/api/admin")
-@Tag(name = "관리자 학습 콘텐츠", description = "관리자용 강좌 콘텐츠 버전 업로드·조회·게시 API")
+@Tag(name = "관리자 학습 콘텐츠", description = "관리자용 강좌 콘텐츠 버전 업로드·조회·게시·비공개 API")
 public class AdminContentVersionController {
 
     private final ContentVersionService contentVersionService;
@@ -144,6 +145,43 @@ public class AdminContentVersionController {
     ) {
         return ApiResponse.of(ContentVersionPublishResponse.from(
                 contentVersionService.publishContentVersion(
+                        contentVersionId,
+                        currentUser.userId(),
+                        RequestIdFilter.currentRequestId(servletRequest)
+                )
+        ));
+    }
+
+    @PostMapping("/content-versions/{contentVersionId}/retire")
+    @Operation(
+            summary = "강좌 콘텐츠 버전 수동 비공개",
+            description = "현재 공개 중인 PUBLISHED 버전을 RETIRED로 전환하고 소단원의 현재 공개 버전 연결을 해제합니다. "
+                    + "저장소 객체와 과거 학습 이력은 삭제하지 않으며 상태 전환, 연결 해제와 감사 이력을 하나의 트랜잭션으로 처리합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200", description = "콘텐츠 버전 비공개 성공",
+                            content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json",
+                                    schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                            implementation = OpenApiResponseSchemas.ContentVersionRetire.class
+                                    )
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "404", description = "CONTENT_VERSION_NOT_FOUND - 콘텐츠 버전을 찾을 수 없음"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "409", description = "CONTENT_NOT_RETIRABLE - 현재 공개 중인 버전이 아님"
+                    )
+            }
+    )
+    public ApiResponse<ContentVersionRetireResponse> retireContentVersion(
+            @Parameter(description = "비공개할 콘텐츠 버전 ID", example = "301", required = true)
+            @PathVariable long contentVersionId,
+            @CurrentUser AuthenticatedUser currentUser,
+            HttpServletRequest servletRequest
+    ) {
+        return ApiResponse.of(ContentVersionRetireResponse.from(
+                contentVersionService.retireContentVersion(
                         contentVersionId,
                         currentUser.userId(),
                         RequestIdFilter.currentRequestId(servletRequest)

--- a/src/main/java/org/firstfolio/content/dto/response/ContentVersionRetireResponse.java
+++ b/src/main/java/org/firstfolio/content/dto/response/ContentVersionRetireResponse.java
@@ -1,0 +1,31 @@
+package org.firstfolio.content.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.firstfolio.content.domain.ContentVersion;
+import org.firstfolio.content.domain.ContentVersionStatus;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "학습 콘텐츠 수동 비공개 결과")
+public record ContentVersionRetireResponse(
+        @Schema(description = "폐기된 콘텐츠 버전 ID", example = "301")
+        long contentVersionId,
+        @Schema(description = "폐기 후 상태", example = "RETIRED")
+        ContentVersionStatus status,
+        @Schema(description = "최초 공개 시각", example = "2026-08-07T11:00:00Z")
+        LocalDateTime publishedAt,
+        @Schema(description = "소단원 ID", example = "21") long subChapterId,
+        @Schema(description = "현재 공개 버전 여부", example = "false")
+        boolean current
+) {
+
+    public static ContentVersionRetireResponse from(ContentVersion version) {
+        return new ContentVersionRetireResponse(
+                version.getContentVersionId(),
+                version.getStatus(),
+                version.getPublishedAt(),
+                version.getSubChapterId(),
+                false
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/content/service/ContentVersionService.java
+++ b/src/main/java/org/firstfolio/content/service/ContentVersionService.java
@@ -217,6 +217,67 @@ public class ContentVersionService {
         return target;
     }
 
+    @Transactional
+    public ContentVersion retireContentVersion(
+            long contentVersionId,
+            long actorUserId,
+            String requestId
+    ) {
+        ContentVersion reference = contentVersionMapper.findById(contentVersionId);
+        if (reference == null) {
+            throw new ApiException(ErrorCode.CONTENT_VERSION_NOT_FOUND);
+        }
+
+        SubChapter subChapter = subChapterMapper.findByIdForUpdate(
+                reference.getSubChapterId()
+        );
+        if (subChapter == null) {
+            throw new ApiException(ErrorCode.SUB_CHAPTER_NOT_FOUND);
+        }
+
+        ContentVersion target = contentVersionMapper.findByIdForUpdate(
+                contentVersionId
+        );
+        if (target == null) {
+            throw new ApiException(ErrorCode.CONTENT_VERSION_NOT_FOUND);
+        }
+        if (target.getStatus() != ContentVersionStatus.PUBLISHED
+                || !target.getContentVersionId().equals(
+                subChapter.getCurrentContentVersionId()
+        )) {
+            throw new ApiException(ErrorCode.CONTENT_NOT_RETIRABLE);
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        String beforeRetire = snapshot(target);
+        if (contentVersionMapper.retirePublished(contentVersionId) != 1) {
+            throw new ApiException(ErrorCode.CONTENT_NOT_RETIRABLE);
+        }
+        target.retire();
+
+        if (subChapterMapper.clearCurrentContentVersion(
+                subChapter.getSubChapterId(),
+                contentVersionId,
+                now
+        ) != 1) {
+            throw new IllegalStateException("소단원의 현재 콘텐츠 버전 연결을 해제하지 못했습니다.");
+        }
+
+        if (auditLogMapper.insert(
+                actorUserId,
+                "RETIRE",
+                AUDIT_ENTITY_TYPE,
+                contentVersionId,
+                beforeRetire,
+                snapshot(target),
+                requestId,
+                now
+        ) != 1) {
+            throw new IllegalStateException("콘텐츠 버전 폐기 감사 이력을 저장하지 못했습니다.");
+        }
+        return target;
+    }
+
     private void retireCurrentVersion(
             SubChapter subChapter,
             ContentVersion target,

--- a/src/main/java/org/firstfolio/curriculum/mapper/SubChapterMapper.java
+++ b/src/main/java/org/firstfolio/curriculum/mapper/SubChapterMapper.java
@@ -45,4 +45,10 @@ public interface SubChapterMapper {
             @Param("contentVersionId") long contentVersionId,
             @Param("updatedAt") LocalDateTime updatedAt
     );
+
+    int clearCurrentContentVersion(
+            @Param("subChapterId") long subChapterId,
+            @Param("expectedContentVersionId") long expectedContentVersionId,
+            @Param("updatedAt") LocalDateTime updatedAt
+    );
 }

--- a/src/main/java/org/firstfolio/exception/ErrorCode.java
+++ b/src/main/java/org/firstfolio/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     CONTENT_VERSION_NOT_FOUND(HttpStatus.NOT_FOUND, "강좌 콘텐츠 버전을 찾을 수 없습니다."),
     CONTENT_VERSION_CONFLICT(HttpStatus.CONFLICT, "같은 소단원 콘텐츠 버전이 이미 존재합니다."),
     CONTENT_NOT_PUBLISHABLE(HttpStatus.CONFLICT, "공개할 수 없는 강좌 콘텐츠 버전입니다."),
+    CONTENT_NOT_RETIRABLE(HttpStatus.CONFLICT, "폐기할 수 없는 강좌 콘텐츠 버전입니다."),
     CONTENT_VALIDATION_FAILED(HttpStatus.UNPROCESSABLE_ENTITY, "강좌 콘텐츠 검증에 실패했습니다."),
     CONTENT_NOT_PUBLISHED(HttpStatus.NOT_FOUND, "공개된 강좌 콘텐츠가 없습니다."),
     CONTENT_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "강좌 콘텐츠를 불러올 수 없습니다."),

--- a/src/main/resources/mappers/curriculum/SubChapterMapper.xml
+++ b/src/main/resources/mappers/curriculum/SubChapterMapper.xml
@@ -133,4 +133,12 @@
         WHERE sub_chapter_id = #{subChapterId}
     </update>
 
+    <update id="clearCurrentContentVersion">
+        UPDATE sub_chapters
+        SET current_content_version_id = NULL,
+            updated_at = #{updatedAt}
+        WHERE sub_chapter_id = #{subChapterId}
+          AND current_content_version_id = #{expectedContentVersionId}
+    </update>
+
 </mapper>

--- a/src/test/java/org/firstfolio/content/controller/AdminContentVersionControllerTest.java
+++ b/src/test/java/org/firstfolio/content/controller/AdminContentVersionControllerTest.java
@@ -176,6 +176,38 @@ class AdminContentVersionControllerTest {
                         .value("CONTENT_NOT_PUBLISHABLE"));
     }
 
+    @Test
+    void retiresCurrentPublishedContentVersion() throws Exception {
+        ContentVersion retired = publishedContentVersion();
+        retired.retire();
+        when(service.retireContentVersion(eq(301L), eq(900L), anyString()))
+                .thenReturn(retired);
+
+        mockMvc.perform(post("/api/admin/content-versions/301/retire")
+                        .requestAttr(AuthenticationRequestAttributes.CURRENT_USER, ADMIN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content_version_id").value(301))
+                .andExpect(jsonPath("$.data.sub_chapter_id").value(103))
+                .andExpect(jsonPath("$.data.status").value("RETIRED"))
+                .andExpect(jsonPath("$.data.published_at")
+                        .value("2026-08-06T02:00:00Z"))
+                .andExpect(jsonPath("$.data.current").value(false));
+
+        verify(service).retireContentVersion(eq(301L), eq(900L), anyString());
+    }
+
+    @Test
+    void returnsConflictForNonRetirableContentVersion() throws Exception {
+        when(service.retireContentVersion(eq(302L), eq(900L), anyString()))
+                .thenThrow(new ApiException(ErrorCode.CONTENT_NOT_RETIRABLE));
+
+        mockMvc.perform(post("/api/admin/content-versions/302/retire")
+                        .requestAttr(AuthenticationRequestAttributes.CURRENT_USER, ADMIN))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code")
+                        .value("CONTENT_NOT_RETIRABLE"));
+    }
+
     private ContentVersion contentVersion() {
         ContentVersion version = ContentVersion.draft(
                 103L,

--- a/src/test/java/org/firstfolio/content/service/ContentVersionServiceTest.java
+++ b/src/test/java/org/firstfolio/content/service/ContentVersionServiceTest.java
@@ -426,6 +426,107 @@ class ContentVersionServiceTest {
         );
     }
 
+    @Test
+    void retiresCurrentPublishedVersionAndClearsCurrentConnection() {
+        LocalDateTime publishedAt = NOW.minusDays(1);
+        ContentVersion target = contentVersion(
+                301L,
+                1,
+                ContentVersionStatus.PUBLISHED,
+                publishedAt
+        );
+        when(contentVersionMapper.findById(301L)).thenReturn(target);
+        when(subChapterMapper.findByIdForUpdate(SUB_CHAPTER_ID))
+                .thenReturn(subChapter(301L));
+        when(contentVersionMapper.findByIdForUpdate(301L)).thenReturn(target);
+        when(contentVersionMapper.retirePublished(301L)).thenReturn(1);
+        when(subChapterMapper.clearCurrentContentVersion(
+                SUB_CHAPTER_ID,
+                301L,
+                NOW
+        )).thenReturn(1);
+        when(auditLogMapper.insert(
+                anyLong(), anyString(), anyString(), anyLong(),
+                anyString(), anyString(), anyString(), any()
+        )).thenReturn(1);
+
+        ContentVersion retired = service.retireContentVersion(
+                301L,
+                ACTOR_ID,
+                REQUEST_ID
+        );
+
+        assertEquals(ContentVersionStatus.RETIRED, retired.getStatus());
+        assertEquals(publishedAt, retired.getPublishedAt());
+        verify(subChapterMapper).clearCurrentContentVersion(
+                SUB_CHAPTER_ID,
+                301L,
+                NOW
+        );
+        verify(auditLogMapper).insert(
+                eq(ACTOR_ID),
+                eq("RETIRE"),
+                eq("CONTENT_VERSION"),
+                eq(301L),
+                anyString(),
+                anyString(),
+                eq(REQUEST_ID),
+                eq(NOW)
+        );
+    }
+
+    @Test
+    void rejectsRetiringVersionThatIsNotCurrentPublishedVersion() {
+        ContentVersion published = contentVersion(
+                301L,
+                1,
+                ContentVersionStatus.PUBLISHED,
+                NOW.minusDays(1)
+        );
+        when(contentVersionMapper.findById(301L)).thenReturn(published);
+        when(subChapterMapper.findByIdForUpdate(SUB_CHAPTER_ID))
+                .thenReturn(subChapter(302L));
+        when(contentVersionMapper.findByIdForUpdate(301L)).thenReturn(published);
+
+        ApiException notCurrent = assertThrows(
+                ApiException.class,
+                () -> service.retireContentVersion(301L, ACTOR_ID, REQUEST_ID)
+        );
+
+        assertEquals(ErrorCode.CONTENT_NOT_RETIRABLE, notCurrent.getErrorCode());
+        verify(contentVersionMapper, never()).retirePublished(anyLong());
+        verify(subChapterMapper, never()).clearCurrentContentVersion(
+                anyLong(), anyLong(), any()
+        );
+    }
+
+    @Test
+    void rejectsRetiringDraftOrMissingContentVersion() {
+        when(contentVersionMapper.findById(999L)).thenReturn(null);
+        ApiException missing = assertThrows(
+                ApiException.class,
+                () -> service.retireContentVersion(999L, ACTOR_ID, REQUEST_ID)
+        );
+        assertEquals(ErrorCode.CONTENT_VERSION_NOT_FOUND, missing.getErrorCode());
+
+        ContentVersion draft = contentVersion(
+                302L,
+                2,
+                ContentVersionStatus.DRAFT,
+                null
+        );
+        when(contentVersionMapper.findById(302L)).thenReturn(draft);
+        when(subChapterMapper.findByIdForUpdate(SUB_CHAPTER_ID))
+                .thenReturn(subChapter(302L));
+        when(contentVersionMapper.findByIdForUpdate(302L)).thenReturn(draft);
+
+        ApiException notRetirable = assertThrows(
+                ApiException.class,
+                () -> service.retireContentVersion(302L, ACTOR_ID, REQUEST_ID)
+        );
+        assertEquals(ErrorCode.CONTENT_NOT_RETIRABLE, notRetirable.getErrorCode());
+    }
+
     private LessonContentUploadRequest uploadRequest() throws IOException {
         try (InputStream inputStream = getClass().getClassLoader()
                 .getResourceAsStream(VALID_LESSON_RESOURCE)) {

--- a/src/test/java/org/firstfolio/curriculum/mapper/ChapterMapperXmlTest.java
+++ b/src/test/java/org/firstfolio/curriculum/mapper/ChapterMapperXmlTest.java
@@ -2,11 +2,14 @@ package org.firstfolio.curriculum.mapper;
 
 import org.apache.ibatis.builder.xml.XMLMapperBuilder;
 import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.mapping.BoundSql;
 import org.apache.ibatis.session.Configuration;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.LocalDateTime;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -37,6 +40,24 @@ class ChapterMapperXmlTest {
         ));
         assertTrue(configuration.hasStatement(
                 SubChapterMapper.class.getName() + ".updateCurrentContentVersion"
+        ));
+        String clearStatement = SubChapterMapper.class.getName()
+                + ".clearCurrentContentVersion";
+        assertTrue(configuration.hasStatement(clearStatement));
+        BoundSql clearSql = configuration.getMappedStatement(clearStatement)
+                .getBoundSql(Map.of(
+                        "subChapterId", 103L,
+                        "expectedContentVersionId", 301L,
+                        "updatedAt", LocalDateTime.of(2026, 8, 14, 6, 0)
+                ));
+        String normalizedClearSql = clearSql.getSql()
+                .replaceAll("\\s+", " ")
+                .trim();
+        assertTrue(normalizedClearSql.contains(
+                "SET current_content_version_id = NULL"
+        ));
+        assertTrue(normalizedClearSql.endsWith(
+                "WHERE sub_chapter_id = ? AND current_content_version_id = ?"
         ));
         assertTrue(configuration.hasStatement(
                 AdminAuditLogMapper.class.getName() + ".insert"


### PR DESCRIPTION
- POST /api/admin/content-versions/{contentVersionId}/retire
- 현재 공개 중인 PUBLISHED 버전만 RETIRED 처리
- sub_chapters.current_content_version_id를 NULL로 해제
- 이전 버전으로 자동 복구하지 않음
- 저장소 객체와 기존 학습 이력은 보존
- 상태 변경·현재 버전 해제·감사 이력을 하나의 트랜잭션으로 처리
- 불가능한 상태는 CONTENT_NOT_RETIRABLE(409) 반환