### PR TITLE
feat: 뉴스 도메인 news_articles 테이블·GET /financial-news API 구현 #112

### DIFF
--- a/src/main/java/org/firstfolio/config/OpenApiResponseSchemas.java
+++ b/src/main/java/org/firstfolio/config/OpenApiResponseSchemas.java
@@ -26,6 +26,7 @@ import org.firstfolio.dailyquest.dto.response.DailyQuestAnswerSaveResponse;
 import org.firstfolio.dailyquest.dto.response.DailyQuestSubmitResponse;
 import org.firstfolio.dailyquest.dto.response.DailyQuestTodayResponse;
 import org.firstfolio.learning.dto.response.LessonContentResponse;
+import org.firstfolio.news.dto.response.FinancialNewsListResponse;
 import org.firstfolio.learning.dto.response.LearningProgressResponse;
 import org.firstfolio.learning.dto.response.LearningProgressUpdateResponse;
 import org.firstfolio.learning.dto.response.LearningContinueResponse;
@@ -210,4 +211,7 @@ public final class OpenApiResponseSchemas {
 
     @Schema(name = "DashboardApiResponse")
     public record Dashboard(DashboardResponse data) { }
+
+    @Schema(name = "FinancialNewsApiResponse")
+    public record FinancialNews(FinancialNewsListResponse data) { }
 }

--- a/src/main/java/org/firstfolio/news/controller/NewsController.java
+++ b/src/main/java/org/firstfolio/news/controller/NewsController.java
@@ -1,0 +1,57 @@
+package org.firstfolio.news.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.firstfolio.common.response.ApiResponse;
+import org.firstfolio.config.OpenApiResponseSchemas;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.news.dto.response.FinancialNewsListResponse;
+import org.firstfolio.news.service.NewsService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/financial-news")
+@Tag(name = "뉴스", description = "금융 뉴스 스크랩 목록 조회 API")
+public class NewsController {
+
+    private static final int DEFAULT_LIMIT = 3;
+    private static final int MIN_LIMIT = 1;
+    private static final int MAX_LIMIT = 10;
+
+    private final NewsService newsService;
+
+    public NewsController(NewsService newsService) {
+        this.newsService = newsService;
+    }
+
+    @GetMapping
+    @Operation(
+            summary = "금융 뉴스 목록 조회",
+            description = "발행 시각(published_at) 내림차순으로 최신 금융 뉴스를 조회합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            description = "금융 뉴스 목록 조회 성공",
+                            content = @io.swagger.v3.oas.annotations.media.Content(
+                                    mediaType = "application/json",
+                                    schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                            implementation = OpenApiResponseSchemas.FinancialNews.class
+                                    )
+                            )
+                    )
+            }
+    )
+    public ApiResponse<FinancialNewsListResponse> getFinancialNews(
+            @RequestParam(defaultValue = "" + DEFAULT_LIMIT) int limit
+    ) {
+        if (limit < MIN_LIMIT || limit > MAX_LIMIT) {
+            throw new ApiException(ErrorCode.INVALID_REQUEST, "limit은 1~10 사이의 정수여야 합니다.");
+        }
+
+        return ApiResponse.of(newsService.getFinancialNews(limit));
+    }
+}

--- a/src/main/java/org/firstfolio/news/domain/NewsArticle.java
+++ b/src/main/java/org/firstfolio/news/domain/NewsArticle.java
@@ -1,0 +1,103 @@
+package org.firstfolio.news.domain;
+
+import java.time.LocalDateTime;
+
+/**
+ * {@code news_articles} 한 행.
+ *
+ * <p>{@code financialNewsId}는 FE가 기대하는 필드명을 그대로 식별자명으로 쓴다
+ * ({@code news-scrap-dashboard-design.md} 참고).</p>
+ */
+public class NewsArticle {
+
+    private Long financialNewsId;
+    private String title;
+    private String summary;
+    private String imageUrl;
+    private String sourceName;
+    private String sourceUrl;
+    private LocalDateTime sourcePublishedAt;
+    private LocalDateTime publishedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public Long getFinancialNewsId() {
+        return financialNewsId;
+    }
+
+    public void setFinancialNewsId(Long financialNewsId) {
+        this.financialNewsId = financialNewsId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public void setSummary(String summary) {
+        this.summary = summary;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public String getSourceName() {
+        return sourceName;
+    }
+
+    public void setSourceName(String sourceName) {
+        this.sourceName = sourceName;
+    }
+
+    public String getSourceUrl() {
+        return sourceUrl;
+    }
+
+    public void setSourceUrl(String sourceUrl) {
+        this.sourceUrl = sourceUrl;
+    }
+
+    public LocalDateTime getSourcePublishedAt() {
+        return sourcePublishedAt;
+    }
+
+    public void setSourcePublishedAt(LocalDateTime sourcePublishedAt) {
+        this.sourcePublishedAt = sourcePublishedAt;
+    }
+
+    public LocalDateTime getPublishedAt() {
+        return publishedAt;
+    }
+
+    public void setPublishedAt(LocalDateTime publishedAt) {
+        this.publishedAt = publishedAt;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/org/firstfolio/news/dto/response/FinancialNewsItemResponse.java
+++ b/src/main/java/org/firstfolio/news/dto/response/FinancialNewsItemResponse.java
@@ -1,0 +1,81 @@
+package org.firstfolio.news.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "금융 뉴스 한 건")
+public final class FinancialNewsItemResponse {
+
+    @Schema(description = "금융 뉴스 식별자")
+    private final Long financialNewsId;
+    @Schema(description = "제목")
+    private final String title;
+    @Schema(description = "요약")
+    private final String summary;
+    @Schema(description = "썸네일 이미지 URL")
+    private final String imageUrl;
+    @Schema(description = "원문 언론사명")
+    private final String sourceName;
+    @Schema(description = "원문 기사 URL")
+    private final String sourceUrl;
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    @Schema(description = "원문 기사 발행 시각")
+    private final LocalDateTime sourcePublishedAt;
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    @Schema(description = "서비스 노출 시각")
+    private final LocalDateTime publishedAt;
+
+    public FinancialNewsItemResponse(
+        Long financialNewsId,
+        String title,
+        String summary,
+        String imageUrl,
+        String sourceName,
+        String sourceUrl,
+        LocalDateTime sourcePublishedAt,
+        LocalDateTime publishedAt
+    ) {
+        this.financialNewsId = financialNewsId;
+        this.title = title;
+        this.summary = summary;
+        this.imageUrl = imageUrl;
+        this.sourceName = sourceName;
+        this.sourceUrl = sourceUrl;
+        this.sourcePublishedAt = sourcePublishedAt;
+        this.publishedAt = publishedAt;
+    }
+
+    public Long getFinancialNewsId() {
+        return financialNewsId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public String getSourceName() {
+        return sourceName;
+    }
+
+    public String getSourceUrl() {
+        return sourceUrl;
+    }
+
+    public LocalDateTime getSourcePublishedAt() {
+        return sourcePublishedAt;
+    }
+
+    public LocalDateTime getPublishedAt() {
+        return publishedAt;
+    }
+}

--- a/src/main/java/org/firstfolio/news/dto/response/FinancialNewsListResponse.java
+++ b/src/main/java/org/firstfolio/news/dto/response/FinancialNewsListResponse.java
@@ -1,0 +1,23 @@
+package org.firstfolio.news.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+/**
+ * FE {@code FinancialNewsListResponse} 타입과 맞춘 {@code { items: [...] } }형태.
+ */
+@Schema(description = "금융 뉴스 목록 응답")
+public final class FinancialNewsListResponse {
+
+    @Schema(description = "금융 뉴스 목록")
+    private final List<FinancialNewsItemResponse> items;
+
+    public FinancialNewsListResponse(List<FinancialNewsItemResponse> items) {
+        this.items = items;
+    }
+
+    public List<FinancialNewsItemResponse> getItems() {
+        return items;
+    }
+}

--- a/src/main/java/org/firstfolio/news/mapper/NewsMapper.java
+++ b/src/main/java/org/firstfolio/news/mapper/NewsMapper.java
@@ -1,0 +1,13 @@
+package org.firstfolio.news.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.firstfolio.news.domain.NewsArticle;
+
+import java.util.List;
+
+@Mapper
+public interface NewsMapper {
+
+    List<NewsArticle> findLatest(@Param("limit") int limit);
+}

--- a/src/main/java/org/firstfolio/news/service/NewsService.java
+++ b/src/main/java/org/firstfolio/news/service/NewsService.java
@@ -1,0 +1,46 @@
+package org.firstfolio.news.service;
+
+import org.firstfolio.news.domain.NewsArticle;
+import org.firstfolio.news.dto.response.FinancialNewsItemResponse;
+import org.firstfolio.news.dto.response.FinancialNewsListResponse;
+import org.firstfolio.news.mapper.NewsMapper;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * 컨트롤러에 로직을 두지 않고 여기 모아, 대시보드 쪽(latest_news)에서도
+ * 이 서비스를 그대로 재사용할 수 있게 한다.
+ */
+@Service
+public class NewsService {
+
+    private final NewsMapper newsMapper;
+
+    public NewsService(NewsMapper newsMapper) {
+        this.newsMapper = newsMapper;
+    }
+
+    public FinancialNewsListResponse getFinancialNews(int limit) {
+        List<NewsArticle> articles = newsMapper.findLatest(limit);
+
+        List<FinancialNewsItemResponse> items = articles.stream()
+            .map(this::toItem)
+            .toList();
+
+        return new FinancialNewsListResponse(items);
+    }
+
+    private FinancialNewsItemResponse toItem(NewsArticle article) {
+        return new FinancialNewsItemResponse(
+            article.getFinancialNewsId(),
+            article.getTitle(),
+            article.getSummary(),
+            article.getImageUrl(),
+            article.getSourceName(),
+            article.getSourceUrl(),
+            article.getSourcePublishedAt(),
+            article.getPublishedAt()
+        );
+    }
+}

--- a/src/main/resources/db/migration/V3__create_news_articles.sql
+++ b/src/main/resources/db/migration/V3__create_news_articles.sql
@@ -1,0 +1,14 @@
+CREATE TABLE news_articles (
+    financial_news_id BIGINT NOT NULL AUTO_INCREMENT COMMENT '금융 뉴스 식별자',
+    title VARCHAR(255) NOT NULL COMMENT '뉴스 제목',
+    summary TEXT NOT NULL COMMENT '요약',
+    image_url VARCHAR(1024) NULL COMMENT '썸네일 이미지 URL',
+    source_name VARCHAR(100) NOT NULL COMMENT '원문 언론사명',
+    source_url VARCHAR(1024) NOT NULL COMMENT '원문 기사 URL',
+    source_published_at DATETIME NOT NULL COMMENT '원문 기사 발행 시각',
+    published_at DATETIME NOT NULL COMMENT '서비스 노출 시각',
+    created_at DATETIME NOT NULL COMMENT '등록 일시',
+    updated_at DATETIME NOT NULL COMMENT '마지막 수정 일시',
+    CONSTRAINT pk_news_articles PRIMARY KEY (financial_news_id),
+    INDEX idx_news_articles_published_at (published_at)
+) ENGINE = InnoDB COMMENT = '금융 뉴스 스크랩 기사';

--- a/src/main/resources/mappers/news/NewsMapper.xml
+++ b/src/main/resources/mappers/news/NewsMapper.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.firstfolio.news.mapper.NewsMapper">
+
+    <resultMap id="newsArticleResult" type="org.firstfolio.news.domain.NewsArticle">
+        <id property="financialNewsId" column="financial_news_id"/>
+        <result property="title" column="title"/>
+        <result property="summary" column="summary"/>
+        <result property="imageUrl" column="image_url"/>
+        <result property="sourceName" column="source_name"/>
+        <result property="sourceUrl" column="source_url"/>
+        <result property="sourcePublishedAt" column="source_published_at"/>
+        <result property="publishedAt" column="published_at"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="updatedAt" column="updated_at"/>
+    </resultMap>
+
+    <sql id="columns">
+        financial_news_id,
+        title,
+        summary,
+        image_url,
+        source_name,
+        source_url,
+        source_published_at,
+        published_at,
+        created_at,
+        updated_at
+    </sql>
+
+    <select id="findLatest" resultMap="newsArticleResult">
+        SELECT <include refid="columns"/>
+        FROM news_articles
+        ORDER BY published_at DESC
+        LIMIT #{limit}
+    </select>
+
+</mapper>


### PR DESCRIPTION
## 요약
뉴스 스크랩 대시보드용 news 도메인을 새로 만들고, GET /financial-news 조회 API를 구현했습니다.

## 변경 사항
- news_articles 테이블 마이그레이션 추가 (V3__create_news_articles.sql)
- NewsController / NewsService / NewsMapper 구현 (GET /financial-news, limit 1~10)
- 응답 DTO(FinancialNewsListResponse, FinancialNewsItemResponse) 및 OpenAPI 스키마 등록
- 로직은 NewsController가 아닌 NewsService에 두어, 이후 DashboardService의 latestNews 연동에서 재사용 가능

## DB 마이그레이션 포함
이 PR은 news_articles 테이블을 새로 생성하는 실제 스키마 변경(V3)을 포함합니다. 기존 테이블 변경은 없고 신규 테이블 추가뿐입니다.

## 테스트
- 로컬 DB에 테이블 생성 후 샘플 데이터 삽입, GET /financial-news 응답 확인
- FE(newsApi.js/newsService.js 연동)와 로컬에서 붙여 /daily 화면 노출 확인

## 체크리스트
- [x] 로컬 무오류 실행 확인
- [x] dev 기준 Conflict 없음
- [x] DB·API 스펙 변경 공유