### PR TITLE
feat: 금융 뉴스 내부 등록 API 구현

### DIFF
--- a/src/main/java/org/firstfolio/config/OpenApiResponseSchemas.java
+++ b/src/main/java/org/firstfolio/config/OpenApiResponseSchemas.java
@@ -26,6 +26,7 @@ import org.firstfolio.dailyquest.dto.response.DailyQuestAnswerSaveResponse;
 import org.firstfolio.dailyquest.dto.response.DailyQuestSubmitResponse;
 import org.firstfolio.dailyquest.dto.response.DailyQuestTodayResponse;
 import org.firstfolio.learning.dto.response.LessonContentResponse;
+import org.firstfolio.news.dto.response.FinancialNewsItemResponse;
 import org.firstfolio.news.dto.response.FinancialNewsListResponse;
 import org.firstfolio.learning.dto.response.LearningProgressResponse;
 import org.firstfolio.learning.dto.response.LearningProgressUpdateResponse;
@@ -214,4 +215,7 @@ public final class OpenApiResponseSchemas {
 
     @Schema(name = "FinancialNewsApiResponse")
     public record FinancialNews(FinancialNewsListResponse data) { }
+
+    @Schema(name = "FinancialNewsItemApiResponse")
+    public record FinancialNewsItem(FinancialNewsItemResponse data) { }
 }

--- a/src/main/java/org/firstfolio/news/controller/InternalNewsController.java
+++ b/src/main/java/org/firstfolio/news/controller/InternalNewsController.java
@@ -1,0 +1,66 @@
+package org.firstfolio.news.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.firstfolio.common.response.ApiResponse;
+import org.firstfolio.config.OpenApiResponseSchemas;
+import org.firstfolio.news.dto.request.NewsCreateRequest;
+import org.firstfolio.news.dto.response.FinancialNewsItemResponse;
+import org.firstfolio.news.service.NewsService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 내부 뉴스 등록 API.
+ *
+ * <p>내부 호출 검증은 {@code ServletConfig}의 경로 인터셉터가 담당한다
+ * ({@code /api/internal/**} → {@code X-Internal-Token}). 컨트롤러마다 반복하지 않는다.</p>
+ *
+ * <p>지금은 AI 쪽 수집·요약 파이프라인 없이, 수동으로 실행하는 스크립트가 이 API를
+ * 한 건씩 호출하는 것까지만 지원한다. 스케줄링·자동 수집은 이 API의 범위가 아니다.</p>
+ */
+@RestController
+@RequestMapping("/api/internal/news")
+@Tag(name = "내부 뉴스", description = "내부 호출용 금융 뉴스 등록 API")
+public class InternalNewsController {
+
+    private final NewsService newsService;
+
+    public InternalNewsController(NewsService newsService) {
+        this.newsService = newsService;
+    }
+
+    @PostMapping
+    @Operation(
+            summary = "금융 뉴스 등록",
+            description = "금융 뉴스 한 건을 등록합니다. published_at을 생략하면 현재 시각으로 채웁니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            description = "금융 뉴스 등록 성공",
+                            content = @io.swagger.v3.oas.annotations.media.Content(
+                                    mediaType = "application/json",
+                                    schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                            implementation = OpenApiResponseSchemas.FinancialNewsItem.class
+                                    )
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "400", description = "INVALID_REQUEST - 필수 필드 누락"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "403", description = "INTERNAL_CALL_REQUIRED - 내부 호출 토큰이 없거나 올바르지 않음"
+                    )
+            }
+    )
+    public ApiResponse<FinancialNewsItemResponse> create(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true, description = "등록할 금융 뉴스 한 건"
+            )
+            @RequestBody NewsCreateRequest request
+    ) {
+        return ApiResponse.of(newsService.createArticle(request));
+    }
+}

--- a/src/main/java/org/firstfolio/news/dto/request/NewsCreateRequest.java
+++ b/src/main/java/org/firstfolio/news/dto/request/NewsCreateRequest.java
@@ -1,0 +1,86 @@
+package org.firstfolio.news.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+/**
+ * 내부 뉴스 등록 요청 ({@code POST /api/internal/news}).
+ *
+ * <p>{@code publishedAt}을 비우면 서비스 노출 시각을 현재 시각으로 채운다. 원문 발행 시각
+ * ({@code sourcePublishedAt})은 호출한 쪽이 반드시 채워야 한다.</p>
+ */
+@Schema(description = "금융 뉴스 등록 요청")
+public class NewsCreateRequest {
+
+    @Schema(description = "제목", example = "예·적금 금리 비교 수요 증가…은행권 경쟁 격화")
+    private String title;
+    @Schema(description = "요약")
+    private String summary;
+    @Schema(description = "썸네일 이미지 URL")
+    private String imageUrl;
+    @Schema(description = "원문 언론사명")
+    private String sourceName;
+    @Schema(description = "원문 기사 URL")
+    private String sourceUrl;
+    @Schema(description = "원문 기사 발행 시각")
+    private LocalDateTime sourcePublishedAt;
+    @Schema(description = "서비스 노출 시각. 생략하면 현재 시각")
+    private LocalDateTime publishedAt;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public void setSummary(String summary) {
+        this.summary = summary;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public String getSourceName() {
+        return sourceName;
+    }
+
+    public void setSourceName(String sourceName) {
+        this.sourceName = sourceName;
+    }
+
+    public String getSourceUrl() {
+        return sourceUrl;
+    }
+
+    public void setSourceUrl(String sourceUrl) {
+        this.sourceUrl = sourceUrl;
+    }
+
+    public LocalDateTime getSourcePublishedAt() {
+        return sourcePublishedAt;
+    }
+
+    public void setSourcePublishedAt(LocalDateTime sourcePublishedAt) {
+        this.sourcePublishedAt = sourcePublishedAt;
+    }
+
+    public LocalDateTime getPublishedAt() {
+        return publishedAt;
+    }
+
+    public void setPublishedAt(LocalDateTime publishedAt) {
+        this.publishedAt = publishedAt;
+    }
+}

--- a/src/main/java/org/firstfolio/news/mapper/NewsMapper.java
+++ b/src/main/java/org/firstfolio/news/mapper/NewsMapper.java
@@ -10,4 +10,6 @@ import java.util.List;
 public interface NewsMapper {
 
     List<NewsArticle> findLatest(@Param("limit") int limit);
+
+    int insert(NewsArticle article);
 }

--- a/src/main/java/org/firstfolio/news/service/NewsService.java
+++ b/src/main/java/org/firstfolio/news/service/NewsService.java
@@ -1,11 +1,16 @@
 package org.firstfolio.news.service;
 
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
 import org.firstfolio.news.domain.NewsArticle;
+import org.firstfolio.news.dto.request.NewsCreateRequest;
 import org.firstfolio.news.dto.response.FinancialNewsItemResponse;
 import org.firstfolio.news.dto.response.FinancialNewsListResponse;
 import org.firstfolio.news.mapper.NewsMapper;
 import org.springframework.stereotype.Service;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -16,9 +21,11 @@ import java.util.List;
 public class NewsService {
 
     private final NewsMapper newsMapper;
+    private final Clock clock;
 
-    public NewsService(NewsMapper newsMapper) {
+    public NewsService(NewsMapper newsMapper, Clock clock) {
         this.newsMapper = newsMapper;
+        this.clock = clock;
     }
 
     public FinancialNewsListResponse getFinancialNews(int limit) {
@@ -29,6 +36,45 @@ public class NewsService {
             .toList();
 
         return new FinancialNewsListResponse(items);
+    }
+
+    public FinancialNewsItemResponse createArticle(NewsCreateRequest request) {
+        validate(request);
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        NewsArticle article = new NewsArticle();
+        article.setTitle(request.getTitle());
+        article.setSummary(request.getSummary());
+        article.setImageUrl(request.getImageUrl());
+        article.setSourceName(request.getSourceName());
+        article.setSourceUrl(request.getSourceUrl());
+        article.setSourcePublishedAt(request.getSourcePublishedAt());
+        article.setPublishedAt(request.getPublishedAt() != null ? request.getPublishedAt() : now);
+        article.setCreatedAt(now);
+        article.setUpdatedAt(now);
+
+        if (newsMapper.insert(article) != 1 || article.getFinancialNewsId() == null) {
+            throw new ApiException(ErrorCode.INTERNAL_ERROR);
+        }
+
+        return toItem(article);
+    }
+
+    private void validate(NewsCreateRequest request) {
+        if (isBlank(request.getTitle())
+                || isBlank(request.getSummary())
+                || isBlank(request.getSourceName())
+                || isBlank(request.getSourceUrl())
+                || request.getSourcePublishedAt() == null) {
+            throw new ApiException(
+                    ErrorCode.INVALID_REQUEST,
+                    "title, summary, source_name, source_url, source_published_at는 필수입니다."
+            );
+        }
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 
     private FinancialNewsItemResponse toItem(NewsArticle article) {

--- a/src/main/resources/mappers/news/NewsMapper.xml
+++ b/src/main/resources/mappers/news/NewsMapper.xml
@@ -38,4 +38,28 @@
         LIMIT #{limit}
     </select>
 
+    <insert id="insert" useGeneratedKeys="true" keyProperty="financialNewsId">
+        INSERT INTO news_articles (
+            title,
+            summary,
+            image_url,
+            source_name,
+            source_url,
+            source_published_at,
+            published_at,
+            created_at,
+            updated_at
+        ) VALUES (
+            #{title},
+            #{summary},
+            #{imageUrl},
+            #{sourceName},
+            #{sourceUrl},
+            #{sourcePublishedAt},
+            #{publishedAt},
+            #{createdAt},
+            #{updatedAt}
+        )
+    </insert>
+
 </mapper>


### PR DESCRIPTION
작업 배경
AI가 나중에 뉴스를 수집해 자동으로 넣을 수 있도록, 그 전 단계로 내부에서 뉴스 한 건을 등록하는 API가 필요함. 지금은 실제 AI 파이프라인 없이, 스크립트가 이 API를 수동으로 호출하는 것까지만 지원.

작업(구현) 내용 및 현황

* [x] `NewsCreateRequest` DTO 작성
* [x] `NewsMapper`에 `insert` 메서드 추가
* [x] `NewsService`에 `createArticle` 메서드 추가 (필수 필드 검증 포함)
* [x] `InternalNewsController` 신규 작성 (`POST /api/internal/news`, 기존 `/api/internal/**` 패턴과 동일하게 `X-Internal-Token`으로 보호)

테스트

* 로컬 컴파일 확인 (`./gradlew compileJava`)
* `dev` 최신 상태 반영 확인 (머지 후 재확인)

관련 이슈
Closes [#118](https://github.com/KB7-25-2/FirstFolio-BE/issues/118)