### PR TITLE
feat: 관리자 퀴즈 조회 API

### DIFF
--- a/src/main/java/org/firstfolio/config/OpenApiResponseSchemas.java
+++ b/src/main/java/org/firstfolio/config/OpenApiResponseSchemas.java
@@ -45,6 +45,7 @@ import org.firstfolio.quiz.dto.response.LevelTestSubmitResponse;
 import org.firstfolio.quiz.dto.response.QuizAttemptStartResponse;
 import org.firstfolio.quiz.dto.response.QuizAnswerGradingResponse;
 import org.firstfolio.quiz.dto.response.QuizQuestionCreateResponse;
+import org.firstfolio.quiz.dto.response.QuizQuestionPageResponse;
 import org.firstfolio.quiz.dto.response.QuizQuestionStatusResponse;
 import org.firstfolio.simulation.dto.response.PriceRefreshResponse;
 import org.firstfolio.simulation.dto.response.ProductDetailResponse;
@@ -145,6 +146,9 @@ public final class OpenApiResponseSchemas {
 
     @Schema(name = "QuizQuestionCreateApiResponse")
     public record QuizQuestionCreate(QuizQuestionCreateResponse data) { }
+
+    @Schema(name = "QuizQuestionPageApiResponse")
+    public record QuizQuestionPage(QuizQuestionPageResponse data) { }
 
     @Schema(name = "QuizQuestionStatusApiResponse")
     public record QuizQuestionStatus(QuizQuestionStatusResponse data) { }

--- a/src/main/java/org/firstfolio/quiz/controller/AdminQuizQuestionController.java
+++ b/src/main/java/org/firstfolio/quiz/controller/AdminQuizQuestionController.java
@@ -11,14 +11,18 @@ import org.firstfolio.config.OpenApiResponseSchemas;
 import org.firstfolio.quiz.dto.request.QuizQuestionCreateRequest;
 import org.firstfolio.quiz.dto.request.QuizQuestionVersionCreateRequest;
 import org.firstfolio.quiz.dto.response.QuizQuestionCreateResponse;
+import org.firstfolio.quiz.dto.response.QuizQuestionPageResponse;
 import org.firstfolio.quiz.dto.response.QuizQuestionStatusResponse;
 import org.firstfolio.quiz.service.QuizQuestionPublicationService;
+import org.firstfolio.quiz.service.QuizQuestionQueryService;
 import org.firstfolio.quiz.service.QuizQuestionRegistrationService;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,18 +30,65 @@ import javax.servlet.http.HttpServletRequest;
 
 @RestController
 @RequestMapping("/api/admin/quiz-questions")
-@Tag(name = "관리자 퀴즈 문항", description = "관리자용 퀴즈 문항 등록·버전 관리 API")
+@Tag(name = "관리자 퀴즈 문항", description = "관리자용 퀴즈 문항 조회·등록·버전 관리 API")
 public class AdminQuizQuestionController {
 
     private final QuizQuestionRegistrationService registrationService;
     private final QuizQuestionPublicationService publicationService;
+    private final QuizQuestionQueryService queryService;
 
     public AdminQuizQuestionController(
             QuizQuestionRegistrationService registrationService,
-            QuizQuestionPublicationService publicationService
+            QuizQuestionPublicationService publicationService,
+            QuizQuestionQueryService queryService
     ) {
         this.registrationService = registrationService;
         this.publicationService = publicationService;
+        this.queryService = queryService;
+    }
+
+    @GetMapping
+    @Operation(
+            summary = "퀴즈 문항 목록 조회",
+            description = "관리자가 퀴즈 문항을 사용처·단원·상태·논리 키로 검색합니다. "
+                    + "결과는 question_id 오름차순 커서 페이지로 반환합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200", description = "퀴즈 문항 조회 성공",
+                            content = @io.swagger.v3.oas.annotations.media.Content(
+                                    mediaType = "application/json",
+                                    schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                            implementation = OpenApiResponseSchemas.QuizQuestionPage.class
+                                    )
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "403", description = "ADMIN_REQUIRED - 관리자 권한 필요"
+                    )
+            }
+    )
+    public ApiResponse<QuizQuestionPageResponse> findQuestions(
+            @Parameter(description = "문항 사용처", example = "SUB_CHAPTER")
+            @RequestParam(value = "usage_type", required = false) String usageType,
+            @Parameter(description = "대단원 필터", example = "2")
+            @RequestParam(value = "main_chapter_id", required = false) Long mainChapterId,
+            @Parameter(description = "소단원 필터", example = "101")
+            @RequestParam(value = "sub_chapter_id", required = false) Long subChapterId,
+            @Parameter(description = "버전 상태", example = "PUBLISHED")
+            @RequestParam(value = "status", required = false) String status,
+            @Parameter(description = "논리 문항 키", example = "deposit-q-001")
+            @RequestParam(value = "question_key", required = false) String questionKey,
+            @Parameter(description = "다음 페이지 조회용 커서")
+            @RequestParam(value = "cursor", required = false) String cursor
+    ) {
+        return ApiResponse.of(queryService.findPage(
+                usageType,
+                mainChapterId,
+                subChapterId,
+                status,
+                questionKey,
+                cursor
+        ));
     }
 
     @PostMapping

--- a/src/main/java/org/firstfolio/quiz/dto/response/QuizQuestionListItemResponse.java
+++ b/src/main/java/org/firstfolio/quiz/dto/response/QuizQuestionListItemResponse.java
@@ -1,0 +1,34 @@
+package org.firstfolio.quiz.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.firstfolio.quiz.domain.QuizGenerationType;
+import org.firstfolio.quiz.domain.QuizQuestion;
+import org.firstfolio.quiz.domain.QuizQuestionStatus;
+import org.firstfolio.quiz.domain.QuizQuestionType;
+import org.firstfolio.quiz.domain.QuizUsageType;
+
+@Schema(description = "관리자용 퀴즈 문항 목록 항목")
+public record QuizQuestionListItemResponse(
+        @Schema(description = "문항 버전 ID", example = "1001") long questionId,
+        @Schema(description = "논리 문항 키", example = "deposit-q-001") String questionKey,
+        @Schema(description = "문항 버전 번호", example = "1") int versionNo,
+        @Schema(description = "문항 사용처", example = "SUB_CHAPTER") QuizUsageType usageType,
+        @Schema(description = "문항 유형", example = "SINGLE_CHOICE") QuizQuestionType questionType,
+        @Schema(description = "생성 방식", example = "HUMAN") QuizGenerationType generationType,
+        @Schema(description = "문항 지문", example = "예금의 특징으로 적절한 것은?") String prompt,
+        @Schema(description = "버전 상태", example = "PUBLISHED") QuizQuestionStatus status
+) {
+
+    public static QuizQuestionListItemResponse from(QuizQuestion question) {
+        return new QuizQuestionListItemResponse(
+                question.getQuestionId(),
+                question.getQuestionKey(),
+                question.getVersionNo(),
+                question.getUsageType(),
+                question.getQuestionType(),
+                question.getGenerationType(),
+                question.getPrompt(),
+                question.getStatus()
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/dto/response/QuizQuestionPageResponse.java
+++ b/src/main/java/org/firstfolio/quiz/dto/response/QuizQuestionPageResponse.java
@@ -1,0 +1,13 @@
+package org.firstfolio.quiz.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "관리자용 퀴즈 문항 커서 페이지")
+public record QuizQuestionPageResponse(
+        @Schema(description = "퀴즈 문항 목록") List<QuizQuestionListItemResponse> items,
+        @Schema(description = "다음 페이지 커서. 마지막 페이지면 null", example = "1001")
+        String nextCursor
+) {
+}

--- a/src/main/java/org/firstfolio/quiz/mapper/QuizQuestionMapper.java
+++ b/src/main/java/org/firstfolio/quiz/mapper/QuizQuestionMapper.java
@@ -4,6 +4,8 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.firstfolio.quiz.domain.QuizQuestion;
 import org.firstfolio.quiz.domain.QuizQuestionReference;
+import org.firstfolio.quiz.domain.QuizQuestionStatus;
+import org.firstfolio.quiz.domain.QuizUsageType;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -43,6 +45,16 @@ public interface QuizQuestionMapper {
 
     QuizQuestion findLatestPublishedDailyNewsByQuestDate(
             @Param("questDate") LocalDate questDate
+    );
+
+    List<QuizQuestion> findPage(
+            @Param("usageType") QuizUsageType usageType,
+            @Param("mainChapterId") Long mainChapterId,
+            @Param("subChapterId") Long subChapterId,
+            @Param("status") QuizQuestionStatus status,
+            @Param("questionKey") String questionKey,
+            @Param("cursor") Long cursor,
+            @Param("size") int size
     );
 
     int publishDraft(

--- a/src/main/java/org/firstfolio/quiz/service/QuizQuestionQueryService.java
+++ b/src/main/java/org/firstfolio/quiz/service/QuizQuestionQueryService.java
@@ -1,0 +1,115 @@
+package org.firstfolio.quiz.service;
+
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.quiz.domain.QuizQuestion;
+import org.firstfolio.quiz.domain.QuizQuestionStatus;
+import org.firstfolio.quiz.domain.QuizUsageType;
+import org.firstfolio.quiz.dto.response.QuizQuestionListItemResponse;
+import org.firstfolio.quiz.dto.response.QuizQuestionPageResponse;
+import org.firstfolio.quiz.mapper.QuizQuestionMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class QuizQuestionQueryService {
+
+    private static final int DEFAULT_PAGE_SIZE = 20;
+
+    private final QuizQuestionMapper quizQuestionMapper;
+
+    public QuizQuestionQueryService(QuizQuestionMapper quizQuestionMapper) {
+        this.quizQuestionMapper = quizQuestionMapper;
+    }
+
+    @Transactional(readOnly = true)
+    public QuizQuestionPageResponse findPage(
+            String usageType,
+            Long mainChapterId,
+            Long subChapterId,
+            String status,
+            String questionKey,
+            String cursor
+    ) {
+        List<QuizQuestion> found = quizQuestionMapper.findPage(
+                parseUsageType(usageType),
+                mainChapterId,
+                subChapterId,
+                parseStatus(status),
+                normalizeQuestionKey(questionKey),
+                parseCursor(cursor),
+                DEFAULT_PAGE_SIZE + 1
+        );
+
+        boolean hasNext = found.size() > DEFAULT_PAGE_SIZE;
+        List<QuizQuestion> page = hasNext
+                ? found.subList(0, DEFAULT_PAGE_SIZE)
+                : found;
+
+        List<QuizQuestionListItemResponse> items = new ArrayList<>(page.size());
+        for (QuizQuestion question : page) {
+            items.add(QuizQuestionListItemResponse.from(question));
+        }
+
+        String nextCursor = hasNext
+                ? String.valueOf(page.get(page.size() - 1).getQuestionId())
+                : null;
+
+        return new QuizQuestionPageResponse(items, nextCursor);
+    }
+
+    private static QuizUsageType parseUsageType(String usageType) {
+        if (usageType == null || usageType.isBlank()) {
+            return null;
+        }
+
+        try {
+            return QuizUsageType.valueOf(usageType.trim().toUpperCase());
+        } catch (IllegalArgumentException exception) {
+            throw new ApiException(
+                    ErrorCode.INVALID_REQUEST,
+                    "usage_type 값이 올바르지 않습니다."
+            );
+        }
+    }
+
+    private static QuizQuestionStatus parseStatus(String status) {
+        if (status == null || status.isBlank()) {
+            return null;
+        }
+
+        try {
+            return QuizQuestionStatus.valueOf(status.trim().toUpperCase());
+        } catch (IllegalArgumentException exception) {
+            throw new ApiException(
+                    ErrorCode.INVALID_REQUEST,
+                    "status 값이 올바르지 않습니다."
+            );
+        }
+    }
+
+    private static String normalizeQuestionKey(String questionKey) {
+        if (questionKey == null || questionKey.isBlank()) {
+            return null;
+        }
+        return questionKey.trim();
+    }
+
+    private static Long parseCursor(String cursor) {
+        if (cursor == null || cursor.isBlank()) {
+            return null;
+        }
+
+        try {
+            return Long.parseLong(cursor.trim());
+        } catch (NumberFormatException exception) {
+            throw new ApiException(
+                    ErrorCode.INVALID_REQUEST,
+                    "cursor 값이 올바르지 않습니다."
+            );
+        }
+    }
+}

--- a/src/main/resources/mappers/quiz/QuizQuestionMapper.xml
+++ b/src/main/resources/mappers/quiz/QuizQuestionMapper.xml
@@ -226,6 +226,33 @@
         LIMIT 1
     </select>
 
+    <select id="findPage" resultMap="questionResultMap">
+        SELECT <include refid="questionColumns" />
+        FROM quiz_questions
+        <where>
+            <if test="usageType != null">
+                AND usage_type = #{usageType}
+            </if>
+            <if test="mainChapterId != null">
+                AND main_chapter_id = #{mainChapterId}
+            </if>
+            <if test="subChapterId != null">
+                AND sub_chapter_id = #{subChapterId}
+            </if>
+            <if test="status != null">
+                AND status = #{status}
+            </if>
+            <if test="questionKey != null">
+                AND question_key = #{questionKey}
+            </if>
+            <if test="cursor != null">
+                AND question_id &gt; #{cursor}
+            </if>
+        </where>
+        ORDER BY question_id
+        LIMIT #{size}
+    </select>
+
     <update id="publishDraft">
         UPDATE quiz_questions
         SET status = 'PUBLISHED',

--- a/src/test/java/org/firstfolio/quiz/controller/AdminQuizQuestionControllerTest.java
+++ b/src/test/java/org/firstfolio/quiz/controller/AdminQuizQuestionControllerTest.java
@@ -11,10 +11,14 @@ import org.firstfolio.exception.ErrorCode;
 import org.firstfolio.quiz.domain.QuizDifficulty;
 import org.firstfolio.quiz.domain.QuizGenerationType;
 import org.firstfolio.quiz.domain.QuizQuestion;
+import org.firstfolio.quiz.domain.QuizQuestionStatus;
 import org.firstfolio.quiz.domain.QuizQuestionType;
 import org.firstfolio.quiz.domain.QuizUsageType;
-import org.firstfolio.quiz.service.QuizQuestionRegistrationService;
+import org.firstfolio.quiz.dto.response.QuizQuestionListItemResponse;
+import org.firstfolio.quiz.dto.response.QuizQuestionPageResponse;
 import org.firstfolio.quiz.service.QuizQuestionPublicationService;
+import org.firstfolio.quiz.service.QuizQuestionQueryService;
+import org.firstfolio.quiz.service.QuizQuestionRegistrationService;
 import org.firstfolio.user.domain.UserRole;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,6 +29,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -33,6 +38,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -48,24 +54,74 @@ class AdminQuizQuestionControllerTest {
 
     private QuizQuestionRegistrationService service;
     private QuizQuestionPublicationService publicationService;
+    private QuizQuestionQueryService queryService;
     private MockMvc mockMvc;
 
     @BeforeEach
     void setUp() {
         service = mock(QuizQuestionRegistrationService.class);
         publicationService = mock(QuizQuestionPublicationService.class);
+        queryService = mock(QuizQuestionQueryService.class);
         MappingJackson2HttpMessageConverter converter =
                 new MappingJackson2HttpMessageConverter(ApiObjectMapperFactory.create());
         mockMvc = MockMvcBuilders
                 .standaloneSetup(new AdminQuizQuestionController(
                         service,
-                        publicationService
+                        publicationService,
+                        queryService
                 ))
                 .setControllerAdvice(new CommonExceptionAdvice())
                 .setCustomArgumentResolvers(new CurrentUserArgumentResolver())
                 .setMessageConverters(converter)
                 .addFilter(new RequestIdFilter())
                 .build();
+    }
+
+    @Test
+    void findsQuestionsWithFiltersAndCursorPagination() throws Exception {
+        QuizQuestion published = question(1001L, 1);
+        published.publish(LocalDateTime.of(2026, 8, 14, 6, 0));
+        when(queryService.findPage(
+                "SUB_CHAPTER",
+                2L,
+                101L,
+                "PUBLISHED",
+                "deposit-basic-001",
+                "1000"
+        )).thenReturn(new QuizQuestionPageResponse(
+                List.of(QuizQuestionListItemResponse.from(published)),
+                "1001"
+        ));
+
+        mockMvc.perform(get("/api/admin/quiz-questions")
+                        .requestAttr(AuthenticationRequestAttributes.CURRENT_USER, ADMIN)
+                        .param("usage_type", "SUB_CHAPTER")
+                        .param("main_chapter_id", "2")
+                        .param("sub_chapter_id", "101")
+                        .param("status", "PUBLISHED")
+                        .param("question_key", "deposit-basic-001")
+                        .param("cursor", "1000"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items[0].question_id").value(1001))
+                .andExpect(jsonPath("$.data.items[0].question_key")
+                        .value("deposit-basic-001"))
+                .andExpect(jsonPath("$.data.items[0].version_no").value(1))
+                .andExpect(jsonPath("$.data.items[0].usage_type").value("SUB_CHAPTER"))
+                .andExpect(jsonPath("$.data.items[0].question_type")
+                        .value("SINGLE_CHOICE"))
+                .andExpect(jsonPath("$.data.items[0].generation_type").value("HUMAN"))
+                .andExpect(jsonPath("$.data.items[0].prompt").value("질문"))
+                .andExpect(jsonPath("$.data.items[0].status").value("PUBLISHED"))
+                .andExpect(jsonPath("$.data.next_cursor").value("1001"));
+
+        verify(queryService).findPage(
+                "SUB_CHAPTER",
+                2L,
+                101L,
+                "PUBLISHED",
+                "deposit-basic-001",
+                "1000"
+        );
     }
 
     @Test

--- a/src/test/java/org/firstfolio/quiz/mapper/QuizQuestionMapperXmlTest.java
+++ b/src/test/java/org/firstfolio/quiz/mapper/QuizQuestionMapperXmlTest.java
@@ -198,6 +198,38 @@ class QuizQuestionMapperXmlTest {
                 "ORDER BY question.published_at DESC, "
                         + "question.question_id DESC LIMIT 1"
         ));
+
+        assertTrue(configuration.hasStatement(
+                QuizQuestionMapper.class.getName() + ".findPage"
+        ));
+
+        BoundSql findPageSql = configuration.getMappedStatement(
+                        QuizQuestionMapper.class.getName() + ".findPage"
+                )
+                .getBoundSql(Map.of(
+                        "usageType",
+                        org.firstfolio.quiz.domain.QuizUsageType.SUB_CHAPTER,
+                        "mainChapterId",
+                        2L,
+                        "subChapterId",
+                        101L,
+                        "status",
+                        org.firstfolio.quiz.domain.QuizQuestionStatus.PUBLISHED,
+                        "questionKey",
+                        "deposit-q-001",
+                        "cursor",
+                        1000L,
+                        "size",
+                        21
+                ));
+        String normalizedFindPageSql = normalize(findPageSql.getSql());
+        assertTrue(normalizedFindPageSql.contains("usage_type = ?"));
+        assertTrue(normalizedFindPageSql.contains("main_chapter_id = ?"));
+        assertTrue(normalizedFindPageSql.contains("sub_chapter_id = ?"));
+        assertTrue(normalizedFindPageSql.contains("status = ?"));
+        assertTrue(normalizedFindPageSql.contains("question_key = ?"));
+        assertTrue(normalizedFindPageSql.contains("question_id > ?"));
+        assertTrue(normalizedFindPageSql.endsWith("ORDER BY question_id LIMIT ?"));
     }
 
     private String normalize(String sql) {

--- a/src/test/java/org/firstfolio/quiz/service/QuizQuestionQueryServiceTest.java
+++ b/src/test/java/org/firstfolio/quiz/service/QuizQuestionQueryServiceTest.java
@@ -1,0 +1,158 @@
+package org.firstfolio.quiz.service;
+
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.quiz.domain.QuizDifficulty;
+import org.firstfolio.quiz.domain.QuizGenerationType;
+import org.firstfolio.quiz.domain.QuizQuestion;
+import org.firstfolio.quiz.domain.QuizQuestionStatus;
+import org.firstfolio.quiz.domain.QuizQuestionType;
+import org.firstfolio.quiz.domain.QuizUsageType;
+import org.firstfolio.quiz.dto.response.QuizQuestionPageResponse;
+import org.firstfolio.quiz.mapper.QuizQuestionMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class QuizQuestionQueryServiceTest {
+
+    private QuizQuestionMapper mapper;
+    private QuizQuestionQueryService service;
+
+    @BeforeEach
+    void setUp() {
+        mapper = mock(QuizQuestionMapper.class);
+        service = new QuizQuestionQueryService(mapper);
+    }
+
+    @Test
+    void returnsCursorOnlyWhenMorePagesExist() {
+        List<QuizQuestion> found = new java.util.ArrayList<>();
+        for (long id = 1001L; id <= 1021L; id++) {
+            found.add(question(id));
+        }
+
+        when(mapper.findPage(any(), any(), any(), any(), any(), any(), eq(21)))
+                .thenReturn(found);
+
+        QuizQuestionPageResponse page = service.findPage(
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        assertEquals(20, page.items().size());
+        assertEquals("1020", page.nextCursor());
+    }
+
+    @Test
+    void returnsNullCursorOnLastPage() {
+        when(mapper.findPage(any(), any(), any(), any(), any(), any(), eq(21)))
+                .thenReturn(List.of(question(1001L)));
+
+        QuizQuestionPageResponse page = service.findPage(
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        assertEquals(1, page.items().size());
+        assertNull(page.nextCursor());
+    }
+
+    @Test
+    void passesParsedFiltersToMapper() {
+        when(mapper.findPage(any(), any(), any(), any(), any(), any(), eq(21)))
+                .thenReturn(List.of());
+
+        service.findPage(
+                "sub_chapter",
+                2L,
+                101L,
+                "published",
+                " deposit-q-001 ",
+                "1000"
+        );
+
+        ArgumentCaptor<QuizUsageType> usageTypeCaptor =
+                ArgumentCaptor.forClass(QuizUsageType.class);
+        ArgumentCaptor<QuizQuestionStatus> statusCaptor =
+                ArgumentCaptor.forClass(QuizQuestionStatus.class);
+
+        verify(mapper).findPage(
+                usageTypeCaptor.capture(),
+                eq(2L),
+                eq(101L),
+                statusCaptor.capture(),
+                eq("deposit-q-001"),
+                eq(1000L),
+                eq(21)
+        );
+        assertEquals(QuizUsageType.SUB_CHAPTER, usageTypeCaptor.getValue());
+        assertEquals(QuizQuestionStatus.PUBLISHED, statusCaptor.getValue());
+    }
+
+    @Test
+    void rejectsInvalidFilterValues() {
+        ApiException invalidUsageType = assertThrows(
+                ApiException.class,
+                () -> service.findPage("INVALID", null, null, null, null, null)
+        );
+        assertEquals(ErrorCode.INVALID_REQUEST, invalidUsageType.getErrorCode());
+
+        ApiException invalidStatus = assertThrows(
+                ApiException.class,
+                () -> service.findPage(null, null, null, "READY", null, null)
+        );
+        assertEquals(ErrorCode.INVALID_REQUEST, invalidStatus.getErrorCode());
+
+        ApiException invalidCursor = assertThrows(
+                ApiException.class,
+                () -> service.findPage(null, null, null, null, null, "abc")
+        );
+        assertEquals(ErrorCode.INVALID_REQUEST, invalidCursor.getErrorCode());
+    }
+
+    private QuizQuestion question(long questionId) {
+        QuizQuestion question = QuizQuestion.draft(
+                "deposit-q-001",
+                1,
+                QuizUsageType.SUB_CHAPTER,
+                2L,
+                101L,
+                1,
+                QuizQuestionType.SINGLE_CHOICE,
+                QuizDifficulty.EASY,
+                "질문",
+                null,
+                "[]",
+                "{\"key\":\"1\"}",
+                "해설",
+                QuizGenerationType.HUMAN,
+                null,
+                null,
+                900L,
+                LocalDateTime.of(2026, 8, 10, 6, 0)
+        );
+        question.setQuestionId(questionId);
+        return question;
+    }
+}


### PR DESCRIPTION
**작업명:** feat: 관리자 퀴즈 조회 API

## 작업 배경

관리자가 유형 별로 퀴즈를 조회하는 API를 구현한다.
GET `/admin/quiz-questions`

## 작업(구현) 내용 및 현황

`GET /api/admin/quiz-questions` 관리자 퀴즈 문항 검색 API를 추가했습니다.

**엔드포인트:** `GET /api/admin/quiz-questions`

**쿼리 파라미터**
- `usage_type` — 문항 사용처
- `main_chapter_id` — 대단원 필터
- `sub_chapter_id` — 소단원 필터
- `status` — `DRAFT`, `REVIEW`, `PUBLISHED`, `RETIRED`
- `question_key` — 논리 문항 키 (완전 일치)
- `cursor` — `question_id` 기준 커서

**응답**
- `items`: 문항 목록 (`question_id`, `question_key`, `version_no`, `usage_type`, `question_type`, `generation_type`, `prompt`, `status`)
- `next_cursor`: 다음 페이지 커서 (마지막 페이지면 `null`)

**페이지 크기:** 기본 20건 (한 건 더 조회해 다음 페이지 여부 판단)

## 추가/변경 파일

| 파일 | 역할 |
|------|------|
| `QuizQuestionQueryService` | 필터 파싱 + 커서 페이지네이션 |
| `QuizQuestionMapper.findPage` | 동적 WHERE + `ORDER BY question_id` |
| `AdminQuizQuestionController` | GET 핸들러 |
| `QuizQuestionListItemResponse`, `QuizQuestionPageResponse` | 응답 DTO |

관리자 권한은 기존 `/api/admin/**` 인터셉터가 처리합니다. 잘못된 `usage_type`, `status`, `cursor`는 `400 INVALID_REQUEST`로 반환합니다.

관련 테스트 3개(`Controller`, `Service`, `Mapper XML`)는 모두 통과했습니다.

## 관련 이슈

Closes #119 
