### PR TITLE
feat: AI 퀴즈 배치 수신 내부 API 구현 #22

### DIFF
--- a/src/main/java/org/firstfolio/exception/ErrorCode.java
+++ b/src/main/java/org/firstfolio/exception/ErrorCode.java
@@ -106,6 +106,10 @@ public enum ErrorCode {
     EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "이벤트를 찾을 수 없습니다."),
     EVENT_NOT_RETRYABLE(HttpStatus.CONFLICT, "재처리할 수 없는 상태입니다."),
 
+    // AI 퀴즈 배치 (docs/api/quiz-question-batch-api.md)
+    INVALID_BATCH_REQUEST(HttpStatus.BAD_REQUEST, "최상위 요청 구조, UUID 형식 또는 중복 item_id가 올바르지 않습니다."),
+    BATCH_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "items는 최대 100건까지 허용합니다."),
+
     // 공통 - API_DOCS에 개별 정의가 없는 경우의 기본 코드
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "요청 형식이 올바르지 않습니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 HTTP 메서드입니다."),

--- a/src/main/java/org/firstfolio/quiz/integration/ai/controller/QuizGenerationTargetController.java
+++ b/src/main/java/org/firstfolio/quiz/integration/ai/controller/QuizGenerationTargetController.java
@@ -1,0 +1,44 @@
+package org.firstfolio.quiz.integration.ai.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.firstfolio.common.response.ApiResponse;
+import org.firstfolio.quiz.integration.ai.dto.response.QuizGenerationTargetResponse;
+import org.firstfolio.quiz.integration.ai.service.QuizGenerationTargetQueryService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 내부 호출 검증은 {@code ServletConfig}의 경로 인터셉터가 담당한다
+ * ({@code /api/internal/**} → {@code X-Internal-Token}). 컨트롤러마다 반복하지 않는다.
+ */
+@RestController
+@RequestMapping("/api/internal/quiz-generation-targets")
+@Tag(name = "AI 퀴즈 생성 대상", description = "AI 서버가 퀴즈 생성 전 조회하는 서비스 대상 대·소단원 API")
+public class QuizGenerationTargetController {
+
+    private final QuizGenerationTargetQueryService queryService;
+
+    public QuizGenerationTargetController(QuizGenerationTargetQueryService queryService) {
+        this.queryService = queryService;
+    }
+
+    @GetMapping
+    @Operation(
+            summary = "퀴즈 생성 대상 조회",
+            description = "현재 서비스 대상으로 활성화된 전체 대단원과 각 대단원의 활성 소단원을 반환합니다. "
+                    + "AI 서버는 이 응답의 단원 이름으로 생성 주제를 정하고, 단원 ID를 생성한 퀴즈에 직접 연결합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200", description = "생성 대상 조회 성공"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "403", description = "INTERNAL_CALL_REQUIRED - 내부 호출 토큰이 없거나 올바르지 않음"
+                    )
+            }
+    )
+    public ApiResponse<QuizGenerationTargetResponse> getTargets() {
+        return ApiResponse.of(queryService.findTargets());
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/integration/ai/controller/QuizQuestionBatchController.java
+++ b/src/main/java/org/firstfolio/quiz/integration/ai/controller/QuizQuestionBatchController.java
@@ -1,0 +1,49 @@
+package org.firstfolio.quiz.integration.ai.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.firstfolio.common.response.ApiResponse;
+import org.firstfolio.quiz.integration.ai.dto.request.QuizQuestionBatchRequest;
+import org.firstfolio.quiz.integration.ai.dto.response.QuizQuestionBatchResponse;
+import org.firstfolio.quiz.integration.ai.service.QuizQuestionBatchService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 내부 호출 검증은 {@code ServletConfig}의 경로 인터셉터가 담당한다
+ * ({@code /api/internal/**} → {@code X-Internal-Token}). 컨트롤러마다 반복하지 않는다.
+ */
+@RestController
+@RequestMapping("/api/internal/quiz-questions/batches")
+@Tag(name = "AI 퀴즈 배치", description = "AI 서버가 생성한 퀴즈를 문제 풀에 저장하는 내부 API")
+public class QuizQuestionBatchController {
+
+    private final QuizQuestionBatchService batchService;
+
+    public QuizQuestionBatchController(QuizQuestionBatchService batchService) {
+        this.batchService = batchService;
+    }
+
+    @PostMapping
+    @Operation(
+            summary = "퀴즈 배치 저장",
+            description = "AI가 생성하고 자동 검증까지 통과한 퀴즈를 최대 100건 배치로 받아 REVIEW 상태로 저장합니다. "
+                    + "항목별 검증 실패는 REJECTED로 응답하며 다른 정상 항목 저장을 막지 않습니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200", description = "전체 성공, 부분 성공 또는 유효한 요청의 전체 항목 거절"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "400", description = "INVALID_BATCH_REQUEST/BATCH_SIZE_EXCEEDED - 최상위 요청 오류"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "403", description = "INTERNAL_CALL_REQUIRED - 내부 호출 토큰이 없거나 올바르지 않음"
+                    )
+            }
+    )
+    public ApiResponse<QuizQuestionBatchResponse> receive(@RequestBody QuizQuestionBatchRequest request) {
+        return ApiResponse.of(batchService.process(request));
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/integration/ai/dto/request/QuizCorrectAnswerRequest.java
+++ b/src/main/java/org/firstfolio/quiz/integration/ai/dto/request/QuizCorrectAnswerRequest.java
@@ -1,0 +1,6 @@
+package org.firstfolio.quiz.integration.ai.dto.request;
+
+public record QuizCorrectAnswerRequest(
+        String key
+) {
+}

--- a/src/main/java/org/firstfolio/quiz/integration/ai/dto/request/QuizOptionRequest.java
+++ b/src/main/java/org/firstfolio/quiz/integration/ai/dto/request/QuizOptionRequest.java
@@ -1,0 +1,8 @@
+package org.firstfolio.quiz.integration.ai.dto.request;
+
+public record QuizOptionRequest(
+        String key,
+        String label,
+        String description
+) {
+}

--- a/src/main/java/org/firstfolio/quiz/integration/ai/dto/request/QuizQuestionBatchItemRequest.java
+++ b/src/main/java/org/firstfolio/quiz/integration/ai/dto/request/QuizQuestionBatchItemRequest.java
@@ -1,0 +1,7 @@
+package org.firstfolio.quiz.integration.ai.dto.request;
+
+public record QuizQuestionBatchItemRequest(
+        String itemId,
+        QuizQuestionRequest quiz
+) {
+}

--- a/src/main/java/org/firstfolio/quiz/integration/ai/dto/request/QuizQuestionBatchRequest.java
+++ b/src/main/java/org/firstfolio/quiz/integration/ai/dto/request/QuizQuestionBatchRequest.java
@@ -1,0 +1,9 @@
+package org.firstfolio.quiz.integration.ai.dto.request;
+
+import java.util.List;
+
+public record QuizQuestionBatchRequest(
+        String batchId,
+        List<QuizQuestionBatchItemRequest> items
+) {
+}

--- a/src/main/java/org/firstfolio/quiz/integration/ai/dto/request/QuizQuestionRequest.java
+++ b/src/main/java/org/firstfolio/quiz/integration/ai/dto/request/QuizQuestionRequest.java
@@ -1,0 +1,22 @@
+package org.firstfolio.quiz.integration.ai.dto.request;
+
+import org.firstfolio.quiz.domain.QuizDifficulty;
+import org.firstfolio.quiz.domain.QuizQuestionType;
+import org.firstfolio.quiz.domain.QuizUsageType;
+
+import java.util.List;
+
+public record QuizQuestionRequest(
+        QuizUsageType usageType,
+        Long mainChapterId,
+        Long subChapterId,
+        QuizQuestionType questionType,
+        QuizDifficulty difficulty,
+        String prompt,
+        QuizScenarioRequest scenarioJson,
+        List<QuizOptionRequest> optionsJson,
+        QuizCorrectAnswerRequest correctAnswerJson,
+        String explanation,
+        Object sourceRefsJson
+) {
+}

--- a/src/main/java/org/firstfolio/quiz/integration/ai/dto/request/QuizScenarioRequest.java
+++ b/src/main/java/org/firstfolio/quiz/integration/ai/dto/request/QuizScenarioRequest.java
@@ -1,0 +1,35 @@
+package org.firstfolio.quiz.integration.ai.dto.request;
+
+import java.util.List;
+
+public record QuizScenarioRequest(
+        String title,
+        String narrative,
+        Persona persona,
+        Requirements requirements,
+        Market market,
+        List<String> constraints,
+        String paperTitle
+) {
+
+    public record Persona(
+            String name,
+            String age,
+            String job
+    ) {
+    }
+
+    public record Requirements(
+            String assets,
+            String risk,
+            String goal
+    ) {
+    }
+
+    public record Market(
+            String title,
+            String referenceAt,
+            List<String> bullets
+    ) {
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/integration/ai/dto/response/QuizGenerationTargetResponse.java
+++ b/src/main/java/org/firstfolio/quiz/integration/ai/dto/response/QuizGenerationTargetResponse.java
@@ -1,0 +1,31 @@
+package org.firstfolio.quiz.integration.ai.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.firstfolio.curriculum.domain.ChapterType;
+
+import java.util.List;
+
+@Schema(description = "AI 퀴즈 생성 대상 대단원·소단원 목록")
+public record QuizGenerationTargetResponse(
+        @Schema(description = "서비스 대상 대단원 목록")
+        List<MainChapterTarget> mainChapters
+) {
+
+    @Schema(description = "AI 퀴즈 생성 대상 대단원")
+    public record MainChapterTarget(
+            @Schema(description = "대단원 ID", example = "2") long mainChapterId,
+            @Schema(description = "대단원 이름. AI 생성 주제로 사용", example = "예·적금") String title,
+            @Schema(description = "대단원 유형", example = "ASSET") ChapterType chapterType,
+            @Schema(description = "해당 대단원의 서비스 대상 소단원 목록")
+            List<SubChapterTarget> subChapters
+    ) {
+    }
+
+    @Schema(description = "AI 퀴즈 생성 대상 소단원")
+    public record SubChapterTarget(
+            @Schema(description = "소단원 ID", example = "17") long subChapterId,
+            @Schema(description = "소단원이 속한 대단원 ID", example = "2") long mainChapterId,
+            @Schema(description = "소단원 이름. AI 생성 주제로 사용", example = "예금과 적금의 차이") String title
+    ) {
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/integration/ai/dto/response/QuizQuestionBatchItemResponse.java
+++ b/src/main/java/org/firstfolio/quiz/integration/ai/dto/response/QuizQuestionBatchItemResponse.java
@@ -1,0 +1,28 @@
+package org.firstfolio.quiz.integration.ai.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.firstfolio.quiz.domain.QuizQuestionStatus;
+import org.firstfolio.quiz.integration.ai.service.QuizItemErrorCode;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record QuizQuestionBatchItemResponse(
+        String itemId,
+        String result,
+        Long questionId,
+        QuizQuestionStatus status,
+        QuizItemErrorCode errorCode,
+        String errorMessage
+) {
+
+    public static QuizQuestionBatchItemResponse accepted(
+            String itemId, long questionId, QuizQuestionStatus status
+    ) {
+        return new QuizQuestionBatchItemResponse(itemId, "ACCEPTED", questionId, status, null, null);
+    }
+
+    public static QuizQuestionBatchItemResponse rejected(
+            String itemId, QuizItemErrorCode errorCode, String errorMessage
+    ) {
+        return new QuizQuestionBatchItemResponse(itemId, "REJECTED", null, null, errorCode, errorMessage);
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/integration/ai/dto/response/QuizQuestionBatchResponse.java
+++ b/src/main/java/org/firstfolio/quiz/integration/ai/dto/response/QuizQuestionBatchResponse.java
@@ -1,0 +1,26 @@
+package org.firstfolio.quiz.integration.ai.dto.response;
+
+import java.util.List;
+
+public record QuizQuestionBatchResponse(
+        String batchId,
+        int total,
+        int accepted,
+        int rejected,
+        List<QuizQuestionBatchItemResponse> items
+) {
+
+    public static QuizQuestionBatchResponse of(String batchId, List<QuizQuestionBatchItemResponse> items) {
+        int acceptedCount = (int) items.stream()
+                .filter(item -> "ACCEPTED".equals(item.result()))
+                .count();
+
+        return new QuizQuestionBatchResponse(
+                batchId,
+                items.size(),
+                acceptedCount,
+                items.size() - acceptedCount,
+                items
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/integration/ai/service/QuizChapterScopeValidator.java
+++ b/src/main/java/org/firstfolio/quiz/integration/ai/service/QuizChapterScopeValidator.java
@@ -1,0 +1,70 @@
+package org.firstfolio.quiz.integration.ai.service;
+
+import org.firstfolio.curriculum.domain.MainChapter;
+import org.firstfolio.curriculum.domain.SubChapter;
+import org.firstfolio.curriculum.mapper.MainChapterMapper;
+import org.firstfolio.curriculum.mapper.SubChapterMapper;
+import org.firstfolio.quiz.integration.ai.dto.request.QuizQuestionRequest;
+import org.springframework.stereotype.Component;
+
+/**
+ * {@link QuizQuestionPayloadValidator}가 먼저 통과해서 main_chapter_id가 null이 아니고,
+ * sub_chapter_id 유무가 usage_type과 이미 맞는 상태라고 전제하고 호출한다.
+ */
+@Component
+public class QuizChapterScopeValidator {
+
+    private final MainChapterMapper mainChapterMapper;
+    private final SubChapterMapper subChapterMapper;
+
+    public QuizChapterScopeValidator(
+            MainChapterMapper mainChapterMapper,
+            SubChapterMapper subChapterMapper
+    ) {
+        this.mainChapterMapper = mainChapterMapper;
+        this.subChapterMapper = subChapterMapper;
+    }
+
+    public QuizItemValidationResult validate(QuizQuestionRequest quiz) {
+        MainChapter mainChapter = mainChapterMapper.findById(quiz.mainChapterId());
+        if (mainChapter == null) {
+            return QuizItemValidationResult.invalid(
+                    QuizItemErrorCode.CHAPTER_NOT_FOUND,
+                    "요청한 대단원을 찾을 수 없습니다: " + quiz.mainChapterId()
+            );
+        }
+        if (!mainChapter.isActive()) {
+            return QuizItemValidationResult.invalid(
+                    QuizItemErrorCode.CHAPTER_NOT_ACTIVE,
+                    "요청한 대단원이 현재 서비스 대상이 아닙니다: " + quiz.mainChapterId()
+            );
+        }
+
+        if (quiz.subChapterId() == null) {
+            return QuizItemValidationResult.valid();
+        }
+
+        SubChapter subChapter = subChapterMapper.findById(quiz.subChapterId());
+        if (subChapter == null) {
+            return QuizItemValidationResult.invalid(
+                    QuizItemErrorCode.CHAPTER_NOT_FOUND,
+                    "요청한 소단원을 찾을 수 없습니다: " + quiz.subChapterId()
+            );
+        }
+        if (!subChapter.isActive()) {
+            return QuizItemValidationResult.invalid(
+                    QuizItemErrorCode.CHAPTER_NOT_ACTIVE,
+                    "요청한 소단원이 현재 서비스 대상이 아닙니다: " + quiz.subChapterId()
+            );
+        }
+        if (subChapter.getMainChapterId() != quiz.mainChapterId()) {
+            return QuizItemValidationResult.invalid(
+                    QuizItemErrorCode.INVALID_CHAPTER_SCOPE,
+                    "소단원이 요청한 대단원에 속하지 않습니다: sub_chapter_id="
+                            + quiz.subChapterId() + ", main_chapter_id=" + quiz.mainChapterId()
+            );
+        }
+
+        return QuizItemValidationResult.valid();
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/integration/ai/service/QuizGenerationTargetQueryService.java
+++ b/src/main/java/org/firstfolio/quiz/integration/ai/service/QuizGenerationTargetQueryService.java
@@ -1,0 +1,60 @@
+package org.firstfolio.quiz.integration.ai.service;
+
+import org.firstfolio.curriculum.domain.MainChapter;
+import org.firstfolio.curriculum.domain.SubChapter;
+import org.firstfolio.curriculum.mapper.MainChapterMapper;
+import org.firstfolio.curriculum.mapper.SubChapterMapper;
+import org.firstfolio.quiz.integration.ai.dto.response.QuizGenerationTargetResponse;
+import org.firstfolio.quiz.integration.ai.dto.response.QuizGenerationTargetResponse.MainChapterTarget;
+import org.firstfolio.quiz.integration.ai.dto.response.QuizGenerationTargetResponse.SubChapterTarget;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class QuizGenerationTargetQueryService {
+
+    private final MainChapterMapper mainChapterMapper;
+    private final SubChapterMapper subChapterMapper;
+
+    public QuizGenerationTargetQueryService(
+            MainChapterMapper mainChapterMapper,
+            SubChapterMapper subChapterMapper
+    ) {
+        this.mainChapterMapper = mainChapterMapper;
+        this.subChapterMapper = subChapterMapper;
+    }
+
+    public QuizGenerationTargetResponse findTargets() {
+        List<MainChapterTarget> mainChapterTargets = mainChapterMapper.findAll(null, true)
+                .stream()
+                .map(this::toMainChapterTarget)
+                .toList();
+
+        return new QuizGenerationTargetResponse(mainChapterTargets);
+    }
+
+    private MainChapterTarget toMainChapterTarget(MainChapter mainChapter) {
+        List<SubChapterTarget> subChapterTargets = subChapterMapper
+                .findAllByMainChapterId(mainChapter.getMainChapterId())
+                .stream()
+                .filter(SubChapter::isActive)
+                .map(this::toSubChapterTarget)
+                .toList();
+
+        return new MainChapterTarget(
+                mainChapter.getMainChapterId(),
+                mainChapter.getTitle(),
+                mainChapter.getChapterType(),
+                subChapterTargets
+        );
+    }
+
+    private SubChapterTarget toSubChapterTarget(SubChapter subChapter) {
+        return new SubChapterTarget(
+                subChapter.getSubChapterId(),
+                subChapter.getMainChapterId(),
+                subChapter.getTitle()
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/integration/ai/service/QuizItemErrorCode.java
+++ b/src/main/java/org/firstfolio/quiz/integration/ai/service/QuizItemErrorCode.java
@@ -1,0 +1,14 @@
+package org.firstfolio.quiz.integration.ai.service;
+
+public enum QuizItemErrorCode {
+    INVALID_QUIZ_PAYLOAD,
+    INVALID_USAGE_TYPE,
+    INVALID_QUESTION_TYPE,
+    INVALID_DIFFICULTY,
+    INVALID_CHAPTER_SCOPE,
+    CHAPTER_NOT_FOUND,
+    CHAPTER_NOT_ACTIVE,
+    INVALID_OPTIONS,
+    INVALID_CORRECT_ANSWER,
+    INVALID_SCENARIO
+}

--- a/src/main/java/org/firstfolio/quiz/integration/ai/service/QuizItemValidationResult.java
+++ b/src/main/java/org/firstfolio/quiz/integration/ai/service/QuizItemValidationResult.java
@@ -1,0 +1,19 @@
+package org.firstfolio.quiz.integration.ai.service;
+
+public record QuizItemValidationResult(
+        QuizItemErrorCode errorCode,
+        String errorMessage
+) {
+
+    public static QuizItemValidationResult valid() {
+        return new QuizItemValidationResult(null, null);
+    }
+
+    public static QuizItemValidationResult invalid(QuizItemErrorCode errorCode, String errorMessage) {
+        return new QuizItemValidationResult(errorCode, errorMessage);
+    }
+
+    public boolean isValid() {
+        return errorCode == null;
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/integration/ai/service/QuizQuestionBatchService.java
+++ b/src/main/java/org/firstfolio/quiz/integration/ai/service/QuizQuestionBatchService.java
@@ -1,0 +1,76 @@
+package org.firstfolio.quiz.integration.ai.service;
+
+import org.firstfolio.quiz.domain.QuizQuestion;
+import org.firstfolio.quiz.integration.ai.dto.request.QuizQuestionBatchItemRequest;
+import org.firstfolio.quiz.integration.ai.dto.request.QuizQuestionBatchRequest;
+import org.firstfolio.quiz.integration.ai.dto.request.QuizQuestionRequest;
+import org.firstfolio.quiz.integration.ai.dto.response.QuizQuestionBatchItemResponse;
+import org.firstfolio.quiz.integration.ai.dto.response.QuizQuestionBatchResponse;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class QuizQuestionBatchService {
+
+    private final QuizQuestionBatchStructureValidator structureValidator;
+    private final QuizQuestionPayloadValidator payloadValidator;
+    private final QuizChapterScopeValidator chapterScopeValidator;
+    private final QuizQuestionBatchWriter writer;
+
+    public QuizQuestionBatchService(
+            QuizQuestionBatchStructureValidator structureValidator,
+            QuizQuestionPayloadValidator payloadValidator,
+            QuizChapterScopeValidator chapterScopeValidator,
+            QuizQuestionBatchWriter writer
+    ) {
+        this.structureValidator = structureValidator;
+        this.payloadValidator = payloadValidator;
+        this.chapterScopeValidator = chapterScopeValidator;
+        this.writer = writer;
+    }
+
+    public QuizQuestionBatchResponse process(QuizQuestionBatchRequest request) {
+        structureValidator.validate(request);
+
+        List<QuizQuestionBatchItemRequest> items = request.items();
+        QuizQuestionBatchItemResponse[] results = new QuizQuestionBatchItemResponse[items.size()];
+
+        List<Integer> pendingIndexes = new ArrayList<>();
+        List<QuizQuestionRequest> pendingQuizzes = new ArrayList<>();
+
+        for (int i = 0; i < items.size(); i++) {
+            QuizQuestionBatchItemRequest item = items.get(i);
+            QuizItemValidationResult validation = validateItem(item.quiz());
+            if (validation.isValid()) {
+                pendingIndexes.add(i);
+                pendingQuizzes.add(item.quiz());
+            } else {
+                results[i] = QuizQuestionBatchItemResponse.rejected(
+                        item.itemId(), validation.errorCode(), validation.errorMessage()
+                );
+            }
+        }
+
+        List<QuizQuestion> saved = writer.saveAll(pendingQuizzes);
+        for (int i = 0; i < pendingIndexes.size(); i++) {
+            int originalIndex = pendingIndexes.get(i);
+            String itemId = items.get(originalIndex).itemId();
+            QuizQuestion question = saved.get(i);
+            results[originalIndex] = QuizQuestionBatchItemResponse.accepted(
+                    itemId, question.getQuestionId(), question.getStatus()
+            );
+        }
+
+        return QuizQuestionBatchResponse.of(request.batchId(), List.of(results));
+    }
+
+    private QuizItemValidationResult validateItem(QuizQuestionRequest quiz) {
+        QuizItemValidationResult payloadResult = payloadValidator.validate(quiz);
+        if (!payloadResult.isValid()) {
+            return payloadResult;
+        }
+        return chapterScopeValidator.validate(quiz);
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/integration/ai/service/QuizQuestionBatchStructureValidator.java
+++ b/src/main/java/org/firstfolio/quiz/integration/ai/service/QuizQuestionBatchStructureValidator.java
@@ -1,0 +1,61 @@
+package org.firstfolio.quiz.integration.ai.service;
+
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.quiz.integration.ai.dto.request.QuizQuestionBatchItemRequest;
+import org.firstfolio.quiz.integration.ai.dto.request.QuizQuestionBatchRequest;
+import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+@Component
+public class QuizQuestionBatchStructureValidator {
+
+    private static final int MAX_ITEMS = 100;
+
+    public void validate(QuizQuestionBatchRequest request) {
+        if (request == null) {
+            throw new ApiException(ErrorCode.INVALID_BATCH_REQUEST, "요청 본문이 비어 있습니다.");
+        }
+        requireUuid(request.batchId(), "batch_id");
+
+        List<QuizQuestionBatchItemRequest> items = request.items();
+        if (items == null || items.isEmpty()) {
+            throw new ApiException(ErrorCode.INVALID_BATCH_REQUEST, "items는 1건 이상이어야 합니다.");
+        }
+        if (items.size() > MAX_ITEMS) {
+            throw new ApiException(ErrorCode.BATCH_SIZE_EXCEEDED);
+        }
+
+        Set<String> itemIds = new HashSet<>();
+        for (QuizQuestionBatchItemRequest item : items) {
+            if (item == null) {
+                throw new ApiException(ErrorCode.INVALID_BATCH_REQUEST, "items 항목이 비어 있습니다.");
+            }
+            requireUuid(item.itemId(), "item_id");
+            if (!itemIds.add(item.itemId())) {
+                throw new ApiException(
+                        ErrorCode.INVALID_BATCH_REQUEST,
+                        "item_id는 한 요청 내에서 중복될 수 없습니다: " + item.itemId()
+                );
+            }
+        }
+    }
+
+    private void requireUuid(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new ApiException(ErrorCode.INVALID_BATCH_REQUEST, fieldName + "는 필수입니다.");
+        }
+        try {
+            UUID.fromString(value);
+        } catch (IllegalArgumentException exception) {
+            throw new ApiException(
+                    ErrorCode.INVALID_BATCH_REQUEST,
+                    fieldName + "는 UUID 형식이어야 합니다: " + value
+            );
+        }
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/integration/ai/service/QuizQuestionBatchWriter.java
+++ b/src/main/java/org/firstfolio/quiz/integration/ai/service/QuizQuestionBatchWriter.java
@@ -47,6 +47,10 @@ public class QuizQuestionBatchWriter {
 
     @Transactional
     public List<QuizQuestion> saveAll(List<QuizQuestionRequest> validQuizzes) {
+        if (validQuizzes.isEmpty()) {
+            return List.of();
+        }
+
         long aiCreatedBy = resolveAiCreatedBy();
         LocalDateTime now = LocalDateTime.now(clock);
 

--- a/src/main/java/org/firstfolio/quiz/integration/ai/service/QuizQuestionBatchWriter.java
+++ b/src/main/java/org/firstfolio/quiz/integration/ai/service/QuizQuestionBatchWriter.java
@@ -1,0 +1,116 @@
+package org.firstfolio.quiz.integration.ai.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.firstfolio.common.json.ApiObjectMapperFactory;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.quiz.domain.QuizGenerationType;
+import org.firstfolio.quiz.domain.QuizQuestion;
+import org.firstfolio.quiz.domain.QuizQuestionStatus;
+import org.firstfolio.quiz.integration.ai.dto.request.QuizQuestionRequest;
+import org.firstfolio.quiz.mapper.QuizQuestionMapper;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * AI 배치 전용 시스템 사용자 ID({@code quiz.batch.ai-created-by})는 관리자 계정이 정해지기 전까지
+ * 비어 있을 수 있다. 생성자 주입 대신 호출 시점에 읽어서, 값이 없어도 서버 기동 자체는 막지 않는다.
+ */
+@Component
+public class QuizQuestionBatchWriter {
+
+    private static final String AI_CREATED_BY_PROPERTY = "quiz.batch.ai-created-by";
+
+    private final QuizQuestionMapper questionMapper;
+    private final Environment environment;
+    private final Clock clock;
+    private final ObjectMapper objectMapper;
+
+    public QuizQuestionBatchWriter(
+            QuizQuestionMapper questionMapper,
+            Environment environment,
+            Clock clock
+    ) {
+        this.questionMapper = questionMapper;
+        this.environment = environment;
+        this.clock = clock;
+        this.objectMapper = ApiObjectMapperFactory.create();
+    }
+
+    @Transactional
+    public List<QuizQuestion> saveAll(List<QuizQuestionRequest> validQuizzes) {
+        long aiCreatedBy = resolveAiCreatedBy();
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        List<QuizQuestion> saved = new ArrayList<>();
+        for (QuizQuestionRequest quiz : validQuizzes) {
+            QuizQuestion question = toQuestion(quiz, aiCreatedBy, now);
+            questionMapper.insert(question);
+            saved.add(question);
+        }
+        return saved;
+    }
+
+    private long resolveAiCreatedBy() {
+        String value = environment.getProperty(AI_CREATED_BY_PROPERTY);
+        if (value == null || value.isBlank()) {
+            throw new ApiException(
+                    ErrorCode.INTERNAL_ERROR,
+                    AI_CREATED_BY_PROPERTY + " 설정이 없어 AI 배치 문항을 저장할 수 없습니다."
+            );
+        }
+        try {
+            return Long.parseLong(value.trim());
+        } catch (NumberFormatException exception) {
+            throw new ApiException(
+                    ErrorCode.INTERNAL_ERROR,
+                    AI_CREATED_BY_PROPERTY + " 값이 올바른 사용자 ID가 아닙니다: " + value
+            );
+        }
+    }
+
+    private QuizQuestion toQuestion(QuizQuestionRequest quiz, long aiCreatedBy, LocalDateTime now) {
+        QuizQuestion question = QuizQuestion.draft(
+                UUID.randomUUID().toString(),
+                1,
+                quiz.usageType(),
+                quiz.mainChapterId(),
+                quiz.subChapterId(),
+                null,
+                quiz.questionType(),
+                quiz.difficulty(),
+                quiz.prompt(),
+                toJsonOrNull(quiz.scenarioJson()),
+                toJson(quiz.optionsJson()),
+                toJson(quiz.correctAnswerJson()),
+                quiz.explanation(),
+                QuizGenerationType.AI,
+                null,
+                null,
+                aiCreatedBy,
+                now
+        );
+        question.setStatus(QuizQuestionStatus.REVIEW);
+        return question;
+    }
+
+    private String toJsonOrNull(Object value) {
+        return value == null ? null : toJson(value);
+    }
+
+    private String toJson(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("퀴즈 문항 JSON을 직렬화할 수 없습니다.", exception);
+        }
+    }
+}

--- a/src/main/java/org/firstfolio/quiz/integration/ai/service/QuizQuestionPayloadValidator.java
+++ b/src/main/java/org/firstfolio/quiz/integration/ai/service/QuizQuestionPayloadValidator.java
@@ -1,0 +1,172 @@
+package org.firstfolio.quiz.integration.ai.service;
+
+import org.firstfolio.quiz.domain.QuizQuestionType;
+import org.firstfolio.quiz.domain.QuizUsageType;
+import org.firstfolio.quiz.integration.ai.dto.request.QuizOptionRequest;
+import org.firstfolio.quiz.integration.ai.dto.request.QuizQuestionRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+public class QuizQuestionPayloadValidator {
+
+    private static final Set<String> TRUE_FALSE_KEYS = Set.of("O", "X");
+    private static final Set<String> FOUR_CHOICE_KEYS = Set.of("1", "2", "3", "4");
+
+    public QuizItemValidationResult validate(QuizQuestionRequest quiz) {
+        if (quiz == null) {
+            return QuizItemValidationResult.invalid(
+                    QuizItemErrorCode.INVALID_QUIZ_PAYLOAD, "quiz는 필수입니다."
+            );
+        }
+
+        QuizItemValidationResult typeResult = validateUsageAndQuestionType(quiz);
+        if (!typeResult.isValid()) {
+            return typeResult;
+        }
+
+        if (quiz.difficulty() == null) {
+            return QuizItemValidationResult.invalid(
+                    QuizItemErrorCode.INVALID_DIFFICULTY, "difficulty는 필수입니다."
+            );
+        }
+        if (!StringUtils.hasText(quiz.prompt()) || !StringUtils.hasText(quiz.explanation())) {
+            return QuizItemValidationResult.invalid(
+                    QuizItemErrorCode.INVALID_QUIZ_PAYLOAD, "prompt와 explanation은 비어 있을 수 없습니다."
+            );
+        }
+
+        QuizItemValidationResult chapterScopeResult = validateChapterScope(quiz);
+        if (!chapterScopeResult.isValid()) {
+            return chapterScopeResult;
+        }
+
+        QuizItemValidationResult scenarioResult = validateScenarioPresence(quiz);
+        if (!scenarioResult.isValid()) {
+            return scenarioResult;
+        }
+
+        QuizItemValidationResult optionsResult = validateOptions(quiz);
+        if (!optionsResult.isValid()) {
+            return optionsResult;
+        }
+
+        return validateCorrectAnswer(quiz);
+    }
+
+    private QuizItemValidationResult validateUsageAndQuestionType(QuizQuestionRequest quiz) {
+        QuizQuestionType questionType = quiz.questionType();
+        if (questionType != QuizQuestionType.TRUE_FALSE
+                && questionType != QuizQuestionType.SINGLE_CHOICE
+                && questionType != QuizQuestionType.SCENARIO) {
+            return QuizItemValidationResult.invalid(
+                    QuizItemErrorCode.INVALID_QUESTION_TYPE,
+                    "question_type은 TRUE_FALSE, SINGLE_CHOICE, SCENARIO만 허용합니다."
+            );
+        }
+
+        QuizUsageType expectedUsageType = questionType == QuizQuestionType.SCENARIO
+                ? QuizUsageType.MAIN_CHAPTER
+                : QuizUsageType.SUB_CHAPTER;
+
+        if (quiz.usageType() != expectedUsageType) {
+            return QuizItemValidationResult.invalid(
+                    QuizItemErrorCode.INVALID_USAGE_TYPE,
+                    "usage_type(" + quiz.usageType() + ")이 question_type(" + questionType + ")과 맞지 않습니다."
+            );
+        }
+
+        return QuizItemValidationResult.valid();
+    }
+
+    private QuizItemValidationResult validateChapterScope(QuizQuestionRequest quiz) {
+        if (quiz.mainChapterId() == null) {
+            return QuizItemValidationResult.invalid(
+                    QuizItemErrorCode.INVALID_CHAPTER_SCOPE, "main_chapter_id는 필수입니다."
+            );
+        }
+
+        boolean subChapterRequired = quiz.usageType() == QuizUsageType.SUB_CHAPTER;
+        boolean subChapterPresent = quiz.subChapterId() != null;
+
+        if (subChapterRequired != subChapterPresent) {
+            return QuizItemValidationResult.invalid(
+                    QuizItemErrorCode.INVALID_CHAPTER_SCOPE,
+                    "sub_chapter_id는 SUB_CHAPTER 문제만 필수이고 MAIN_CHAPTER 문제는 null이어야 합니다."
+            );
+        }
+
+        return QuizItemValidationResult.valid();
+    }
+
+    private QuizItemValidationResult validateScenarioPresence(QuizQuestionRequest quiz) {
+        boolean scenarioRequired = quiz.questionType() == QuizQuestionType.SCENARIO;
+        boolean scenarioPresent = quiz.scenarioJson() != null;
+
+        if (scenarioRequired != scenarioPresent) {
+            return QuizItemValidationResult.invalid(
+                    QuizItemErrorCode.INVALID_SCENARIO,
+                    "scenario_json은 SCENARIO 문제만 필수이고 나머지 유형은 null이어야 합니다."
+            );
+        }
+
+        return QuizItemValidationResult.valid();
+    }
+
+    private QuizItemValidationResult validateOptions(QuizQuestionRequest quiz) {
+        List<QuizOptionRequest> options = quiz.optionsJson();
+        if (options == null || options.isEmpty()) {
+            return QuizItemValidationResult.invalid(
+                    QuizItemErrorCode.INVALID_OPTIONS, "options_json은 비어 있을 수 없습니다."
+            );
+        }
+
+        Set<String> expectedKeys = quiz.questionType() == QuizQuestionType.TRUE_FALSE
+                ? TRUE_FALSE_KEYS
+                : FOUR_CHOICE_KEYS;
+
+        if (options.size() != expectedKeys.size()) {
+            return QuizItemValidationResult.invalid(
+                    QuizItemErrorCode.INVALID_OPTIONS,
+                    "선택지 개수가 올바르지 않습니다. 기대값: " + expectedKeys.size()
+            );
+        }
+
+        Set<String> actualKeys = options.stream()
+                .map(QuizOptionRequest::key)
+                .collect(Collectors.toSet());
+
+        if (actualKeys.size() != options.size() || !actualKeys.equals(expectedKeys)) {
+            return QuizItemValidationResult.invalid(
+                    QuizItemErrorCode.INVALID_OPTIONS,
+                    "선택지 키가 중복되었거나 허용된 키 집합과 다릅니다: " + expectedKeys
+            );
+        }
+
+        return QuizItemValidationResult.valid();
+    }
+
+    private QuizItemValidationResult validateCorrectAnswer(QuizQuestionRequest quiz) {
+        String correctKey = quiz.correctAnswerJson() == null ? null : quiz.correctAnswerJson().key();
+        if (!StringUtils.hasText(correctKey)) {
+            return QuizItemValidationResult.invalid(
+                    QuizItemErrorCode.INVALID_CORRECT_ANSWER, "correct_answer_json.key는 필수입니다."
+            );
+        }
+
+        boolean existsInOptions = quiz.optionsJson().stream()
+                .anyMatch(option -> correctKey.equals(option.key()));
+
+        if (!existsInOptions) {
+            return QuizItemValidationResult.invalid(
+                    QuizItemErrorCode.INVALID_CORRECT_ANSWER, "정답 키가 선택지에 없습니다: " + correctKey
+            );
+        }
+
+        return QuizItemValidationResult.valid();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -48,4 +48,6 @@ trade.policy.interest-income-tax-rate=${TRADE_INTEREST_INCOME_TAX_RATE:0.154}
 
 internal.call-token=${INTERNAL_CALL_TOKEN:}
 
+quiz.batch.ai-created-by=${QUIZ_BATCH_AI_CREATED_BY:}
+
 cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://127.0.0.1:5173}

--- a/src/test/java/org/firstfolio/quiz/validation/QuizQuestionSchemaValidatorTest.java
+++ b/src/test/java/org/firstfolio/quiz/validation/QuizQuestionSchemaValidatorTest.java
@@ -44,6 +44,14 @@ class QuizQuestionSchemaValidatorTest {
     }
 
     @Test
+    void acceptsAiQuestionWithNullSourceRefs() throws IOException {
+        ObjectNode question = aiScenario();
+        question.putNull("source_refs_json");
+
+        assertTrue(validate(question).isValid());
+    }
+
+    @Test
     void acceptsDailyGeneralAndDatedDailyNewsQuestions() throws IOException {
         ObjectNode general = humanSingleChoice();
         general.put("usage_type", "DAILY_GENERAL");


### PR DESCRIPTION
## 작업 배경
AI 서버가 생성한 퀴즈를 BE로 전달받을 내부 API가 없어 AI→BE 배치 전송이 막혀 있음.
AI 레포에서 이미 병합된 배치 전송 클라이언트(#50)가 호출하는 두 엔드포인트를 구현.

## 작업(구현) 내용
- [x] GET /api/internal/quiz-generation-targets 구현 — 생성 대상 대/소단원 조회
- [x] POST /api/internal/quiz-questions/batches 구현 — 배치 최대 100건, REVIEW 상태로 저장
- [x] 배치 요청 구조 검증 (UUID, item_id 중복 등)
- [x] 문제 유형별 필드·선택지·정답 검증
- [x] 단원 존재·활성·부모관계 검증
- [x] 저장 트랜잭션 처리
- [x] source_refs_json=null 유효 케이스 포함 단위/통합 테스트

## 확인 사항
- [x] dev 기준 conflict 없음 (겹치는 파일: ErrorCode.java, application.properties — 자동 병합 확인됨)
- [x] ./gradlew test 전체 통과
- [x] DB 마이그레이션 변경 없음

## 참고 사항
- AI 레포 문서: docs/api/quiz-question-batch-api.md
- 병합 후에도 REVIEW→PUBLISHED 승인 로직은 별도 이슈로 진행 필요 (미포함)