### PR TITLE
feat: AI 생성 퀴즈 REVIEW 상태 관리자 공개 허용 #143

### DIFF
--- a/src/main/java/org/firstfolio/quiz/controller/AdminQuizQuestionController.java
+++ b/src/main/java/org/firstfolio/quiz/controller/AdminQuizQuestionController.java
@@ -183,7 +183,7 @@ public class AdminQuizQuestionController {
     @PostMapping("/{questionId}/publish")
     @Operation(
             summary = "퀴즈 문항 버전 공개",
-            description = "최신 DRAFT 문항 버전을 PUBLISHED로 전환합니다. 같은 논리 키의 기존 공개 버전은 RETIRED로 보존하고 모든 상태 변경을 하나의 트랜잭션으로 처리합니다.",
+            description = "최신 DRAFT 또는 REVIEW 문항 버전을 PUBLISHED로 전환합니다. 같은 논리 키의 기존 공개 버전은 RETIRED로 보존하고 모든 상태 변경을 하나의 트랜잭션으로 처리합니다.",
             responses = {
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(
                             responseCode = "200", description = "퀴즈 문항 공개 성공",
@@ -198,7 +198,7 @@ public class AdminQuizQuestionController {
                             responseCode = "404", description = "QUESTION_NOT_FOUND - 문항을 찾을 수 없음"
                     ),
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "409", description = "QUESTION_NOT_PUBLISHABLE - 최신 DRAFT가 아니거나 공개할 수 없는 상태"
+                            responseCode = "409", description = "QUESTION_NOT_PUBLISHABLE - 최신 DRAFT/REVIEW가 아니거나 공개할 수 없는 상태"
                     ),
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(
                             responseCode = "422", description = "QUESTION_VALIDATION_FAILED - 문항 또는 단원 참조 재검증 실패"

--- a/src/main/java/org/firstfolio/quiz/service/QuizQuestionPublicationService.java
+++ b/src/main/java/org/firstfolio/quiz/service/QuizQuestionPublicationService.java
@@ -79,7 +79,8 @@ public class QuizQuestionPublicationService {
             throw new ApiException(ErrorCode.QUESTION_NOT_FOUND);
         }
         if (!Objects.equals(target.getQuestionId(), questionId)
-                || target.getStatus() != QuizQuestionStatus.DRAFT) {
+                || (target.getStatus() != QuizQuestionStatus.DRAFT
+                && target.getStatus() != QuizQuestionStatus.REVIEW)) {
             throw new ApiException(ErrorCode.QUESTION_NOT_PUBLISHABLE);
         }
 

--- a/src/main/resources/mappers/quiz/QuizQuestionMapper.xml
+++ b/src/main/resources/mappers/quiz/QuizQuestionMapper.xml
@@ -258,7 +258,7 @@
         SET status = 'PUBLISHED',
             published_at = #{publishedAt}
         WHERE question_id = #{questionId}
-          AND status = 'DRAFT'
+          AND status IN ('DRAFT', 'REVIEW')
     </update>
 
     <update id="retirePublished">

--- a/src/test/java/org/firstfolio/quiz/mapper/QuizQuestionMapperXmlTest.java
+++ b/src/test/java/org/firstfolio/quiz/mapper/QuizQuestionMapperXmlTest.java
@@ -136,7 +136,7 @@ class QuizQuestionMapperXmlTest {
                 "SET status = 'PUBLISHED', published_at = ?"
         ));
         assertTrue(normalize(publishSql.getSql()).endsWith(
-                "WHERE question_id = ? AND status = 'DRAFT'"
+                "WHERE question_id = ? AND status IN ('DRAFT', 'REVIEW')"
         ));
 
         BoundSql retireSql = configuration.getMappedStatement(

--- a/src/test/java/org/firstfolio/quiz/service/QuizQuestionPublicationServiceTest.java
+++ b/src/test/java/org/firstfolio/quiz/service/QuizQuestionPublicationServiceTest.java
@@ -113,6 +113,51 @@ class QuizQuestionPublicationServiceTest {
     }
 
     @Test
+    void publishesLatestReviewAndRetiresPreviouslyPublishedVersion() {
+        QuizQuestion previous = question(1201L, 1);
+        previous.publish(LocalDateTime.of(2026, 8, 10, 6, 0));
+        QuizQuestion target = question(1202L, 2);
+        target.setStatus(QuizQuestionStatus.REVIEW);
+        when(questionMapper.findById(1202L)).thenReturn(target);
+        when(questionMapper.findLatestByQuestionKeyForUpdate(
+                "deposit-basic-001"
+        )).thenReturn(target);
+        when(questionMapper.findPublishedByQuestionKeyForUpdate(
+                "deposit-basic-001"
+        )).thenReturn(List.of(previous));
+        when(questionMapper.retirePublished(1201L)).thenReturn(1);
+        when(questionMapper.publishDraft(1202L, NOW)).thenReturn(1);
+
+        QuizQuestion result = service.publish(1202L, ACTOR_ID, REQUEST_ID);
+
+        assertEquals(QuizQuestionStatus.RETIRED, previous.getStatus());
+        assertEquals(QuizQuestionStatus.PUBLISHED, result.getStatus());
+        assertEquals(NOW, result.getPublishedAt());
+        verify(auditLogMapper).insert(
+                eq(ACTOR_ID), eq("PUBLISH"), eq("QUIZ_QUESTION"), eq(1202L),
+                anyString(), anyString(), eq(REQUEST_ID), eq(NOW)
+        );
+    }
+
+    @Test
+    void rejectsPublishingAlreadyPublishedQuestion() {
+        QuizQuestion target = question(1201L, 1);
+        target.publish(LocalDateTime.of(2026, 8, 10, 6, 0));
+        when(questionMapper.findById(1201L)).thenReturn(target);
+        when(questionMapper.findLatestByQuestionKeyForUpdate(
+                "deposit-basic-001"
+        )).thenReturn(target);
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.publish(1201L, ACTOR_ID, REQUEST_ID)
+        );
+
+        assertEquals(ErrorCode.QUESTION_NOT_PUBLISHABLE, exception.getErrorCode());
+        verify(questionMapper, never()).publishDraft(anyLong(), any());
+    }
+
+    @Test
     void rejectsPublishingNonLatestDraft() {
         QuizQuestion requested = question(1201L, 1);
         QuizQuestion latest = question(1202L, 2);


### PR DESCRIPTION
## 작업 배경
AI 서버가 생성한 퀴즈 배치(#22, PR #141)는 REVIEW 상태로 저장되는데, 기존 공개(publish) API는 DRAFT만 처리해서 REVIEW 문항을 PUBLISHED로 전환할 방법이 없었음.

## 작업(구현) 내용 및 현황
- [x] QuizQuestionPublicationService.publish() — DRAFT/REVIEW 모두 공개 대상으로 허용
- [x] QuizQuestionMapper.xml publishDraft SQL — status IN ('DRAFT', 'REVIEW')로 변경
- [x] AdminQuizQuestionController Swagger 설명 갱신
- [x] QuizQuestionPublicationServiceTest — REVIEW 공개 성공/이미 PUBLISHED 재공개 차단 테스트 추가
- [x] QuizQuestionMapperXmlTest — SQL 문자열 검증 갱신

## 참고 사항
- ./gradlew test 전체 통과 확인