### PR TITLE
feat: 퀴즈 문항 DRAFT→REVIEW 수동 전환 API 구현 #145

### DIFF
--- a/src/main/java/org/firstfolio/exception/ErrorCode.java
+++ b/src/main/java/org/firstfolio/exception/ErrorCode.java
@@ -42,6 +42,7 @@ public enum ErrorCode {
     QUESTION_VERSION_CONFLICT(HttpStatus.CONFLICT, "퀴즈 문항 버전을 생성할 수 없습니다."),
     QUESTION_NOT_PUBLISHABLE(HttpStatus.CONFLICT, "공개할 수 없는 퀴즈 문항 버전입니다."),
     QUESTION_NOT_RETIRABLE(HttpStatus.CONFLICT, "폐기할 수 없는 퀴즈 문항 버전입니다."),
+    QUESTION_NOT_REVIEWABLE(HttpStatus.CONFLICT, "검수로 전환할 수 없는 퀴즈 문항 버전입니다."),
     QUESTION_VALIDATION_FAILED(HttpStatus.UNPROCESSABLE_ENTITY, "퀴즈 문항 검증에 실패했습니다."),
 
     // 퀴즈 응시

--- a/src/main/java/org/firstfolio/quiz/controller/AdminQuizQuestionController.java
+++ b/src/main/java/org/firstfolio/quiz/controller/AdminQuizQuestionController.java
@@ -9,6 +9,7 @@ import org.firstfolio.common.response.ApiResponse;
 import org.firstfolio.common.web.RequestIdFilter;
 import org.firstfolio.config.OpenApiResponseSchemas;
 import org.firstfolio.quiz.dto.request.QuizQuestionCreateRequest;
+import org.firstfolio.quiz.dto.request.QuizQuestionStatusUpdateRequest;
 import org.firstfolio.quiz.dto.request.QuizQuestionVersionCreateRequest;
 import org.firstfolio.quiz.dto.response.QuizQuestionCreateResponse;
 import org.firstfolio.quiz.dto.response.QuizQuestionPageResponse;
@@ -16,8 +17,11 @@ import org.firstfolio.quiz.dto.response.QuizQuestionStatusResponse;
 import org.firstfolio.quiz.service.QuizQuestionPublicationService;
 import org.firstfolio.quiz.service.QuizQuestionQueryService;
 import org.firstfolio.quiz.service.QuizQuestionRegistrationService;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -174,6 +178,58 @@ public class AdminQuizQuestionController {
                 registrationService.createVersion(
                         questionId,
                         request,
+                        currentUser.userId(),
+                        RequestIdFilter.currentRequestId(servletRequest)
+                )
+        ));
+    }
+
+    @PatchMapping("/{questionId}")
+    @Operation(
+            summary = "퀴즈 문항 상태 전환",
+            description = "현재는 DRAFT 문항을 REVIEW로 전환하는 요청만 지원합니다({\"status\": \"REVIEW\"}). "
+                    + "그 외 status 값은 400으로 거부합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200", description = "상태 전환 성공",
+                            content = @io.swagger.v3.oas.annotations.media.Content(
+                                    mediaType = "application/json",
+                                    schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                            implementation = OpenApiResponseSchemas.QuizQuestionStatus.class
+                                    )
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "400", description = "INVALID_REQUEST - 지원하지 않는 status 값"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "404", description = "QUESTION_NOT_FOUND - 문항을 찾을 수 없음"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "409", description = "QUESTION_NOT_REVIEWABLE - DRAFT 상태가 아니어서 전환 불가"
+                    )
+            }
+    )
+    public ApiResponse<QuizQuestionStatusResponse> updateQuestionStatus(
+            @Parameter(description = "상태를 전환할 문항 버전 ID", example = "1201", required = true)
+            @PathVariable long questionId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true, description = "전환할 상태 — 현재 REVIEW만 지원"
+            )
+            @RequestBody(required = false) QuizQuestionStatusUpdateRequest request,
+            @CurrentUser AuthenticatedUser currentUser,
+            HttpServletRequest servletRequest
+    ) {
+        if (request == null || !"REVIEW".equals(request.status())) {
+            throw new ApiException(
+                    ErrorCode.INVALID_REQUEST,
+                    ErrorCode.INVALID_REQUEST.getDefaultMessage()
+                            + " status는 \"REVIEW\"만 지원합니다."
+            );
+        }
+        return ApiResponse.of(QuizQuestionStatusResponse.from(
+                publicationService.submitForReview(
+                        questionId,
                         currentUser.userId(),
                         RequestIdFilter.currentRequestId(servletRequest)
                 )

--- a/src/main/java/org/firstfolio/quiz/dto/request/QuizQuestionStatusUpdateRequest.java
+++ b/src/main/java/org/firstfolio/quiz/dto/request/QuizQuestionStatusUpdateRequest.java
@@ -1,0 +1,9 @@
+package org.firstfolio.quiz.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "퀴즈 문항 상태 전환 요청 — 현재 DRAFT to REVIEW 전환만 지원")
+public record QuizQuestionStatusUpdateRequest(
+        @Schema(description = "전환할 상태", example = "REVIEW") String status
+) {
+}

--- a/src/main/java/org/firstfolio/quiz/mapper/QuizQuestionMapper.java
+++ b/src/main/java/org/firstfolio/quiz/mapper/QuizQuestionMapper.java
@@ -64,5 +64,7 @@ public interface QuizQuestionMapper {
 
     int retirePublished(@Param("questionId") long questionId);
 
+    int submitForReview(@Param("questionId") long questionId);
+
     int insert(QuizQuestion question);
 }

--- a/src/main/java/org/firstfolio/quiz/service/QuizQuestionPublicationService.java
+++ b/src/main/java/org/firstfolio/quiz/service/QuizQuestionPublicationService.java
@@ -111,6 +111,37 @@ public class QuizQuestionPublicationService {
     }
 
     @Transactional
+    public QuizQuestion submitForReview(
+            long questionId,
+            long actorUserId,
+            String requestId
+    ) {
+        QuizQuestion target = questionMapper.findByIdForUpdate(questionId);
+        if (target == null) {
+            throw new ApiException(ErrorCode.QUESTION_NOT_FOUND);
+        }
+        if (target.getStatus() != QuizQuestionStatus.DRAFT) {
+            throw new ApiException(ErrorCode.QUESTION_NOT_REVIEWABLE);
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        String before = snapshot(target);
+        if (questionMapper.submitForReview(questionId) != 1) {
+            throw new ApiException(ErrorCode.QUESTION_NOT_REVIEWABLE);
+        }
+        target.setStatus(QuizQuestionStatus.REVIEW);
+        insertAuditLog(
+                actorUserId,
+                "SUBMIT_REVIEW",
+                target,
+                before,
+                requestId,
+                now
+        );
+        return target;
+    }
+
+    @Transactional
     public QuizQuestion retire(
             long questionId,
             long actorUserId,

--- a/src/main/resources/mappers/quiz/QuizQuestionMapper.xml
+++ b/src/main/resources/mappers/quiz/QuizQuestionMapper.xml
@@ -268,6 +268,13 @@
           AND status = 'PUBLISHED'
     </update>
 
+    <update id="submitForReview">
+        UPDATE quiz_questions
+        SET status = 'REVIEW'
+        WHERE question_id = #{questionId}
+          AND status = 'DRAFT'
+    </update>
+
     <insert id="insert"
             parameterType="org.firstfolio.quiz.domain.QuizQuestion"
             useGeneratedKeys="true"

--- a/src/test/java/org/firstfolio/quiz/controller/AdminQuizQuestionControllerTest.java
+++ b/src/test/java/org/firstfolio/quiz/controller/AdminQuizQuestionControllerTest.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -225,6 +226,47 @@ class AdminQuizQuestionControllerTest {
                         .content(versionRequestBody()))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.error.code").value("QUESTION_NOT_FOUND"));
+    }
+
+    @Test
+    void submitsDraftQuestionForReview() throws Exception {
+        QuizQuestion reviewing = question(1201L, 1);
+        reviewing.setStatus(QuizQuestionStatus.REVIEW);
+        when(publicationService.submitForReview(eq(1201L), eq(900L), anyString()))
+                .thenReturn(reviewing);
+
+        mockMvc.perform(patch("/api/admin/quiz-questions/1201")
+                        .requestAttr(AuthenticationRequestAttributes.CURRENT_USER, ADMIN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"status\": \"REVIEW\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.question_id").value(1201))
+                .andExpect(jsonPath("$.data.status").value("REVIEW"));
+
+        verify(publicationService).submitForReview(eq(1201L), eq(900L), anyString());
+    }
+
+    @Test
+    void rejectsUnsupportedStatusTransitionValue() throws Exception {
+        mockMvc.perform(patch("/api/admin/quiz-questions/1201")
+                        .requestAttr(AuthenticationRequestAttributes.CURRENT_USER, ADMIN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"status\": \"PUBLISHED\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("INVALID_REQUEST"));
+    }
+
+    @Test
+    void returnsNotReviewableWhenQuestionIsNotDraft() throws Exception {
+        when(publicationService.submitForReview(eq(1201L), eq(900L), anyString()))
+                .thenThrow(new ApiException(ErrorCode.QUESTION_NOT_REVIEWABLE));
+
+        mockMvc.perform(patch("/api/admin/quiz-questions/1201")
+                        .requestAttr(AuthenticationRequestAttributes.CURRENT_USER, ADMIN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"status\": \"REVIEW\"}"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("QUESTION_NOT_REVIEWABLE"));
     }
 
     @Test

--- a/src/test/java/org/firstfolio/quiz/mapper/QuizQuestionMapperXmlTest.java
+++ b/src/test/java/org/firstfolio/quiz/mapper/QuizQuestionMapperXmlTest.java
@@ -60,6 +60,9 @@ class QuizQuestionMapperXmlTest {
                 QuizQuestionMapper.class.getName() + ".retirePublished"
         ));
         assertTrue(configuration.hasStatement(
+                QuizQuestionMapper.class.getName() + ".submitForReview"
+        ));
+        assertTrue(configuration.hasStatement(
                 QuizQuestionMapper.class.getName() + ".findAllByIds"
         ));
         assertTrue(configuration.hasStatement(
@@ -145,6 +148,17 @@ class QuizQuestionMapperXmlTest {
                 .getBoundSql(Map.of("questionId", 1201L));
         assertTrue(normalize(retireSql.getSql()).endsWith(
                 "WHERE question_id = ? AND status = 'PUBLISHED'"
+        ));
+
+        BoundSql submitForReviewSql = configuration.getMappedStatement(
+                        QuizQuestionMapper.class.getName() + ".submitForReview"
+                )
+                .getBoundSql(Map.of("questionId", 1201L));
+        assertTrue(normalize(submitForReviewSql.getSql()).contains(
+                "SET status = 'REVIEW'"
+        ));
+        assertTrue(normalize(submitForReviewSql.getSql()).endsWith(
+                "WHERE question_id = ? AND status = 'DRAFT'"
         ));
 
         BoundSql levelTestSql = configuration.getMappedStatement(

--- a/src/test/java/org/firstfolio/quiz/service/QuizQuestionPublicationServiceTest.java
+++ b/src/test/java/org/firstfolio/quiz/service/QuizQuestionPublicationServiceTest.java
@@ -181,6 +181,36 @@ class QuizQuestionPublicationServiceTest {
     }
 
     @Test
+    void submitsDraftQuestionForReview() {
+        QuizQuestion target = question(1201L, 1);
+        when(questionMapper.findByIdForUpdate(1201L)).thenReturn(target);
+        when(questionMapper.submitForReview(1201L)).thenReturn(1);
+
+        QuizQuestion result = service.submitForReview(1201L, ACTOR_ID, REQUEST_ID);
+
+        assertEquals(QuizQuestionStatus.REVIEW, result.getStatus());
+        verify(auditLogMapper).insert(
+                eq(ACTOR_ID), eq("SUBMIT_REVIEW"), eq("QUIZ_QUESTION"), eq(1201L),
+                anyString(), anyString(), eq(REQUEST_ID), eq(NOW)
+        );
+    }
+
+    @Test
+    void rejectsSubmittingNonDraftQuestionForReview() {
+        QuizQuestion target = question(1201L, 1);
+        target.setStatus(QuizQuestionStatus.REVIEW);
+        when(questionMapper.findByIdForUpdate(1201L)).thenReturn(target);
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.submitForReview(1201L, ACTOR_ID, REQUEST_ID)
+        );
+
+        assertEquals(ErrorCode.QUESTION_NOT_REVIEWABLE, exception.getErrorCode());
+        verify(questionMapper, never()).submitForReview(anyLong());
+    }
+
+    @Test
     void manuallyRetiresPublishedQuestionAndKeepsPublishedTimestamp() {
         LocalDateTime publishedAt = LocalDateTime.of(2026, 8, 10, 6, 0);
         QuizQuestion target = question(1201L, 1);


### PR DESCRIPTION
## 작업 배경
FE `AdminQuizView`의 "검수" 버튼이 `PATCH /api/admin/quiz-questions/{questionId}`(body: `{status: "REVIEW"}`)를 호출하는데 BE에 해당 엔드포인트가 없어 404 후 로컬 캐시에만 반영되고 서버엔 저장되지 않던 문제. 사람이 직접 등록한 DRAFT 문항을 검수로 보낼 방법이 없었음.

## 작업(구현) 내용 및 현황
- [x] AdminQuizQuestionController — PATCH /{questionId} 엔드포인트 추가 (FE가 이미 쓰던 경로·바디 그대로 맞춤, status가 "REVIEW"가 아니면 400)
- [x] QuizQuestionPublicationService — submitForReview() 추가, DRAFT 상태만 REVIEW로 전환 허용
- [x] QuizQuestionMapper / QuizQuestionMapper.xml — submitForReview UPDATE 쿼리 추가
- [x] ErrorCode — QUESTION_NOT_REVIEWABLE 추가
- [x] 감사 로그(SUBMIT_REVIEW 액션) 기록
- [x] 컨트롤러/서비스/mapper 테스트 보강

## 참고 사항
- ./gradlew test 전체 통과 확인
- AI가 생성한 퀴즈는 처음부터 REVIEW로 들어오므로 이 작업과는 무관 (해당 흐름은 #143에서 처리)