### PR TITLE
fix: AI 생성 대단원(SCENARIO) 퀴즈 display_order 자동 채번 #146

### DIFF
--- a/src/main/java/org/firstfolio/quiz/integration/ai/service/QuizQuestionBatchWriter.java
+++ b/src/main/java/org/firstfolio/quiz/integration/ai/service/QuizQuestionBatchWriter.java
@@ -8,6 +8,7 @@ import org.firstfolio.exception.ErrorCode;
 import org.firstfolio.quiz.domain.QuizGenerationType;
 import org.firstfolio.quiz.domain.QuizQuestion;
 import org.firstfolio.quiz.domain.QuizQuestionStatus;
+import org.firstfolio.quiz.domain.QuizUsageType;
 import org.firstfolio.quiz.integration.ai.dto.request.QuizQuestionRequest;
 import org.firstfolio.quiz.mapper.QuizQuestionMapper;
 import org.springframework.core.env.Environment;
@@ -17,7 +18,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -53,14 +56,39 @@ public class QuizQuestionBatchWriter {
 
         long aiCreatedBy = resolveAiCreatedBy();
         LocalDateTime now = LocalDateTime.now(clock);
+        Map<Long, Integer> nextDisplayOrderByMainChapter = new HashMap<>();
 
         List<QuizQuestion> saved = new ArrayList<>();
         for (QuizQuestionRequest quiz : validQuizzes) {
-            QuizQuestion question = toQuestion(quiz, aiCreatedBy, now);
+            Integer displayOrder = resolveDisplayOrder(quiz, nextDisplayOrderByMainChapter);
+            QuizQuestion question = toQuestion(quiz, aiCreatedBy, now, displayOrder);
             questionMapper.insert(question);
             saved.add(question);
         }
         return saved;
+    }
+
+    /**
+     * MAIN_CHAPTER(대단원 시나리오) 문항만 display_order를 채운다. AI는 순서 개념이 없어
+     * 대단원별 현재 최대값 다음 번호를 이어붙이고, 같은 배치 안에 같은 대단원 문항이 여럿이면
+     * 배치 내에서 순번을 이어서 증가시킨다.
+     */
+    private Integer resolveDisplayOrder(
+            QuizQuestionRequest quiz,
+            Map<Long, Integer> nextDisplayOrderByMainChapter
+    ) {
+        if (quiz.usageType() != QuizUsageType.MAIN_CHAPTER) {
+            return null;
+        }
+
+        long mainChapterId = quiz.mainChapterId();
+        Integer next = nextDisplayOrderByMainChapter.get(mainChapterId);
+        if (next == null) {
+            Integer max = questionMapper.findMaxDisplayOrderByMainChapterId(mainChapterId);
+            next = max == null ? 1 : max + 1;
+        }
+        nextDisplayOrderByMainChapter.put(mainChapterId, next + 1);
+        return next;
     }
 
     private long resolveAiCreatedBy() {
@@ -81,14 +109,19 @@ public class QuizQuestionBatchWriter {
         }
     }
 
-    private QuizQuestion toQuestion(QuizQuestionRequest quiz, long aiCreatedBy, LocalDateTime now) {
+    private QuizQuestion toQuestion(
+            QuizQuestionRequest quiz,
+            long aiCreatedBy,
+            LocalDateTime now,
+            Integer displayOrder
+    ) {
         QuizQuestion question = QuizQuestion.draft(
                 UUID.randomUUID().toString(),
                 1,
                 quiz.usageType(),
                 quiz.mainChapterId(),
                 quiz.subChapterId(),
-                null,
+                displayOrder,
                 quiz.questionType(),
                 quiz.difficulty(),
                 quiz.prompt(),

--- a/src/main/java/org/firstfolio/quiz/mapper/QuizQuestionMapper.java
+++ b/src/main/java/org/firstfolio/quiz/mapper/QuizQuestionMapper.java
@@ -66,5 +66,7 @@ public interface QuizQuestionMapper {
 
     int submitForReview(@Param("questionId") long questionId);
 
+    Integer findMaxDisplayOrderByMainChapterId(@Param("mainChapterId") long mainChapterId);
+
     int insert(QuizQuestion question);
 }

--- a/src/main/resources/mappers/quiz/QuizQuestionMapper.xml
+++ b/src/main/resources/mappers/quiz/QuizQuestionMapper.xml
@@ -275,6 +275,13 @@
           AND status = 'DRAFT'
     </update>
 
+    <select id="findMaxDisplayOrderByMainChapterId" resultType="java.lang.Integer">
+        SELECT MAX(display_order)
+        FROM quiz_questions
+        WHERE usage_type = 'MAIN_CHAPTER'
+          AND main_chapter_id = #{mainChapterId}
+    </select>
+
     <insert id="insert"
             parameterType="org.firstfolio.quiz.domain.QuizQuestion"
             useGeneratedKeys="true"

--- a/src/test/java/org/firstfolio/quiz/integration/ai/service/QuizQuestionBatchWriterTest.java
+++ b/src/test/java/org/firstfolio/quiz/integration/ai/service/QuizQuestionBatchWriterTest.java
@@ -1,0 +1,147 @@
+package org.firstfolio.quiz.integration.ai.service;
+
+import org.firstfolio.quiz.domain.QuizDifficulty;
+import org.firstfolio.quiz.domain.QuizQuestion;
+import org.firstfolio.quiz.domain.QuizQuestionType;
+import org.firstfolio.quiz.domain.QuizUsageType;
+import org.firstfolio.quiz.integration.ai.dto.request.QuizCorrectAnswerRequest;
+import org.firstfolio.quiz.integration.ai.dto.request.QuizOptionRequest;
+import org.firstfolio.quiz.integration.ai.dto.request.QuizQuestionRequest;
+import org.firstfolio.quiz.integration.ai.dto.request.QuizScenarioRequest;
+import org.firstfolio.quiz.mapper.QuizQuestionMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.Environment;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class QuizQuestionBatchWriterTest {
+
+    private QuizQuestionMapper questionMapper;
+    private QuizQuestionBatchWriter writer;
+
+    @BeforeEach
+    void setUp() {
+        questionMapper = mock(QuizQuestionMapper.class);
+        Environment environment = mock(Environment.class);
+        when(environment.getProperty("quiz.batch.ai-created-by")).thenReturn("1");
+        writer = new QuizQuestionBatchWriter(
+                questionMapper,
+                environment,
+                Clock.fixed(Instant.parse("2026-08-19T06:00:00Z"), ZoneOffset.UTC)
+        );
+    }
+
+    @Test
+    void leavesDisplayOrderNullForSubChapterQuestions() {
+        List<QuizQuestion> saved = writer.saveAll(List.of(subChapterQuiz()));
+
+        assertNull(saved.get(0).getDisplayOrder());
+    }
+
+    @Test
+    void assignsFirstDisplayOrderWhenNoExistingMainChapterQuestions() {
+        when(questionMapper.findMaxDisplayOrderByMainChapterId(2L)).thenReturn(null);
+
+        List<QuizQuestion> saved = writer.saveAll(List.of(mainChapterQuiz(2L)));
+
+        assertEquals(1, saved.get(0).getDisplayOrder());
+    }
+
+    @Test
+    void continuesFromExistingMaxDisplayOrder() {
+        when(questionMapper.findMaxDisplayOrderByMainChapterId(2L)).thenReturn(5);
+
+        List<QuizQuestion> saved = writer.saveAll(List.of(mainChapterQuiz(2L)));
+
+        assertEquals(6, saved.get(0).getDisplayOrder());
+    }
+
+    @Test
+    void incrementsSequentiallyWithinSameBatchForSameChapter() {
+        when(questionMapper.findMaxDisplayOrderByMainChapterId(2L)).thenReturn(5);
+
+        List<QuizQuestion> saved = writer.saveAll(
+                List.of(mainChapterQuiz(2L), mainChapterQuiz(2L))
+        );
+
+        assertEquals(6, saved.get(0).getDisplayOrder());
+        assertEquals(7, saved.get(1).getDisplayOrder());
+        verify(questionMapper, times(1)).findMaxDisplayOrderByMainChapterId(2L);
+    }
+
+    @Test
+    void tracksDisplayOrderIndependentlyPerMainChapter() {
+        when(questionMapper.findMaxDisplayOrderByMainChapterId(2L)).thenReturn(null);
+        when(questionMapper.findMaxDisplayOrderByMainChapterId(3L)).thenReturn(10);
+
+        List<QuizQuestion> saved = writer.saveAll(
+                List.of(mainChapterQuiz(2L), mainChapterQuiz(3L))
+        );
+
+        assertEquals(1, saved.get(0).getDisplayOrder());
+        assertEquals(11, saved.get(1).getDisplayOrder());
+    }
+
+    private QuizQuestionRequest subChapterQuiz() {
+        return new QuizQuestionRequest(
+                QuizUsageType.SUB_CHAPTER,
+                2L,
+                101L,
+                QuizQuestionType.TRUE_FALSE,
+                QuizDifficulty.EASY,
+                "예금은 원금이 보장된다.",
+                null,
+                List.of(
+                        new QuizOptionRequest("O", "O", null),
+                        new QuizOptionRequest("X", "X", null)
+                ),
+                new QuizCorrectAnswerRequest("O"),
+                "해설",
+                null
+        );
+    }
+
+    private QuizQuestionRequest mainChapterQuiz(long mainChapterId) {
+        return new QuizQuestionRequest(
+                QuizUsageType.MAIN_CHAPTER,
+                mainChapterId,
+                null,
+                QuizQuestionType.SCENARIO,
+                QuizDifficulty.MEDIUM,
+                "시나리오 프롬프트",
+                scenario(),
+                List.of(
+                        new QuizOptionRequest("1", "선택지1", null),
+                        new QuizOptionRequest("2", "선택지2", null),
+                        new QuizOptionRequest("3", "선택지3", null),
+                        new QuizOptionRequest("4", "선택지4", null)
+                ),
+                new QuizCorrectAnswerRequest("1"),
+                "해설",
+                null
+        );
+    }
+
+    private QuizScenarioRequest scenario() {
+        return new QuizScenarioRequest(
+                "제목",
+                "내러티브",
+                new QuizScenarioRequest.Persona("홍길동", "30대", "회사원"),
+                new QuizScenarioRequest.Requirements("자산", "중립", "목표"),
+                new QuizScenarioRequest.Market("시장", "2026-08-19T00:00:00Z", List.of("불릿")),
+                List.of("제약"),
+                null
+        );
+    }
+}

--- a/src/test/java/org/firstfolio/quiz/mapper/QuizQuestionMapperXmlTest.java
+++ b/src/test/java/org/firstfolio/quiz/mapper/QuizQuestionMapperXmlTest.java
@@ -63,6 +63,9 @@ class QuizQuestionMapperXmlTest {
                 QuizQuestionMapper.class.getName() + ".submitForReview"
         ));
         assertTrue(configuration.hasStatement(
+                QuizQuestionMapper.class.getName() + ".findMaxDisplayOrderByMainChapterId"
+        ));
+        assertTrue(configuration.hasStatement(
                 QuizQuestionMapper.class.getName() + ".findAllByIds"
         ));
         assertTrue(configuration.hasStatement(
@@ -159,6 +162,18 @@ class QuizQuestionMapperXmlTest {
         ));
         assertTrue(normalize(submitForReviewSql.getSql()).endsWith(
                 "WHERE question_id = ? AND status = 'DRAFT'"
+        ));
+
+        BoundSql maxDisplayOrderSql = configuration.getMappedStatement(
+                        QuizQuestionMapper.class.getName()
+                                + ".findMaxDisplayOrderByMainChapterId"
+                )
+                .getBoundSql(Map.of("mainChapterId", 2L));
+        assertTrue(normalize(maxDisplayOrderSql.getSql()).contains(
+                "SELECT MAX(display_order)"
+        ));
+        assertTrue(normalize(maxDisplayOrderSql.getSql()).endsWith(
+                "WHERE usage_type = 'MAIN_CHAPTER' AND main_chapter_id = ?"
         ));
 
         BoundSql levelTestSql = configuration.getMappedStatement(


### PR DESCRIPTION
## 작업 배경
퀴즈 문항 JSON Schema는 usage_type이 MAIN_CHAPTER(시나리오형)인 경우 display_order를 필수로 요구하는데, AI 배치 수신 쪽(QuizQuestionBatchWriter)은 이 값을 항상 null로 저장했음. AI 요청 DTO(QuizQuestionRequest)에 애초에 display_order 필드가 없기 때문. 이 상태로 관리자가 공개(publish)를 시도하면 스키마 재검증에서 QUESTION_VALIDATION_FAILED로 막힘.
현재 display_order를 나중에 수정할 수 있는 API/화면이 전혀 없어(생성 시 1회 입력만 가능, 새 버전 생성 시 이전 값 그대로 상속), 최초 저장 시점에 값을 채워야만 함.

## 작업(구현) 내용 및 현황
- [x] QuizQuestionMapper / QuizQuestionMapper.xml — findMaxDisplayOrderByMainChapterId 쿼리 추가
- [x] QuizQuestionBatchWriter — MAIN_CHAPTER 문항만 대단원별 현재 최대 display_order + 1로 채번. 같은 배치 안에 같은 대단원 문항이 여럿이면 배치 내에서 순번을 이어서 증가시켜 DB를 반복 조회하지 않음. SUB_CHAPTER는 기존대로 null 유지
- [x] QuizQuestionBatchWriterTest 신규 — 소단원 null 유지 / 첫 등록 시 1번 / 기존 최대값 이어받기 / 배치 내 순번 증가 / 대단원별 독립 추적 5개 케이스
- [x] QuizQuestionMapperXmlTest — 신규 쿼리 SQL 검증 추가

## 참고 사항
- ./gradlew test 전체 통과 확인
- 기존 HUMAN이 직접 만든 대단원 문제들의 display_order는 전혀 건드리지 않음 — 새로 들어오는 AI 문제 뒤에 이어 붙는 방식
- display_order를 나중에 수정하는 기능(관리자가 순서 재배치)은 이번 범위에 포함 안 함 — 필요 시 별도 이슈