### PR TITLE
fix: 일일 퀘스트 채점 시 AI 문항 source_refs_json NULL 처리 오류 수정 #163

### DIFF
--- a/src/main/java/org/firstfolio/dailyquest/service/DailyQuestSubmissionSnapshotCodec.java
+++ b/src/main/java/org/firstfolio/dailyquest/service/DailyQuestSubmissionSnapshotCodec.java
@@ -91,6 +91,9 @@ final class DailyQuestSubmissionSnapshotCodec {
             }
             return null;
         }
+        if (sourceRefs.isNull()) {
+            return null;
+        }
         if (!sourceRefs.isArray() || sourceRefs.isEmpty()) {
             throw invalidSnapshot(null);
         }

--- a/src/test/java/org/firstfolio/dailyquest/service/DailyQuestSubmitServiceTest.java
+++ b/src/test/java/org/firstfolio/dailyquest/service/DailyQuestSubmitServiceTest.java
@@ -138,6 +138,28 @@ class DailyQuestSubmitServiceTest {
     }
 
     @Test
+    void gradesAiSnapshotWithNullSourceRefs() {
+        DailyQuest quest = inProgressQuest();
+        List<DailyQuestItem> items = answeredItemsWithAiNullSourceRefs(
+                List.of("A", "A", "B", "A", "A")
+        );
+        stubLockedQuest(quest, items);
+        when(mapper.gradeItem(any())).thenReturn(1);
+        when(rewardService.grant(
+                USER_ID,
+                QUEST_ID,
+                4,
+                COMPLETED_AT
+        )).thenReturn(new PointRewardResult(91L, 400, 9001L));
+        when(mapper.completeQuestIfInProgress(any())).thenReturn(1);
+
+        DailyQuestSubmitResult result = service.submit(USER_ID);
+
+        assertEquals(DailyQuestStatus.COMPLETED, result.status());
+        assertNull(result.results().get(4).sourceRefs());
+    }
+
+    @Test
     void completesZeroCorrectWithoutPointTransaction() {
         DailyQuest quest = inProgressQuest();
         List<DailyQuestItem> items = answeredItems(
@@ -392,6 +414,40 @@ class DailyQuestSubmitServiceTest {
             items.add(item);
         }
         return items;
+    }
+
+    private List<DailyQuestItem> answeredItemsWithAiNullSourceRefs(
+            List<String> keys
+    ) {
+        List<DailyQuestItem> items = new ArrayList<>();
+        for (int index = 0; index < DailyQuest.TOTAL_QUESTION_COUNT; index++) {
+            DailyQuestItem item = DailyQuestItem.assigned(
+                    QUEST_ID,
+                    1001L + index,
+                    index + 1,
+                    index == 4 ? snapshotAiNullSourceRefs() : snapshot(false),
+                    COMPLETED_AT.minusHours(1)
+            );
+            item.setDailyQuestItemId(5001L + index);
+            item.setUserAnswerJson(
+                    "{\"key\":\"" + keys.get(index) + "\"}"
+            );
+            item.setAnsweredAt(COMPLETED_AT.minusMinutes(10 - index));
+            items.add(item);
+        }
+        return items;
+    }
+
+    private String snapshotAiNullSourceRefs() {
+        return "{"
+                + "\"generation_type\":\"AI\","
+                + "\"options_json\":["
+                + "{\"key\":\"A\",\"label\":\"정답\"},"
+                + "{\"key\":\"B\",\"label\":\"오답\"}],"
+                + "\"correct_answer_json\":{\"key\":\"A\"},"
+                + "\"explanation\":\"정답 해설\","
+                + "\"source_refs_json\":null"
+                + "}";
     }
 
     private String snapshot(boolean ai) {


### PR DESCRIPTION
## 작업내용
- 일일 퀘스트 최종 제출(`POST /api/daily-quests/today/submit`) 시 AI가 생성한 문항의 `source_refs_json`이 NULL이면 500 에러가 나던 문제 수정
- DB 제약조건(`V2__allow_nullable_ai_quiz_source_refs.sql`)은 이미 AI 생성 문항의 `source_refs_json` NULL을 허용하고 있었는데, `DailyQuestSubmissionSnapshotCodec.sourceRefs()`만 이를 반영하지 못하고 여전히 비어있지 않은 배열을 강제하고 있었음
- AI 생성 타입이고 `source_refs_json`이 JSON null인 경우, HUMAN 타입과 동일하게 null을 정상 반환하도록 분기 추가 (null이 아닐 때는 기존대로 배열 검증 유지)

## 테스트
- [x] `DailyQuestSubmitServiceTest`에 `gradesAiSnapshotWithNullSourceRefs` 케이스 추가 — AI + source_refs_json null 스냅샷이 예외 없이 정상 채점되는지 확인
- [x] `./gradlew clean test` 전체 통과