### PR TITLE
feat: 관리자 금융 뉴스 수정, 삭제 API 추가

### DIFF
--- a/src/main/java/org/firstfolio/config/OpenApiResponseSchemas.java
+++ b/src/main/java/org/firstfolio/config/OpenApiResponseSchemas.java
@@ -38,6 +38,7 @@ import org.firstfolio.gifticon.dto.response.GifticonProductResponse;
 import org.firstfolio.gifticon.dto.response.MyGifticonPageResponse;
 import org.firstfolio.gifticon.dto.response.MyGifticonResponse;
 import org.firstfolio.learning.dto.response.LessonContentResponse;
+import org.firstfolio.news.dto.response.FinancialNewsDeleteResponse;
 import org.firstfolio.news.dto.response.FinancialNewsItemResponse;
 import org.firstfolio.news.dto.response.FinancialNewsListResponse;
 import org.firstfolio.learning.dto.response.LearningProgressResponse;
@@ -270,4 +271,7 @@ public final class OpenApiResponseSchemas {
 
     @Schema(name = "FinancialNewsItemApiResponse")
     public record FinancialNewsItem(FinancialNewsItemResponse data) { }
+
+    @Schema(name = "FinancialNewsDeleteApiResponse")
+    public record FinancialNewsDelete(FinancialNewsDeleteResponse data) { }
 }

--- a/src/main/java/org/firstfolio/exception/ErrorCode.java
+++ b/src/main/java/org/firstfolio/exception/ErrorCode.java
@@ -121,6 +121,9 @@ public enum ErrorCode {
     INVALID_GIFTICON_ORDER_CURSOR(HttpStatus.BAD_REQUEST, "내 기프티콘 페이지 조건이 올바르지 않습니다."),
     GIFTICON_CODE_DECRYPTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "기프티콘 코드를 공개할 수 없습니다."),
 
+    // 금융 뉴스 스크랩
+    FINANCIAL_NEWS_NOT_FOUND(HttpStatus.NOT_FOUND, "금융 뉴스를 찾을 수 없습니다."),
+
     // 내부 배치 (FUNC-040, 041, 042)
     INTERNAL_CALL_REQUIRED(HttpStatus.FORBIDDEN, "허용된 내부 호출이 아닙니다."),
     PRICE_POLICY_INVALID(HttpStatus.UNPROCESSABLE_ENTITY, "가격 생성 정책 또는 상품 조건이 올바르지 않습니다."),

--- a/src/main/java/org/firstfolio/news/controller/AdminNewsController.java
+++ b/src/main/java/org/firstfolio/news/controller/AdminNewsController.java
@@ -1,0 +1,102 @@
+package org.firstfolio.news.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.firstfolio.common.response.ApiResponse;
+import org.firstfolio.config.OpenApiResponseSchemas;
+import org.firstfolio.news.dto.request.NewsPatchRequest;
+import org.firstfolio.news.dto.response.FinancialNewsDeleteResponse;
+import org.firstfolio.news.dto.response.FinancialNewsItemResponse;
+import org.firstfolio.news.service.NewsService;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 관리자 금융 뉴스 수정·삭제 API.
+ *
+ * <p>ADMIN 권한 검증은 {@code ServletConfig}의 경로 인터셉터가 담당한다
+ * ({@code /api/admin/**}). 컨트롤러마다 권한 검사를 반복하지 않는다.</p>
+ */
+@RestController
+@RequestMapping("/api/admin/financial-news")
+@Tag(name = "관리자 뉴스", description = "관리자용 금융 뉴스 수정·삭제 API")
+public class AdminNewsController {
+
+    private final NewsService newsService;
+
+    public AdminNewsController(NewsService newsService) {
+        this.newsService = newsService;
+    }
+
+    @PatchMapping("/{financialNewsId}")
+    @Operation(
+            summary = "금융 뉴스 수정",
+            description = "등록된 금융 뉴스 한 건의 전달한 필드만 수정합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            description = "금융 뉴스 수정 성공",
+                            content = @io.swagger.v3.oas.annotations.media.Content(
+                                    mediaType = "application/json",
+                                    schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                            implementation = OpenApiResponseSchemas.FinancialNewsItem.class
+                                    )
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "400", description = "INVALID_REQUEST - 수정 필드 없음 또는 값 오류"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "403", description = "ADMIN_REQUIRED - 관리자 권한 필요"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "404", description = "FINANCIAL_NEWS_NOT_FOUND - 금융 뉴스를 찾을 수 없음"
+                    )
+            }
+    )
+    public ApiResponse<FinancialNewsItemResponse> update(
+            @Parameter(description = "수정할 금융 뉴스 ID", example = "1", required = true)
+            @PathVariable long financialNewsId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true, description = "변경할 필드만 포함한 금융 뉴스"
+            )
+            @RequestBody(required = false) NewsPatchRequest request
+    ) {
+        return ApiResponse.of(newsService.updateArticle(financialNewsId, request));
+    }
+
+    @DeleteMapping("/{financialNewsId}")
+    @Operation(
+            summary = "금융 뉴스 삭제",
+            description = "등록된 금융 뉴스 한 건을 삭제합니다. 목록 조회에서 즉시 제외됩니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            description = "금융 뉴스 삭제 성공",
+                            content = @io.swagger.v3.oas.annotations.media.Content(
+                                    mediaType = "application/json",
+                                    schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                            implementation = OpenApiResponseSchemas.FinancialNewsDelete.class
+                                    )
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "403", description = "ADMIN_REQUIRED - 관리자 권한 필요"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "404", description = "FINANCIAL_NEWS_NOT_FOUND - 금융 뉴스를 찾을 수 없음"
+                    )
+            }
+    )
+    public ApiResponse<FinancialNewsDeleteResponse> delete(
+            @Parameter(description = "삭제할 금융 뉴스 ID", example = "1", required = true)
+            @PathVariable long financialNewsId
+    ) {
+        return ApiResponse.of(newsService.deleteArticle(financialNewsId));
+    }
+}

--- a/src/main/java/org/firstfolio/news/dto/request/NewsPatchRequest.java
+++ b/src/main/java/org/firstfolio/news/dto/request/NewsPatchRequest.java
@@ -1,0 +1,146 @@
+package org.firstfolio.news.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+/**
+ * 관리자 뉴스 부분 수정 요청 ({@code PATCH /api/admin/financial-news/{financialNewsId}}).
+ *
+ * <p>본문에 포함한 필드만 변경한다. {@code image_url}은 {@code null}로 보내 썸네일을 지울 수 있다.</p>
+ */
+@Schema(description = "금융 뉴스 부분 수정 요청. 전달한 필드만 변경")
+public class NewsPatchRequest {
+
+    @Schema(description = "제목")
+    private String title;
+    @Schema(description = "요약")
+    private String summary;
+    @Schema(description = "썸네일 이미지 URL")
+    private String imageUrl;
+    @Schema(description = "원문 언론사명")
+    private String sourceName;
+    @Schema(description = "원문 기사 URL")
+    private String sourceUrl;
+    @Schema(description = "원문 기사 발행 시각")
+    private LocalDateTime sourcePublishedAt;
+    @Schema(description = "서비스 노출 시각")
+    private LocalDateTime publishedAt;
+
+    private boolean titleProvided;
+    private boolean summaryProvided;
+    private boolean imageUrlProvided;
+    private boolean sourceNameProvided;
+    private boolean sourceUrlProvided;
+    private boolean sourcePublishedAtProvided;
+    private boolean publishedAtProvided;
+
+    @JsonSetter("title")
+    public void setTitle(String title) {
+        this.title = title;
+        this.titleProvided = true;
+    }
+
+    @JsonSetter("summary")
+    public void setSummary(String summary) {
+        this.summary = summary;
+        this.summaryProvided = true;
+    }
+
+    @JsonSetter("image_url")
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+        this.imageUrlProvided = true;
+    }
+
+    @JsonSetter("source_name")
+    public void setSourceName(String sourceName) {
+        this.sourceName = sourceName;
+        this.sourceNameProvided = true;
+    }
+
+    @JsonSetter("source_url")
+    public void setSourceUrl(String sourceUrl) {
+        this.sourceUrl = sourceUrl;
+        this.sourceUrlProvided = true;
+    }
+
+    @JsonSetter("source_published_at")
+    public void setSourcePublishedAt(LocalDateTime sourcePublishedAt) {
+        this.sourcePublishedAt = sourcePublishedAt;
+        this.sourcePublishedAtProvided = true;
+    }
+
+    @JsonSetter("published_at")
+    public void setPublishedAt(LocalDateTime publishedAt) {
+        this.publishedAt = publishedAt;
+        this.publishedAtProvided = true;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public String getSourceName() {
+        return sourceName;
+    }
+
+    public String getSourceUrl() {
+        return sourceUrl;
+    }
+
+    public LocalDateTime getSourcePublishedAt() {
+        return sourcePublishedAt;
+    }
+
+    public LocalDateTime getPublishedAt() {
+        return publishedAt;
+    }
+
+    public boolean titleProvided() {
+        return titleProvided;
+    }
+
+    public boolean summaryProvided() {
+        return summaryProvided;
+    }
+
+    public boolean imageUrlProvided() {
+        return imageUrlProvided;
+    }
+
+    public boolean sourceNameProvided() {
+        return sourceNameProvided;
+    }
+
+    public boolean sourceUrlProvided() {
+        return sourceUrlProvided;
+    }
+
+    public boolean sourcePublishedAtProvided() {
+        return sourcePublishedAtProvided;
+    }
+
+    public boolean publishedAtProvided() {
+        return publishedAtProvided;
+    }
+
+    public boolean hasAnyField() {
+        return titleProvided
+                || summaryProvided
+                || imageUrlProvided
+                || sourceNameProvided
+                || sourceUrlProvided
+                || sourcePublishedAtProvided
+                || publishedAtProvided;
+    }
+}

--- a/src/main/java/org/firstfolio/news/dto/response/FinancialNewsDeleteResponse.java
+++ b/src/main/java/org/firstfolio/news/dto/response/FinancialNewsDeleteResponse.java
@@ -1,0 +1,10 @@
+package org.firstfolio.news.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "금융 뉴스 삭제 결과")
+public record FinancialNewsDeleteResponse(
+        @Schema(description = "삭제한 금융 뉴스 식별자", example = "1")
+        long financialNewsId
+) {
+}

--- a/src/main/java/org/firstfolio/news/mapper/NewsMapper.java
+++ b/src/main/java/org/firstfolio/news/mapper/NewsMapper.java
@@ -11,5 +11,11 @@ public interface NewsMapper {
 
     List<NewsArticle> findLatest(@Param("limit") int limit);
 
+    NewsArticle findById(@Param("financialNewsId") long financialNewsId);
+
     int insert(NewsArticle article);
+
+    int update(NewsArticle article);
+
+    int deleteById(@Param("financialNewsId") long financialNewsId);
 }

--- a/src/main/java/org/firstfolio/news/service/NewsService.java
+++ b/src/main/java/org/firstfolio/news/service/NewsService.java
@@ -4,10 +4,13 @@ import org.firstfolio.exception.ApiException;
 import org.firstfolio.exception.ErrorCode;
 import org.firstfolio.news.domain.NewsArticle;
 import org.firstfolio.news.dto.request.NewsCreateRequest;
+import org.firstfolio.news.dto.request.NewsPatchRequest;
+import org.firstfolio.news.dto.response.FinancialNewsDeleteResponse;
 import org.firstfolio.news.dto.response.FinancialNewsItemResponse;
 import org.firstfolio.news.dto.response.FinancialNewsListResponse;
 import org.firstfolio.news.mapper.NewsMapper;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
@@ -58,6 +61,86 @@ public class NewsService {
         }
 
         return toItem(article);
+    }
+
+    @Transactional
+    public FinancialNewsItemResponse updateArticle(long financialNewsId, NewsPatchRequest request) {
+        if (request == null || !request.hasAnyField()) {
+            throw new ApiException(ErrorCode.INVALID_REQUEST, "수정할 뉴스 필드가 없습니다.");
+        }
+
+        NewsArticle article = requireArticle(financialNewsId);
+        applyPatch(article, request);
+        article.setUpdatedAt(LocalDateTime.now(clock));
+
+        if (newsMapper.update(article) != 1) {
+            throw new ApiException(ErrorCode.FINANCIAL_NEWS_NOT_FOUND);
+        }
+
+        return toItem(article);
+    }
+
+    @Transactional
+    public FinancialNewsDeleteResponse deleteArticle(long financialNewsId) {
+        requireArticle(financialNewsId);
+
+        if (newsMapper.deleteById(financialNewsId) != 1) {
+            throw new ApiException(ErrorCode.FINANCIAL_NEWS_NOT_FOUND);
+        }
+
+        return new FinancialNewsDeleteResponse(financialNewsId);
+    }
+
+    private NewsArticle requireArticle(long financialNewsId) {
+        NewsArticle article = newsMapper.findById(financialNewsId);
+        if (article == null) {
+            throw new ApiException(ErrorCode.FINANCIAL_NEWS_NOT_FOUND);
+        }
+        return article;
+    }
+
+    private void applyPatch(NewsArticle article, NewsPatchRequest request) {
+        if (request.titleProvided()) {
+            article.setTitle(requireText(request.getTitle(), "title"));
+        }
+        if (request.summaryProvided()) {
+            article.setSummary(requireText(request.getSummary(), "summary"));
+        }
+        if (request.imageUrlProvided()) {
+            article.setImageUrl(normalizeOptional(request.getImageUrl()));
+        }
+        if (request.sourceNameProvided()) {
+            article.setSourceName(requireText(request.getSourceName(), "source_name"));
+        }
+        if (request.sourceUrlProvided()) {
+            article.setSourceUrl(requireText(request.getSourceUrl(), "source_url"));
+        }
+        if (request.sourcePublishedAtProvided()) {
+            if (request.getSourcePublishedAt() == null) {
+                throw new ApiException(ErrorCode.INVALID_REQUEST, "source_published_at는 필수입니다.");
+            }
+            article.setSourcePublishedAt(request.getSourcePublishedAt());
+        }
+        if (request.publishedAtProvided()) {
+            if (request.getPublishedAt() == null) {
+                throw new ApiException(ErrorCode.INVALID_REQUEST, "published_at는 필수입니다.");
+            }
+            article.setPublishedAt(request.getPublishedAt());
+        }
+    }
+
+    private String requireText(String value, String fieldName) {
+        if (isBlank(value)) {
+            throw new ApiException(ErrorCode.INVALID_REQUEST, fieldName + "은(는) 비어 있을 수 없습니다.");
+        }
+        return value.trim();
+    }
+
+    private String normalizeOptional(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.trim();
     }
 
     private void validate(NewsCreateRequest request) {

--- a/src/main/resources/mappers/news/NewsMapper.xml
+++ b/src/main/resources/mappers/news/NewsMapper.xml
@@ -38,6 +38,12 @@
         LIMIT #{limit}
     </select>
 
+    <select id="findById" resultMap="newsArticleResult">
+        SELECT <include refid="columns"/>
+        FROM news_articles
+        WHERE financial_news_id = #{financialNewsId}
+    </select>
+
     <insert id="insert" useGeneratedKeys="true" keyProperty="financialNewsId">
         INSERT INTO news_articles (
             title,
@@ -61,5 +67,23 @@
             #{updatedAt}
         )
     </insert>
+
+    <update id="update">
+        UPDATE news_articles
+        SET title = #{title},
+            summary = #{summary},
+            image_url = #{imageUrl,jdbcType=VARCHAR},
+            source_name = #{sourceName},
+            source_url = #{sourceUrl},
+            source_published_at = #{sourcePublishedAt},
+            published_at = #{publishedAt},
+            updated_at = #{updatedAt}
+        WHERE financial_news_id = #{financialNewsId}
+    </update>
+
+    <delete id="deleteById">
+        DELETE FROM news_articles
+        WHERE financial_news_id = #{financialNewsId}
+    </delete>
 
 </mapper>

--- a/src/test/java/org/firstfolio/news/controller/AdminNewsControllerTest.java
+++ b/src/test/java/org/firstfolio/news/controller/AdminNewsControllerTest.java
@@ -1,0 +1,125 @@
+package org.firstfolio.news.controller;
+
+import org.firstfolio.auth.domain.AuthenticatedUser;
+import org.firstfolio.auth.web.AuthenticationRequestAttributes;
+import org.firstfolio.auth.web.CurrentUserArgumentResolver;
+import org.firstfolio.common.json.ApiObjectMapperFactory;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.CommonExceptionAdvice;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.news.dto.request.NewsPatchRequest;
+import org.firstfolio.news.dto.response.FinancialNewsDeleteResponse;
+import org.firstfolio.news.dto.response.FinancialNewsItemResponse;
+import org.firstfolio.news.service.NewsService;
+import org.firstfolio.user.domain.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class AdminNewsControllerTest {
+
+    private static final AuthenticatedUser ADMIN = new AuthenticatedUser(
+            900L,
+            "firebase-admin",
+            "관리자",
+            UserRole.ADMIN
+    );
+
+    private NewsService newsService;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        newsService = mock(NewsService.class);
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new AdminNewsController(newsService))
+                .setControllerAdvice(new CommonExceptionAdvice())
+                .setCustomArgumentResolvers(new CurrentUserArgumentResolver())
+                .setMessageConverters(
+                        new MappingJackson2HttpMessageConverter(ApiObjectMapperFactory.create())
+                )
+                .build();
+    }
+
+    @Test
+    void patchesNewsAndReturnsUpdatedItem() throws Exception {
+        when(newsService.updateArticle(eq(1L), any(NewsPatchRequest.class)))
+                .thenReturn(item());
+
+        mockMvc.perform(patch("/api/admin/financial-news/1")
+                        .requestAttr(AuthenticationRequestAttributes.CURRENT_USER, ADMIN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "title": "예·적금 금리 비교 수요 증가…은행권 경쟁 격화",
+                                  "summary": "기준금리 동결 결정의 배경과 예·적금, 대출 금리에 미칠 영향을 요약합니다."
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.financial_news_id").value(1))
+                .andExpect(jsonPath("$.data.title")
+                        .value("예·적금 금리 비교 수요 증가…은행권 경쟁 격화"))
+                .andExpect(jsonPath("$.data.source_name").value("경제일보"));
+
+        verify(newsService).updateArticle(eq(1L), any(NewsPatchRequest.class));
+    }
+
+    @Test
+    void deletesNewsAndReturnsId() throws Exception {
+        when(newsService.deleteArticle(1L))
+                .thenReturn(new FinancialNewsDeleteResponse(1L));
+
+        mockMvc.perform(delete("/api/admin/financial-news/1")
+                        .requestAttr(AuthenticationRequestAttributes.CURRENT_USER, ADMIN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.financial_news_id").value(1));
+    }
+
+    @Test
+    void returnsNotFoundWhenNewsMissing() throws Exception {
+        when(newsService.updateArticle(eq(99L), any()))
+                .thenThrow(new ApiException(ErrorCode.FINANCIAL_NEWS_NOT_FOUND));
+        when(newsService.deleteArticle(99L))
+                .thenThrow(new ApiException(ErrorCode.FINANCIAL_NEWS_NOT_FOUND));
+
+        mockMvc.perform(patch("/api/admin/financial-news/99")
+                        .requestAttr(AuthenticationRequestAttributes.CURRENT_USER, ADMIN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\":\"수정 제목\"}"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("FINANCIAL_NEWS_NOT_FOUND"));
+
+        mockMvc.perform(delete("/api/admin/financial-news/99")
+                        .requestAttr(AuthenticationRequestAttributes.CURRENT_USER, ADMIN))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("FINANCIAL_NEWS_NOT_FOUND"));
+    }
+
+    private FinancialNewsItemResponse item() {
+        return new FinancialNewsItemResponse(
+                1L,
+                "예·적금 금리 비교 수요 증가…은행권 경쟁 격화",
+                "기준금리 동결 결정의 배경과 예·적금, 대출 금리에 미칠 영향을 요약합니다.",
+                null,
+                "경제일보",
+                "https://example.com/source-news",
+                LocalDateTime.of(2026, 8, 16, 9, 0),
+                LocalDateTime.of(2026, 8, 17, 9, 0)
+        );
+    }
+}

--- a/src/test/java/org/firstfolio/news/mapper/NewsMapperXmlTest.java
+++ b/src/test/java/org/firstfolio/news/mapper/NewsMapperXmlTest.java
@@ -1,0 +1,57 @@
+package org.firstfolio.news.mapper;
+
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.mapping.BoundSql;
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NewsMapperXmlTest {
+
+    private static final String RESOURCE = "mappers/news/NewsMapper.xml";
+
+    @Test
+    void parsesUpdateAndDeleteStatements() throws IOException {
+        Configuration configuration = new Configuration();
+
+        try (InputStream input = Resources.getResourceAsStream(RESOURCE)) {
+            XMLMapperBuilder builder = new XMLMapperBuilder(
+                    input,
+                    configuration,
+                    RESOURCE,
+                    configuration.getSqlFragments()
+            );
+            builder.parse();
+        }
+
+        assertTrue(configuration.hasMapper(NewsMapper.class));
+        assertTrue(configuration.hasStatement(NewsMapper.class.getName() + ".findById"));
+        assertTrue(configuration.hasStatement(NewsMapper.class.getName() + ".update"));
+        assertTrue(configuration.hasStatement(NewsMapper.class.getName() + ".deleteById"));
+
+        BoundSql updateSql = configuration.getMappedStatement(
+                        NewsMapper.class.getName() + ".update"
+                )
+                .getBoundSql(new Object());
+        String normalizedUpdate = normalize(updateSql.getSql());
+        assertTrue(normalizedUpdate.contains("UPDATE news_articles"));
+        assertTrue(normalizedUpdate.contains("WHERE financial_news_id = ?"));
+
+        BoundSql deleteSql = configuration.getMappedStatement(
+                        NewsMapper.class.getName() + ".deleteById"
+                )
+                .getBoundSql(1L);
+        String normalizedDelete = normalize(deleteSql.getSql());
+        assertTrue(normalizedDelete.contains("DELETE FROM news_articles"));
+        assertTrue(normalizedDelete.contains("WHERE financial_news_id = ?"));
+    }
+
+    private String normalize(String sql) {
+        return sql.replaceAll("\\s+", " ").trim();
+    }
+}

--- a/src/test/java/org/firstfolio/news/service/NewsServiceTest.java
+++ b/src/test/java/org/firstfolio/news/service/NewsServiceTest.java
@@ -1,0 +1,137 @@
+package org.firstfolio.news.service;
+
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.news.domain.NewsArticle;
+import org.firstfolio.news.dto.request.NewsPatchRequest;
+import org.firstfolio.news.mapper.NewsMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class NewsServiceTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 8, 20, 4, 0);
+
+    private NewsMapper newsMapper;
+    private NewsService service;
+
+    @BeforeEach
+    void setUp() {
+        newsMapper = mock(NewsMapper.class);
+        Clock clock = Clock.fixed(Instant.parse("2026-08-20T04:00:00Z"), ZoneOffset.UTC);
+        service = new NewsService(newsMapper, clock);
+    }
+
+    @Test
+    void updatesProvidedFieldsOnly() {
+        NewsArticle stored = article();
+        when(newsMapper.findById(1L)).thenReturn(stored);
+        when(newsMapper.update(stored)).thenReturn(1);
+
+        NewsPatchRequest request = new NewsPatchRequest();
+        request.setTitle("수정 제목");
+        request.setImageUrl(null);
+
+        var result = service.updateArticle(1L, request);
+
+        assertEquals("수정 제목", result.getTitle());
+        assertEquals("기존 요약", result.getSummary());
+        assertNull(result.getImageUrl());
+        assertEquals(NOW, stored.getUpdatedAt());
+        verify(newsMapper).update(stored);
+    }
+
+    @Test
+    void rejectsEmptyPatch() {
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.updateArticle(1L, new NewsPatchRequest())
+        );
+
+        assertEquals(ErrorCode.INVALID_REQUEST, exception.getErrorCode());
+        verify(newsMapper, never()).findById(1L);
+    }
+
+    @Test
+    void rejectsMissingNewsOnUpdate() {
+        when(newsMapper.findById(99L)).thenReturn(null);
+
+        NewsPatchRequest request = new NewsPatchRequest();
+        request.setTitle("수정 제목");
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.updateArticle(99L, request)
+        );
+
+        assertEquals(ErrorCode.FINANCIAL_NEWS_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    void deletesExistingNews() {
+        when(newsMapper.findById(1L)).thenReturn(article());
+        when(newsMapper.deleteById(1L)).thenReturn(1);
+
+        var result = service.deleteArticle(1L);
+
+        assertEquals(1L, result.financialNewsId());
+        verify(newsMapper).deleteById(1L);
+    }
+
+    @Test
+    void rejectsMissingNewsOnDelete() {
+        when(newsMapper.findById(99L)).thenReturn(null);
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.deleteArticle(99L)
+        );
+
+        assertEquals(ErrorCode.FINANCIAL_NEWS_NOT_FOUND, exception.getErrorCode());
+        verify(newsMapper, never()).deleteById(99L);
+    }
+
+    @Test
+    void rejectsBlankTitleOnPatch() {
+        when(newsMapper.findById(1L)).thenReturn(article());
+
+        NewsPatchRequest request = new NewsPatchRequest();
+        request.setTitle("  ");
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.updateArticle(1L, request)
+        );
+
+        assertEquals(ErrorCode.INVALID_REQUEST, exception.getErrorCode());
+        verify(newsMapper, never()).update(org.mockito.ArgumentMatchers.any());
+    }
+
+    private NewsArticle article() {
+        NewsArticle article = new NewsArticle();
+        article.setFinancialNewsId(1L);
+        article.setTitle("기존 제목");
+        article.setSummary("기존 요약");
+        article.setImageUrl("https://example.com/thumb.png");
+        article.setSourceName("경제일보");
+        article.setSourceUrl("https://example.com/source-news");
+        article.setSourcePublishedAt(LocalDateTime.of(2026, 8, 16, 9, 0));
+        article.setPublishedAt(LocalDateTime.of(2026, 8, 17, 9, 0));
+        article.setCreatedAt(LocalDateTime.of(2026, 8, 17, 9, 0));
+        article.setUpdatedAt(LocalDateTime.of(2026, 8, 17, 9, 0));
+        return article;
+    }
+}


### PR DESCRIPTION
**작업명:** feat: 관리자 금융 뉴스 수정, 삭제 API 추가

## 작업 배경

금융 뉴스 스크랩은 `news_articles`에 저장되고, 사용자는 `GET /api/financial-news`로 조회한다. 생성은 내부 파이프라인(`POST /api/internal/news`)이 담당한다.

생성된 기사를 관리자가 검수·정정하거나 잘못 노출된 건을 내릴 수 있어야 하므로, 수정·삭제는 관리자 API로 제공한다.

## 작업(구현) 내용 및 현황

### API
- [ ] `PATCH /api/admin/financial-news/{financialNewsId}` — 전달한 필드만 수정
- [ ] `DELETE /api/admin/financial-news/{financialNewsId}` — 행 삭제, 목록에서 즉시 제외

### 테스트
- [ ] `AdminNewsControllerTest`
- [ ] `NewsServiceTest`
- [ ] `NewsMapperXmlTest`

## 참고 사항

- 등록 API(`POST /api/internal/news`)는 이번 범위에 포함하지 않는다.
- 사용자 목록 조회(`GET /api/financial-news`)는 변경 없음.
- 테이블은 기존 `V3__create_news_articles.sql` (`news_articles`)을 사용한다.

**수정 요청 예시**
```json
{
  "title": "예·적금 금리 비교 수요 증가…은행권 경쟁 격화",
  "summary": "기준금리 동결 결정의 배경과 예·적금, 대출 금리에 미칠 영향을 요약합니다.",
  "image_url": null
}
```

**수정 응답 200**
```json
{
  "data": {
    "financial_news_id": 1,
    "title": "예·적금 금리 비교 수요 증가…은행권 경쟁 격화",
    "summary": "기준금리 동결 결정의 배경과 예·적금, 대출 금리에 미칠 영향을 요약합니다.",
    "image_url": null,
    "source_name": "경제일보",
    "source_url": "https://example.com/source-news",
    "source_published_at": "2026-08-16T09:00:00",
    "published_at": "2026-08-17T09:00:00"
  }
}
```

**삭제 응답 200**
```json
{
  "data": {
    "financial_news_id": 1
  }
}
```

-----
## 관련 이슈

Closes #158 