### PR TITLE
feat: 뉴스레터 도메인·Mapper 기반 계층 구축 #170

### DIFF
--- a/src/main/java/org/firstfolio/newsletter/domain/Newsletter.java
+++ b/src/main/java/org/firstfolio/newsletter/domain/Newsletter.java
@@ -1,0 +1,147 @@
+package org.firstfolio.newsletter.domain;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class Newsletter {
+
+    private Long newsletterId;
+    private LocalDate weekStartDate;
+    private String headline;
+    private String financialWordsJson;
+    private String issuesJson;
+    private String statsJson;
+    private NewsletterStatus status;
+    private NewsletterGenerationType generationType;
+    private long createdBy;
+    private LocalDateTime publishedAt;
+    private LocalDateTime createdAt;
+
+    public Newsletter() {
+    }
+
+    /**
+     * AI 배치가 생성한 뉴스레터는 검수 없이 바로 노출되지 않으므로
+     * {@code REVIEW} 상태로 시작한다. {@code newsletters} 테이블은
+     * {@code DRAFT} 상태를 허용하지 않는다.
+     */
+    public static Newsletter review(
+            LocalDate weekStartDate,
+            String headline,
+            String financialWordsJson,
+            String issuesJson,
+            String statsJson,
+            NewsletterGenerationType generationType,
+            long createdBy,
+            LocalDateTime createdAt
+    ) {
+        Newsletter newsletter = new Newsletter();
+        newsletter.weekStartDate = weekStartDate;
+        newsletter.headline = headline;
+        newsletter.financialWordsJson = financialWordsJson;
+        newsletter.issuesJson = issuesJson;
+        newsletter.statsJson = statsJson;
+        newsletter.status = NewsletterStatus.REVIEW;
+        newsletter.generationType = generationType;
+        newsletter.createdBy = createdBy;
+        newsletter.createdAt = createdAt;
+        return newsletter;
+    }
+
+    public Long getNewsletterId() {
+        return newsletterId;
+    }
+
+    public void setNewsletterId(Long newsletterId) {
+        this.newsletterId = newsletterId;
+    }
+
+    public LocalDate getWeekStartDate() {
+        return weekStartDate;
+    }
+
+    public void setWeekStartDate(LocalDate weekStartDate) {
+        this.weekStartDate = weekStartDate;
+    }
+
+    public String getHeadline() {
+        return headline;
+    }
+
+    public void setHeadline(String headline) {
+        this.headline = headline;
+    }
+
+    public String getFinancialWordsJson() {
+        return financialWordsJson;
+    }
+
+    public void setFinancialWordsJson(String financialWordsJson) {
+        this.financialWordsJson = financialWordsJson;
+    }
+
+    public String getIssuesJson() {
+        return issuesJson;
+    }
+
+    public void setIssuesJson(String issuesJson) {
+        this.issuesJson = issuesJson;
+    }
+
+    public String getStatsJson() {
+        return statsJson;
+    }
+
+    public void setStatsJson(String statsJson) {
+        this.statsJson = statsJson;
+    }
+
+    public NewsletterStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(NewsletterStatus status) {
+        this.status = status;
+    }
+
+    public NewsletterGenerationType getGenerationType() {
+        return generationType;
+    }
+
+    public void setGenerationType(NewsletterGenerationType generationType) {
+        this.generationType = generationType;
+    }
+
+    public void publish(LocalDateTime publishedAt) {
+        this.status = NewsletterStatus.PUBLISHED;
+        this.publishedAt = publishedAt;
+    }
+
+    public void retire() {
+        this.status = NewsletterStatus.RETIRED;
+    }
+
+    public long getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(long createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public LocalDateTime getPublishedAt() {
+        return publishedAt;
+    }
+
+    public void setPublishedAt(LocalDateTime publishedAt) {
+        this.publishedAt = publishedAt;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/org/firstfolio/newsletter/domain/NewsletterGenerationType.java
+++ b/src/main/java/org/firstfolio/newsletter/domain/NewsletterGenerationType.java
@@ -1,0 +1,6 @@
+package org.firstfolio.newsletter.domain;
+
+public enum NewsletterGenerationType {
+    AI,
+    HUMAN
+}

--- a/src/main/java/org/firstfolio/newsletter/domain/NewsletterStatus.java
+++ b/src/main/java/org/firstfolio/newsletter/domain/NewsletterStatus.java
@@ -1,0 +1,7 @@
+package org.firstfolio.newsletter.domain;
+
+public enum NewsletterStatus {
+    REVIEW,
+    PUBLISHED,
+    RETIRED
+}

--- a/src/main/java/org/firstfolio/newsletter/mapper/NewsletterMapper.java
+++ b/src/main/java/org/firstfolio/newsletter/mapper/NewsletterMapper.java
@@ -1,0 +1,28 @@
+package org.firstfolio.newsletter.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.firstfolio.newsletter.domain.Newsletter;
+import org.firstfolio.newsletter.domain.NewsletterStatus;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Mapper
+public interface NewsletterMapper {
+
+    Newsletter findById(@Param("newsletterId") long newsletterId);
+
+    List<Newsletter> findByStatus(@Param("status") NewsletterStatus status);
+
+    List<Newsletter> findByWeekStartDate(@Param("weekStartDate") LocalDate weekStartDate);
+
+    int publishReview(
+            @Param("newsletterId") long newsletterId,
+            @Param("publishedAt") java.time.LocalDateTime publishedAt
+    );
+
+    int retirePublished(@Param("newsletterId") long newsletterId);
+
+    int insert(Newsletter newsletter);
+}

--- a/src/main/resources/mappers/newsletter/NewsletterMapper.xml
+++ b/src/main/resources/mappers/newsletter/NewsletterMapper.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.firstfolio.newsletter.mapper.NewsletterMapper">
+
+    <resultMap id="newsletterResultMap"
+               type="org.firstfolio.newsletter.domain.Newsletter">
+        <id property="newsletterId" column="newsletter_id" />
+        <result property="weekStartDate" column="week_start_date" />
+        <result property="headline" column="headline" />
+        <result property="financialWordsJson" column="financial_words_json" />
+        <result property="issuesJson" column="issues_json" />
+        <result property="statsJson" column="stats_json" />
+        <result property="status" column="status" />
+        <result property="generationType" column="generation_type" />
+        <result property="createdBy" column="created_by" />
+        <result property="publishedAt" column="published_at" />
+        <result property="createdAt" column="created_at" />
+    </resultMap>
+
+    <sql id="newsletterColumns">
+        newsletter_id,
+        week_start_date,
+        headline,
+        financial_words_json,
+        issues_json,
+        stats_json,
+        status,
+        generation_type,
+        created_by,
+        published_at,
+        created_at
+    </sql>
+
+    <select id="findById" resultMap="newsletterResultMap">
+        SELECT <include refid="newsletterColumns" />
+        FROM newsletters
+        WHERE newsletter_id = #{newsletterId}
+    </select>
+
+    <select id="findByStatus" resultMap="newsletterResultMap">
+        SELECT <include refid="newsletterColumns" />
+        FROM newsletters
+        WHERE status = #{status}
+        ORDER BY created_at DESC
+    </select>
+
+    <select id="findByWeekStartDate" resultMap="newsletterResultMap">
+        SELECT <include refid="newsletterColumns" />
+        FROM newsletters
+        WHERE week_start_date = #{weekStartDate}
+        ORDER BY created_at DESC
+    </select>
+
+    <update id="publishReview">
+        UPDATE newsletters
+        SET status = 'PUBLISHED',
+            published_at = #{publishedAt}
+        WHERE newsletter_id = #{newsletterId}
+          AND status = 'REVIEW'
+    </update>
+
+    <update id="retirePublished">
+        UPDATE newsletters
+        SET status = 'RETIRED'
+        WHERE newsletter_id = #{newsletterId}
+          AND status = 'PUBLISHED'
+    </update>
+
+    <insert id="insert"
+            parameterType="org.firstfolio.newsletter.domain.Newsletter"
+            useGeneratedKeys="true"
+            keyProperty="newsletterId"
+            keyColumn="newsletter_id">
+        INSERT INTO newsletters (
+            week_start_date,
+            headline,
+            financial_words_json,
+            issues_json,
+            stats_json,
+            status,
+            generation_type,
+            created_by,
+            published_at,
+            created_at
+        ) VALUES (
+            #{weekStartDate},
+            #{headline},
+            #{financialWordsJson},
+            #{issuesJson},
+            #{statsJson},
+            #{status},
+            #{generationType},
+            #{createdBy},
+            #{publishedAt,jdbcType=TIMESTAMP},
+            #{createdAt}
+        )
+    </insert>
+
+</mapper>

--- a/src/test/java/org/firstfolio/newsletter/domain/NewsletterTest.java
+++ b/src/test/java/org/firstfolio/newsletter/domain/NewsletterTest.java
@@ -1,0 +1,63 @@
+package org.firstfolio.newsletter.domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class NewsletterTest {
+
+    @Test
+    void reviewFactoryStartsInReviewStatusWithoutPublishedAt() {
+        Newsletter newsletter = Newsletter.review(
+                LocalDate.of(2026, 8, 17),
+                "역대 최대 흑자 속에서도, 돈은 안전자산으로",
+                "[]",
+                "[]",
+                "[]",
+                NewsletterGenerationType.AI,
+                1L,
+                LocalDateTime.of(2026, 8, 20, 9, 0)
+        );
+
+        assertEquals(NewsletterStatus.REVIEW, newsletter.getStatus());
+        assertNull(newsletter.getPublishedAt());
+    }
+
+    @Test
+    void publishSetsStatusAndPublishedAt() {
+        Newsletter newsletter = reviewSample();
+        LocalDateTime publishedAt = LocalDateTime.of(2026, 8, 20, 10, 0);
+
+        newsletter.publish(publishedAt);
+
+        assertEquals(NewsletterStatus.PUBLISHED, newsletter.getStatus());
+        assertEquals(publishedAt, newsletter.getPublishedAt());
+    }
+
+    @Test
+    void retireSetsStatusToRetired() {
+        Newsletter newsletter = reviewSample();
+        newsletter.publish(LocalDateTime.of(2026, 8, 20, 10, 0));
+
+        newsletter.retire();
+
+        assertEquals(NewsletterStatus.RETIRED, newsletter.getStatus());
+    }
+
+    private Newsletter reviewSample() {
+        return Newsletter.review(
+                LocalDate.of(2026, 8, 17),
+                "역대 최대 흑자 속에서도, 돈은 안전자산으로",
+                "[]",
+                "[]",
+                "[]",
+                NewsletterGenerationType.AI,
+                1L,
+                LocalDateTime.of(2026, 8, 20, 9, 0)
+        );
+    }
+}

--- a/src/test/java/org/firstfolio/newsletter/mapper/NewsletterMapperXmlTest.java
+++ b/src/test/java/org/firstfolio/newsletter/mapper/NewsletterMapperXmlTest.java
@@ -1,0 +1,103 @@
+package org.firstfolio.newsletter.mapper;
+
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.mapping.BoundSql;
+import org.apache.ibatis.session.Configuration;
+import org.firstfolio.newsletter.domain.Newsletter;
+import org.firstfolio.newsletter.domain.NewsletterGenerationType;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NewsletterMapperXmlTest {
+
+    private static final String RESOURCE = "mappers/newsletter/NewsletterMapper.xml";
+
+    @Test
+    void parsesAllStatements() throws IOException {
+        Configuration configuration = new Configuration();
+
+        try (InputStream input = Resources.getResourceAsStream(RESOURCE)) {
+            XMLMapperBuilder builder = new XMLMapperBuilder(
+                    input,
+                    configuration,
+                    RESOURCE,
+                    configuration.getSqlFragments()
+            );
+            builder.parse();
+        }
+
+        assertTrue(configuration.hasMapper(NewsletterMapper.class));
+        assertTrue(configuration.hasStatement(
+                NewsletterMapper.class.getName() + ".findById"
+        ));
+        assertTrue(configuration.hasStatement(
+                NewsletterMapper.class.getName() + ".findByStatus"
+        ));
+        assertTrue(configuration.hasStatement(
+                NewsletterMapper.class.getName() + ".findByWeekStartDate"
+        ));
+        assertTrue(configuration.hasStatement(
+                NewsletterMapper.class.getName() + ".publishReview"
+        ));
+        assertTrue(configuration.hasStatement(
+                NewsletterMapper.class.getName() + ".retirePublished"
+        ));
+        assertTrue(configuration.hasStatement(
+                NewsletterMapper.class.getName() + ".insert"
+        ));
+
+        Map<String, Object> publishParams = new HashMap<>();
+        publishParams.put("newsletterId", 1L);
+        publishParams.put("publishedAt", LocalDateTime.now());
+        BoundSql publishSql = configuration.getMappedStatement(
+                        NewsletterMapper.class.getName() + ".publishReview"
+                )
+                .getBoundSql(publishParams);
+        String normalizedPublish = normalize(publishSql.getSql());
+        assertTrue(normalizedPublish.contains("UPDATE newsletters"));
+        assertTrue(normalizedPublish.contains("status = 'PUBLISHED'"));
+        assertTrue(normalizedPublish.contains("status = 'REVIEW'"));
+
+        BoundSql retireSql = configuration.getMappedStatement(
+                        NewsletterMapper.class.getName() + ".retirePublished"
+                )
+                .getBoundSql(1L);
+        String normalizedRetire = normalize(retireSql.getSql());
+        assertTrue(normalizedRetire.contains("UPDATE newsletters"));
+        assertTrue(normalizedRetire.contains("status = 'RETIRED'"));
+        assertTrue(normalizedRetire.contains("status = 'PUBLISHED'"));
+
+        BoundSql insertSql = configuration.getMappedStatement(
+                        NewsletterMapper.class.getName() + ".insert"
+                )
+                .getBoundSql(sampleNewsletter());
+        String normalizedInsert = normalize(insertSql.getSql());
+        assertTrue(normalizedInsert.contains("INSERT INTO newsletters"));
+    }
+
+    private String normalize(String sql) {
+        return sql.replaceAll("\\s+", " ").trim();
+    }
+
+    private Newsletter sampleNewsletter() {
+        return Newsletter.review(
+                LocalDate.of(2026, 8, 17),
+                "역대 최대 흑자 속에서도, 돈은 안전자산으로",
+                "[]",
+                "[]",
+                "[]",
+                NewsletterGenerationType.AI,
+                1L,
+                LocalDateTime.of(2026, 8, 20, 9, 0)
+        );
+    }
+}


### PR DESCRIPTION
## 작업 내용
- `newsletters` 테이블(V7)을 다루는 도메인·Mapper 계층 신규 구축
- `org.firstfolio.newsletter` 패키지 신설 (기존 `org.firstfolio.news` 구조 그대로 따름)
- `Newsletter.review()` 팩토리 — 테이블에 DRAFT 상태가 없어서 퀴즈의 `draft()`와 다르게 바로 REVIEW로 시작
- `NewsletterMapper`: insert, findById, findByStatus, findByWeekStartDate, publishReview, retirePublished

## 테스트
- [x] `NewsletterTest` — review 팩토리, publish/retire 상태 전이 검증
- [x] `NewsletterMapperXmlTest` — XML 파싱, insert/publishReview/retirePublished SQL 검증 (news 패키지 테스트 패턴)
- [x] `./gradlew clean test` 전체 통과, 회귀 없음