### PR TITLE
feat: 뉴스레터 내부 수신 API 구현 #171

### DIFF
--- a/src/main/java/org/firstfolio/newsletter/controller/InternalNewsletterController.java
+++ b/src/main/java/org/firstfolio/newsletter/controller/InternalNewsletterController.java
@@ -1,0 +1,58 @@
+package org.firstfolio.newsletter.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.firstfolio.common.response.ApiResponse;
+import org.firstfolio.newsletter.domain.Newsletter;
+import org.firstfolio.newsletter.dto.request.NewsletterCreateRequest;
+import org.firstfolio.newsletter.dto.response.NewsletterCreateResponse;
+import org.firstfolio.newsletter.service.NewsletterCreateService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 내부 뉴스레터 등록 API.
+ *
+ * <p>내부 호출 검증은 {@code ServletConfig}의 경로 인터셉터가 담당한다
+ * ({@code /api/internal/**} → {@code X-Internal-Token}). AI 배치가 주 1회
+ * 생성한 뉴스레터 한 건을 등록하는 용도라 퀴즈 배치처럼 여러 건을 묶지 않는다.</p>
+ */
+@RestController
+@RequestMapping("/api/internal/newsletters")
+@Tag(name = "내부 뉴스레터", description = "내부 호출용 주간 뉴스레터 등록 API")
+public class InternalNewsletterController {
+
+    private final NewsletterCreateService newsletterCreateService;
+
+    public InternalNewsletterController(NewsletterCreateService newsletterCreateService) {
+        this.newsletterCreateService = newsletterCreateService;
+    }
+
+    @PostMapping
+    @Operation(
+            summary = "주간 뉴스레터 등록",
+            description = "AI가 생성한 주간 뉴스레터 한 건을 등록합니다. status는 REVIEW로 저장됩니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200", description = "뉴스레터 등록 성공"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "400", description = "INVALID_REQUEST - 필수 필드 누락 또는 형식 오류"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "403", description = "INTERNAL_CALL_REQUIRED - 내부 호출 토큰이 없거나 올바르지 않음"
+                    )
+            }
+    )
+    public ApiResponse<NewsletterCreateResponse> create(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true, description = "등록할 주간 뉴스레터 한 건"
+            )
+            @RequestBody NewsletterCreateRequest request
+    ) {
+        Newsletter newsletter = newsletterCreateService.create(request);
+        return ApiResponse.of(NewsletterCreateResponse.from(newsletter));
+    }
+}

--- a/src/main/java/org/firstfolio/newsletter/dto/request/FinancialWordRequest.java
+++ b/src/main/java/org/firstfolio/newsletter/dto/request/FinancialWordRequest.java
@@ -1,0 +1,7 @@
+package org.firstfolio.newsletter.dto.request;
+
+public record FinancialWordRequest(
+        String term,
+        String definition
+) {
+}

--- a/src/main/java/org/firstfolio/newsletter/dto/request/NewsletterCreateRequest.java
+++ b/src/main/java/org/firstfolio/newsletter/dto/request/NewsletterCreateRequest.java
@@ -1,0 +1,19 @@
+package org.firstfolio.newsletter.dto.request;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 내부 뉴스레터 등록 요청 ({@code POST /api/internal/newsletters}).
+ *
+ * <p>{@code financialWordsJson}·{@code issuesJson}·{@code statsJson}은 각각
+ * 정확히 3개여야 한다 ({@code NewsletterCreateService} 검증).</p>
+ */
+public record NewsletterCreateRequest(
+        LocalDate weekStartDate,
+        String headline,
+        List<FinancialWordRequest> financialWordsJson,
+        List<NewsletterIssueRequest> issuesJson,
+        List<NewsletterStatRequest> statsJson
+) {
+}

--- a/src/main/java/org/firstfolio/newsletter/dto/request/NewsletterIssueRequest.java
+++ b/src/main/java/org/firstfolio/newsletter/dto/request/NewsletterIssueRequest.java
@@ -1,0 +1,11 @@
+package org.firstfolio.newsletter.dto.request;
+
+import java.util.List;
+
+public record NewsletterIssueRequest(
+        String title,
+        String summary,
+        String relatedTerm,
+        List<NewsletterSourceRequest> sources
+) {
+}

--- a/src/main/java/org/firstfolio/newsletter/dto/request/NewsletterSourceRequest.java
+++ b/src/main/java/org/firstfolio/newsletter/dto/request/NewsletterSourceRequest.java
@@ -1,0 +1,9 @@
+package org.firstfolio.newsletter.dto.request;
+
+public record NewsletterSourceRequest(
+        Long documentId,
+        String chunkKey,
+        String sourceUrl,
+        String evidenceText
+) {
+}

--- a/src/main/java/org/firstfolio/newsletter/dto/request/NewsletterStatRequest.java
+++ b/src/main/java/org/firstfolio/newsletter/dto/request/NewsletterStatRequest.java
@@ -1,0 +1,7 @@
+package org.firstfolio.newsletter.dto.request;
+
+public record NewsletterStatRequest(
+        String label,
+        String value
+) {
+}

--- a/src/main/java/org/firstfolio/newsletter/dto/response/NewsletterCreateResponse.java
+++ b/src/main/java/org/firstfolio/newsletter/dto/response/NewsletterCreateResponse.java
@@ -1,0 +1,19 @@
+package org.firstfolio.newsletter.dto.response;
+
+import org.firstfolio.newsletter.domain.Newsletter;
+
+import java.time.LocalDate;
+
+public record NewsletterCreateResponse(
+        Long newsletterId,
+        LocalDate weekStartDate,
+        String status
+) {
+    public static NewsletterCreateResponse from(Newsletter newsletter) {
+        return new NewsletterCreateResponse(
+                newsletter.getNewsletterId(),
+                newsletter.getWeekStartDate(),
+                newsletter.getStatus().name()
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/newsletter/service/NewsletterCreateService.java
+++ b/src/main/java/org/firstfolio/newsletter/service/NewsletterCreateService.java
@@ -1,0 +1,168 @@
+package org.firstfolio.newsletter.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.firstfolio.common.json.ApiObjectMapperFactory;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.newsletter.domain.Newsletter;
+import org.firstfolio.newsletter.domain.NewsletterGenerationType;
+import org.firstfolio.newsletter.dto.request.FinancialWordRequest;
+import org.firstfolio.newsletter.dto.request.NewsletterCreateRequest;
+import org.firstfolio.newsletter.dto.request.NewsletterIssueRequest;
+import org.firstfolio.newsletter.dto.request.NewsletterStatRequest;
+import org.firstfolio.newsletter.mapper.NewsletterMapper;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * AI 배치 전용 시스템 사용자 ID({@code newsletter.batch.ai-created-by})는 관리자 계정이
+ * 정해지기 전까지 비어 있을 수 있다. 호출 시점에 읽어서, 값이 없어도 서버 기동 자체는
+ * 막지 않는다 ({@code QuizQuestionBatchWriter}와 동일한 이유).
+ */
+@Service
+public class NewsletterCreateService {
+
+    private static final String AI_CREATED_BY_PROPERTY = "newsletter.batch.ai-created-by";
+    private static final int REQUIRED_SECTION_SIZE = 3;
+
+    private final NewsletterMapper newsletterMapper;
+    private final Environment environment;
+    private final Clock clock;
+    private final ObjectMapper objectMapper = ApiObjectMapperFactory.create();
+
+    public NewsletterCreateService(
+            NewsletterMapper newsletterMapper,
+            Environment environment,
+            Clock clock
+    ) {
+        this.newsletterMapper = newsletterMapper;
+        this.environment = environment;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public Newsletter create(NewsletterCreateRequest request) {
+        validate(request);
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        Newsletter newsletter = Newsletter.review(
+                request.weekStartDate(),
+                request.headline(),
+                toJson(request.financialWordsJson()),
+                toJson(request.issuesJson()),
+                toJson(request.statsJson()),
+                NewsletterGenerationType.AI,
+                resolveAiCreatedBy(),
+                now
+        );
+
+        if (newsletterMapper.insert(newsletter) != 1 || newsletter.getNewsletterId() == null) {
+            throw new ApiException(ErrorCode.INTERNAL_ERROR);
+        }
+
+        return newsletter;
+    }
+
+    private void validate(NewsletterCreateRequest request) {
+        if (request.weekStartDate() == null) {
+            throw new ApiException(ErrorCode.INVALID_REQUEST, "week_start_date는 필수입니다.");
+        }
+        if (request.weekStartDate().getDayOfWeek() != DayOfWeek.MONDAY) {
+            throw new ApiException(ErrorCode.INVALID_REQUEST, "week_start_date는 월요일이어야 합니다.");
+        }
+        if (isBlank(request.headline())) {
+            throw new ApiException(ErrorCode.INVALID_REQUEST, "headline은 비어 있을 수 없습니다.");
+        }
+        validateFinancialWords(request.financialWordsJson());
+        validateIssues(request.issuesJson());
+        validateStats(request.statsJson());
+    }
+
+    private void validateFinancialWords(List<FinancialWordRequest> financialWords) {
+        requireExactSize(financialWords, "financial_words_json");
+        for (FinancialWordRequest word : financialWords) {
+            if (isBlank(word.term()) || isBlank(word.definition())) {
+                throw new ApiException(
+                        ErrorCode.INVALID_REQUEST,
+                        "financial_words_json의 term, definition은 비어 있을 수 없습니다."
+                );
+            }
+        }
+    }
+
+    private void validateIssues(List<NewsletterIssueRequest> issues) {
+        requireExactSize(issues, "issues_json");
+        for (NewsletterIssueRequest issue : issues) {
+            if (isBlank(issue.title()) || isBlank(issue.summary()) || isBlank(issue.relatedTerm())) {
+                throw new ApiException(
+                        ErrorCode.INVALID_REQUEST,
+                        "issues_json의 title, summary, related_term은 비어 있을 수 없습니다."
+                );
+            }
+            if (issue.sources() == null || issue.sources().isEmpty()) {
+                throw new ApiException(
+                        ErrorCode.INVALID_REQUEST,
+                        "issues_json 각 항목의 sources는 비어 있을 수 없습니다."
+                );
+            }
+        }
+    }
+
+    private void validateStats(List<NewsletterStatRequest> stats) {
+        requireExactSize(stats, "stats_json");
+        for (NewsletterStatRequest stat : stats) {
+            if (isBlank(stat.label()) || isBlank(stat.value())) {
+                throw new ApiException(
+                        ErrorCode.INVALID_REQUEST,
+                        "stats_json의 label, value는 비어 있을 수 없습니다."
+                );
+            }
+        }
+    }
+
+    private void requireExactSize(List<?> items, String fieldName) {
+        if (items == null || items.size() != REQUIRED_SECTION_SIZE) {
+            throw new ApiException(
+                    ErrorCode.INVALID_REQUEST,
+                    fieldName + "은(는) 정확히 " + REQUIRED_SECTION_SIZE + "개여야 합니다."
+            );
+        }
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private long resolveAiCreatedBy() {
+        String value = environment.getProperty(AI_CREATED_BY_PROPERTY);
+        if (value == null || value.isBlank()) {
+            throw new ApiException(
+                    ErrorCode.INTERNAL_ERROR,
+                    AI_CREATED_BY_PROPERTY + " 설정이 없어 뉴스레터를 저장할 수 없습니다."
+            );
+        }
+        try {
+            return Long.parseLong(value.trim());
+        } catch (NumberFormatException exception) {
+            throw new ApiException(
+                    ErrorCode.INTERNAL_ERROR,
+                    AI_CREATED_BY_PROPERTY + " 값이 올바른 사용자 ID가 아닙니다: " + value
+            );
+        }
+    }
+
+    private String toJson(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("뉴스레터 JSON을 직렬화할 수 없습니다.", exception);
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -49,6 +49,7 @@ trade.policy.interest-income-tax-rate=${TRADE_INTEREST_INCOME_TAX_RATE:0.154}
 internal.call-token=${INTERNAL_CALL_TOKEN:}
 
 quiz.batch.ai-created-by=${QUIZ_BATCH_AI_CREATED_BY:}
+newsletter.batch.ai-created-by=${NEWSLETTER_BATCH_AI_CREATED_BY:}
 
 cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://127.0.0.1:5173}
 

--- a/src/test/java/org/firstfolio/newsletter/service/NewsletterCreateServiceTest.java
+++ b/src/test/java/org/firstfolio/newsletter/service/NewsletterCreateServiceTest.java
@@ -1,0 +1,185 @@
+package org.firstfolio.newsletter.service;
+
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.newsletter.domain.Newsletter;
+import org.firstfolio.newsletter.domain.NewsletterGenerationType;
+import org.firstfolio.newsletter.domain.NewsletterStatus;
+import org.firstfolio.newsletter.dto.request.FinancialWordRequest;
+import org.firstfolio.newsletter.dto.request.NewsletterCreateRequest;
+import org.firstfolio.newsletter.dto.request.NewsletterIssueRequest;
+import org.firstfolio.newsletter.dto.request.NewsletterSourceRequest;
+import org.firstfolio.newsletter.dto.request.NewsletterStatRequest;
+import org.firstfolio.newsletter.mapper.NewsletterMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.core.env.Environment;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class NewsletterCreateServiceTest {
+
+    private static final LocalDate MONDAY = LocalDate.of(2026, 8, 17);
+
+    private NewsletterMapper newsletterMapper;
+    private Environment environment;
+    private NewsletterCreateService service;
+
+    @BeforeEach
+    void setUp() {
+        newsletterMapper = mock(NewsletterMapper.class);
+        environment = mock(Environment.class);
+        when(environment.getProperty("newsletter.batch.ai-created-by")).thenReturn("1");
+        Clock clock = Clock.fixed(Instant.parse("2026-08-20T09:00:00Z"), ZoneOffset.UTC);
+        service = new NewsletterCreateService(newsletterMapper, environment, clock);
+
+        when(newsletterMapper.insert(any())).thenAnswer(invocation -> {
+            Newsletter newsletter = invocation.getArgument(0);
+            newsletter.setNewsletterId(1L);
+            return 1;
+        });
+    }
+
+    @Test
+    void createsNewsletterInReviewStatus() {
+        Newsletter created = service.create(validRequest());
+
+        assertEquals(NewsletterStatus.REVIEW, created.getStatus());
+        assertEquals(NewsletterGenerationType.AI, created.getGenerationType());
+        assertEquals(1L, created.getNewsletterId());
+        assertEquals(MONDAY, created.getWeekStartDate());
+
+        ArgumentCaptor<Newsletter> captor = ArgumentCaptor.forClass(Newsletter.class);
+        verify(newsletterMapper).insert(captor.capture());
+        assertTrue(captor.getValue().getFinancialWordsJson().contains("요구불예금"));
+    }
+
+    @Test
+    void rejectsWeekStartDateNotMonday() {
+        NewsletterCreateRequest request = new NewsletterCreateRequest(
+                LocalDate.of(2026, 8, 18),
+                "대제목",
+                validFinancialWords(),
+                validIssues(),
+                validStats()
+        );
+
+        ApiException exception = assertThrows(ApiException.class, () -> service.create(request));
+        assertEquals(ErrorCode.INVALID_REQUEST, exception.getErrorCode());
+    }
+
+    @Test
+    void rejectsBlankHeadline() {
+        NewsletterCreateRequest request = new NewsletterCreateRequest(
+                MONDAY, "  ", validFinancialWords(), validIssues(), validStats()
+        );
+
+        assertThrows(ApiException.class, () -> service.create(request));
+    }
+
+    @Test
+    void rejectsFinancialWordsWithWrongSize() {
+        NewsletterCreateRequest request = new NewsletterCreateRequest(
+                MONDAY,
+                "대제목",
+                List.of(new FinancialWordRequest("요구불예금", "정의")),
+                validIssues(),
+                validStats()
+        );
+
+        ApiException exception = assertThrows(ApiException.class, () -> service.create(request));
+        assertEquals(ErrorCode.INVALID_REQUEST, exception.getErrorCode());
+    }
+
+    @Test
+    void rejectsIssueWithoutSources() {
+        NewsletterCreateRequest request = new NewsletterCreateRequest(
+                MONDAY,
+                "대제목",
+                validFinancialWords(),
+                List.of(
+                        new NewsletterIssueRequest("제목1", "요약1", "요구불예금", List.of()),
+                        new NewsletterIssueRequest("제목2", "요약2", "경상수지", validSources()),
+                        new NewsletterIssueRequest("제목3", "요약3", "해지환급금", validSources())
+                ),
+                validStats()
+        );
+
+        assertThrows(ApiException.class, () -> service.create(request));
+    }
+
+    @Test
+    void rejectsStatsWithBlankValue() {
+        NewsletterCreateRequest request = new NewsletterCreateRequest(
+                MONDAY,
+                "대제목",
+                validFinancialWords(),
+                validIssues(),
+                List.of(
+                        new NewsletterStatRequest("라벨1", ""),
+                        new NewsletterStatRequest("라벨2", "값2"),
+                        new NewsletterStatRequest("라벨3", "값3")
+                )
+        );
+
+        assertThrows(ApiException.class, () -> service.create(request));
+    }
+
+    @Test
+    void throwsWhenAiCreatedByPropertyMissing() {
+        when(environment.getProperty("newsletter.batch.ai-created-by")).thenReturn(null);
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.create(validRequest())
+        );
+        assertEquals(ErrorCode.INTERNAL_ERROR, exception.getErrorCode());
+    }
+
+    private NewsletterCreateRequest validRequest() {
+        return new NewsletterCreateRequest(
+                MONDAY, "대제목", validFinancialWords(), validIssues(), validStats()
+        );
+    }
+
+    private List<FinancialWordRequest> validFinancialWords() {
+        return List.of(
+                new FinancialWordRequest("요구불예금", "필요할 때 언제든 빼 쓸 수 있는 예금"),
+                new FinancialWordRequest("경상수지", "나라가 외국과 주고받은 돈의 성적표"),
+                new FinancialWordRequest("해지환급금", "보험을 중간에 깨면 돌려받는 돈")
+        );
+    }
+
+    private List<NewsletterIssueRequest> validIssues() {
+        return List.of(
+                new NewsletterIssueRequest("이슈1", "요약1", "요구불예금", validSources()),
+                new NewsletterIssueRequest("이슈2", "요약2", "경상수지", validSources()),
+                new NewsletterIssueRequest("이슈3", "요약3", "해지환급금", validSources())
+        );
+    }
+
+    private List<NewsletterSourceRequest> validSources() {
+        return List.of(new NewsletterSourceRequest(1L, "1:0", "https://example.com", "근거 문장"));
+    }
+
+    private List<NewsletterStatRequest> validStats() {
+        return List.of(
+                new NewsletterStatRequest("라벨1", "값1"),
+                new NewsletterStatRequest("라벨2", "값2"),
+                new NewsletterStatRequest("라벨3", "값3")
+        );
+    }
+}


### PR DESCRIPTION
## 작업내용
- AI가 생성한 주간 뉴스레터를 등록받는 내부 API 신규 구현
- `POST /api/internal/newsletters` — 기존 `/api/internal/news`와 동일한 인증(X-Internal-Token) · 단일 리소스 생성 패턴
- 페이로드 검증: `financial_words_json`/`issues_json`/`stats_json` 각각 정확히 3개, `week_start_date`는 월요일, 각 이슈의 `sources`는 비어있으면 안 됨
- `newsletter.batch.ai-created-by` 설정 추가 (퀴즈의 `quiz.batch.ai-created-by`와 동일한 지연 검증 패턴)

## 테스트
- [x] `NewsletterCreateServiceTest` 7개 — 정상 생성, 월요일 검증, 헤드라인 공백, 섹션 개수 불일치, sources 누락, stats 공백값, ai-created-by 미설정 케이스
- [x] `./gradlew clean test` 전체 통과, 회귀 없음