### PR TITLE
feat: 뉴스레터 관리자 검수 API 구현 #172

### DIFF
--- a/src/main/java/org/firstfolio/exception/ErrorCode.java
+++ b/src/main/java/org/firstfolio/exception/ErrorCode.java
@@ -124,6 +124,11 @@ public enum ErrorCode {
     // 금융 뉴스 스크랩
     FINANCIAL_NEWS_NOT_FOUND(HttpStatus.NOT_FOUND, "금융 뉴스를 찾을 수 없습니다."),
 
+    // 주간 뉴스레터
+    NEWSLETTER_NOT_FOUND(HttpStatus.NOT_FOUND, "뉴스레터를 찾을 수 없습니다."),
+    NEWSLETTER_NOT_PUBLISHABLE(HttpStatus.CONFLICT, "공개할 수 없는 뉴스레터입니다."),
+    NEWSLETTER_NOT_RETIRABLE(HttpStatus.CONFLICT, "폐기할 수 없는 뉴스레터입니다."),
+
     // 내부 배치 (FUNC-040, 041, 042)
     INTERNAL_CALL_REQUIRED(HttpStatus.FORBIDDEN, "허용된 내부 호출이 아닙니다."),
     PRICE_POLICY_INVALID(HttpStatus.UNPROCESSABLE_ENTITY, "가격 생성 정책 또는 상품 조건이 올바르지 않습니다."),

--- a/src/main/java/org/firstfolio/newsletter/controller/AdminNewsletterController.java
+++ b/src/main/java/org/firstfolio/newsletter/controller/AdminNewsletterController.java
@@ -1,0 +1,142 @@
+package org.firstfolio.newsletter.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.firstfolio.auth.annotation.CurrentUser;
+import org.firstfolio.auth.domain.AuthenticatedUser;
+import org.firstfolio.common.response.ApiResponse;
+import org.firstfolio.common.web.RequestIdFilter;
+import org.firstfolio.newsletter.domain.NewsletterStatus;
+import org.firstfolio.newsletter.dto.response.NewsletterDetailResponse;
+import org.firstfolio.newsletter.dto.response.NewsletterListResponse;
+import org.firstfolio.newsletter.dto.response.NewsletterStatusResponse;
+import org.firstfolio.newsletter.service.NewsletterPublicationService;
+import org.firstfolio.newsletter.service.NewsletterQueryService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequestMapping("/api/admin/newsletters")
+@Tag(name = "관리자 뉴스레터", description = "관리자용 주간 뉴스레터 검수·게시·비공개 API")
+public class AdminNewsletterController {
+
+    private final NewsletterQueryService queryService;
+    private final NewsletterPublicationService publicationService;
+
+    public AdminNewsletterController(
+            NewsletterQueryService queryService,
+            NewsletterPublicationService publicationService
+    ) {
+        this.queryService = queryService;
+        this.publicationService = publicationService;
+    }
+
+    @GetMapping
+    @Operation(
+            summary = "뉴스레터 목록 조회",
+            description = "상태별로 뉴스레터 목록을 최신순으로 조회합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200", description = "뉴스레터 목록 조회 성공"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "400", description = "INVALID_REQUEST - status 값이 올바르지 않음"
+                    )
+            }
+    )
+    public ApiResponse<NewsletterListResponse> findNewsletters(
+            @Parameter(description = "조회할 상태", example = "REVIEW", required = true)
+            @RequestParam("status") NewsletterStatus status
+    ) {
+        return ApiResponse.of(queryService.findByStatus(status));
+    }
+
+    @GetMapping("/{newsletterId}")
+    @Operation(
+            summary = "뉴스레터 상세 조회",
+            description = "대제목·금융단어·이슈·숫자를 포함한 뉴스레터 전체 내용을 조회합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200", description = "뉴스레터 상세 조회 성공"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "404", description = "NEWSLETTER_NOT_FOUND - 뉴스레터를 찾을 수 없음"
+                    )
+            }
+    )
+    public ApiResponse<NewsletterDetailResponse> findNewsletter(
+            @Parameter(description = "조회할 뉴스레터 ID", example = "1", required = true)
+            @PathVariable long newsletterId
+    ) {
+        return ApiResponse.of(queryService.findById(newsletterId));
+    }
+
+    @PostMapping("/{newsletterId}/publish")
+    @Operation(
+            summary = "뉴스레터 게시",
+            description = "REVIEW 상태의 뉴스레터를 PUBLISHED로 전환합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200", description = "뉴스레터 게시 성공"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "404", description = "NEWSLETTER_NOT_FOUND - 뉴스레터를 찾을 수 없음"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "409", description = "NEWSLETTER_NOT_PUBLISHABLE - REVIEW 상태가 아니어서 게시할 수 없음"
+                    )
+            }
+    )
+    public ApiResponse<NewsletterStatusResponse> publishNewsletter(
+            @Parameter(description = "게시할 뉴스레터 ID", example = "1", required = true)
+            @PathVariable long newsletterId,
+            @CurrentUser AuthenticatedUser currentUser,
+            HttpServletRequest servletRequest
+    ) {
+        return ApiResponse.of(NewsletterStatusResponse.from(
+                publicationService.publish(
+                        newsletterId,
+                        currentUser.userId(),
+                        RequestIdFilter.currentRequestId(servletRequest)
+                )
+        ));
+    }
+
+    @PostMapping("/{newsletterId}/retire")
+    @Operation(
+            summary = "뉴스레터 비공개 전환",
+            description = "PUBLISHED 상태의 뉴스레터를 RETIRED로 전환합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200", description = "뉴스레터 비공개 전환 성공"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "404", description = "NEWSLETTER_NOT_FOUND - 뉴스레터를 찾을 수 없음"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "409", description = "NEWSLETTER_NOT_RETIRABLE - 공개 상태가 아닌 뉴스레터"
+                    )
+            }
+    )
+    public ApiResponse<NewsletterStatusResponse> retireNewsletter(
+            @Parameter(description = "비공개할 뉴스레터 ID", example = "1", required = true)
+            @PathVariable long newsletterId,
+            @CurrentUser AuthenticatedUser currentUser,
+            HttpServletRequest servletRequest
+    ) {
+        return ApiResponse.of(NewsletterStatusResponse.from(
+                publicationService.retire(
+                        newsletterId,
+                        currentUser.userId(),
+                        RequestIdFilter.currentRequestId(servletRequest)
+                )
+        ));
+    }
+}

--- a/src/main/java/org/firstfolio/newsletter/dto/response/FinancialWordResponse.java
+++ b/src/main/java/org/firstfolio/newsletter/dto/response/FinancialWordResponse.java
@@ -1,0 +1,7 @@
+package org.firstfolio.newsletter.dto.response;
+
+public record FinancialWordResponse(
+        String term,
+        String definition
+) {
+}

--- a/src/main/java/org/firstfolio/newsletter/dto/response/NewsletterDetailResponse.java
+++ b/src/main/java/org/firstfolio/newsletter/dto/response/NewsletterDetailResponse.java
@@ -1,0 +1,47 @@
+package org.firstfolio.newsletter.dto.response;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.firstfolio.newsletter.domain.Newsletter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record NewsletterDetailResponse(
+        Long newsletterId,
+        LocalDate weekStartDate,
+        String headline,
+        List<FinancialWordResponse> financialWordsJson,
+        List<NewsletterIssueResponse> issuesJson,
+        List<NewsletterStatResponse> statsJson,
+        String status,
+        String generationType,
+        LocalDateTime publishedAt,
+        LocalDateTime createdAt
+) {
+
+    public static NewsletterDetailResponse from(Newsletter newsletter, ObjectMapper objectMapper) {
+        return new NewsletterDetailResponse(
+                newsletter.getNewsletterId(),
+                newsletter.getWeekStartDate(),
+                newsletter.getHeadline(),
+                readList(objectMapper, newsletter.getFinancialWordsJson(), FinancialWordResponse[].class),
+                readList(objectMapper, newsletter.getIssuesJson(), NewsletterIssueResponse[].class),
+                readList(objectMapper, newsletter.getStatsJson(), NewsletterStatResponse[].class),
+                newsletter.getStatus().name(),
+                newsletter.getGenerationType().name(),
+                newsletter.getPublishedAt(),
+                newsletter.getCreatedAt()
+        );
+    }
+
+    private static <T> List<T> readList(ObjectMapper objectMapper, String json, Class<T[]> arrayType) {
+        try {
+            T[] items = objectMapper.readValue(json, arrayType);
+            return List.of(items);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("저장된 뉴스레터 JSON을 읽을 수 없습니다.", exception);
+        }
+    }
+}

--- a/src/main/java/org/firstfolio/newsletter/dto/response/NewsletterIssueResponse.java
+++ b/src/main/java/org/firstfolio/newsletter/dto/response/NewsletterIssueResponse.java
@@ -1,0 +1,11 @@
+package org.firstfolio.newsletter.dto.response;
+
+import java.util.List;
+
+public record NewsletterIssueResponse(
+        String title,
+        String summary,
+        String relatedTerm,
+        List<NewsletterSourceResponse> sources
+) {
+}

--- a/src/main/java/org/firstfolio/newsletter/dto/response/NewsletterListResponse.java
+++ b/src/main/java/org/firstfolio/newsletter/dto/response/NewsletterListResponse.java
@@ -1,0 +1,8 @@
+package org.firstfolio.newsletter.dto.response;
+
+import java.util.List;
+
+public record NewsletterListResponse(
+        List<NewsletterDetailResponse> items
+) {
+}

--- a/src/main/java/org/firstfolio/newsletter/dto/response/NewsletterSourceResponse.java
+++ b/src/main/java/org/firstfolio/newsletter/dto/response/NewsletterSourceResponse.java
@@ -1,0 +1,9 @@
+package org.firstfolio.newsletter.dto.response;
+
+public record NewsletterSourceResponse(
+        Long documentId,
+        String chunkKey,
+        String sourceUrl,
+        String evidenceText
+) {
+}

--- a/src/main/java/org/firstfolio/newsletter/dto/response/NewsletterStatResponse.java
+++ b/src/main/java/org/firstfolio/newsletter/dto/response/NewsletterStatResponse.java
@@ -1,0 +1,7 @@
+package org.firstfolio.newsletter.dto.response;
+
+public record NewsletterStatResponse(
+        String label,
+        String value
+) {
+}

--- a/src/main/java/org/firstfolio/newsletter/dto/response/NewsletterStatusResponse.java
+++ b/src/main/java/org/firstfolio/newsletter/dto/response/NewsletterStatusResponse.java
@@ -1,0 +1,23 @@
+package org.firstfolio.newsletter.dto.response;
+
+import org.firstfolio.newsletter.domain.Newsletter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record NewsletterStatusResponse(
+        Long newsletterId,
+        LocalDate weekStartDate,
+        String status,
+        LocalDateTime publishedAt
+) {
+
+    public static NewsletterStatusResponse from(Newsletter newsletter) {
+        return new NewsletterStatusResponse(
+                newsletter.getNewsletterId(),
+                newsletter.getWeekStartDate(),
+                newsletter.getStatus().name(),
+                newsletter.getPublishedAt()
+        );
+    }
+}

--- a/src/main/java/org/firstfolio/newsletter/mapper/NewsletterMapper.java
+++ b/src/main/java/org/firstfolio/newsletter/mapper/NewsletterMapper.java
@@ -13,6 +13,8 @@ public interface NewsletterMapper {
 
     Newsletter findById(@Param("newsletterId") long newsletterId);
 
+    Newsletter findByIdForUpdate(@Param("newsletterId") long newsletterId);
+
     List<Newsletter> findByStatus(@Param("status") NewsletterStatus status);
 
     List<Newsletter> findByWeekStartDate(@Param("weekStartDate") LocalDate weekStartDate);

--- a/src/main/java/org/firstfolio/newsletter/service/NewsletterPublicationService.java
+++ b/src/main/java/org/firstfolio/newsletter/service/NewsletterPublicationService.java
@@ -1,0 +1,119 @@
+package org.firstfolio.newsletter.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.firstfolio.common.json.ApiObjectMapperFactory;
+import org.firstfolio.curriculum.mapper.AdminAuditLogMapper;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.newsletter.domain.Newsletter;
+import org.firstfolio.newsletter.domain.NewsletterStatus;
+import org.firstfolio.newsletter.mapper.NewsletterMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Service
+public class NewsletterPublicationService {
+
+    private static final String AUDIT_ENTITY_TYPE = "NEWSLETTER";
+
+    private final NewsletterMapper newsletterMapper;
+    private final AdminAuditLogMapper auditLogMapper;
+    private final Clock clock;
+    private final ObjectMapper objectMapper = ApiObjectMapperFactory.create();
+
+    public NewsletterPublicationService(
+            NewsletterMapper newsletterMapper,
+            AdminAuditLogMapper auditLogMapper,
+            Clock clock
+    ) {
+        this.newsletterMapper = newsletterMapper;
+        this.auditLogMapper = auditLogMapper;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public Newsletter publish(long newsletterId, long actorUserId, String requestId) {
+        Newsletter target = newsletterMapper.findByIdForUpdate(newsletterId);
+        if (target == null) {
+            throw new ApiException(ErrorCode.NEWSLETTER_NOT_FOUND);
+        }
+        if (target.getStatus() != NewsletterStatus.REVIEW) {
+            throw new ApiException(ErrorCode.NEWSLETTER_NOT_PUBLISHABLE);
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        String before = snapshot(target);
+        if (newsletterMapper.publishReview(newsletterId, now) != 1) {
+            throw new ApiException(ErrorCode.NEWSLETTER_NOT_PUBLISHABLE);
+        }
+        target.publish(now);
+        insertAuditLog(actorUserId, "PUBLISH", target, before, requestId, now);
+        return target;
+    }
+
+    @Transactional
+    public Newsletter retire(long newsletterId, long actorUserId, String requestId) {
+        Newsletter target = newsletterMapper.findByIdForUpdate(newsletterId);
+        if (target == null) {
+            throw new ApiException(ErrorCode.NEWSLETTER_NOT_FOUND);
+        }
+        if (target.getStatus() != NewsletterStatus.PUBLISHED) {
+            throw new ApiException(ErrorCode.NEWSLETTER_NOT_RETIRABLE);
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        String before = snapshot(target);
+        if (newsletterMapper.retirePublished(newsletterId) != 1) {
+            throw new ApiException(ErrorCode.NEWSLETTER_NOT_RETIRABLE);
+        }
+        target.retire();
+        insertAuditLog(actorUserId, "RETIRE", target, before, requestId, now);
+        return target;
+    }
+
+    private void insertAuditLog(
+            long actorUserId,
+            String action,
+            Newsletter newsletter,
+            String before,
+            String requestId,
+            LocalDateTime now
+    ) {
+        if (auditLogMapper.insert(
+                actorUserId,
+                action,
+                AUDIT_ENTITY_TYPE,
+                newsletter.getNewsletterId(),
+                before,
+                snapshot(newsletter),
+                requestId,
+                now
+        ) != 1) {
+            throw new IllegalStateException("뉴스레터 상태 변경 감사 이력을 저장하지 못했습니다.");
+        }
+    }
+
+    private String snapshot(Newsletter newsletter) {
+        Map<String, Object> snapshot = new LinkedHashMap<>();
+        snapshot.put("newsletter_id", newsletter.getNewsletterId());
+        snapshot.put("week_start_date", newsletter.getWeekStartDate());
+        snapshot.put("headline", newsletter.getHeadline());
+        snapshot.put("status", newsletter.getStatus());
+        snapshot.put("generation_type", newsletter.getGenerationType());
+        snapshot.put("published_at", newsletter.getPublishedAt());
+        snapshot.put("created_by", newsletter.getCreatedBy());
+        snapshot.put("created_at", newsletter.getCreatedAt());
+
+        try {
+            return objectMapper.writeValueAsString(snapshot);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("뉴스레터 감사 이력을 직렬화할 수 없습니다.", exception);
+        }
+    }
+}

--- a/src/main/java/org/firstfolio/newsletter/service/NewsletterQueryService.java
+++ b/src/main/java/org/firstfolio/newsletter/service/NewsletterQueryService.java
@@ -1,0 +1,39 @@
+package org.firstfolio.newsletter.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.firstfolio.common.json.ApiObjectMapperFactory;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.newsletter.domain.Newsletter;
+import org.firstfolio.newsletter.domain.NewsletterStatus;
+import org.firstfolio.newsletter.dto.response.NewsletterDetailResponse;
+import org.firstfolio.newsletter.dto.response.NewsletterListResponse;
+import org.firstfolio.newsletter.mapper.NewsletterMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NewsletterQueryService {
+
+    private final NewsletterMapper newsletterMapper;
+    private final ObjectMapper objectMapper = ApiObjectMapperFactory.create();
+
+    public NewsletterQueryService(NewsletterMapper newsletterMapper) {
+        this.newsletterMapper = newsletterMapper;
+    }
+
+    public NewsletterListResponse findByStatus(NewsletterStatus status) {
+        return new NewsletterListResponse(
+                newsletterMapper.findByStatus(status).stream()
+                        .map(newsletter -> NewsletterDetailResponse.from(newsletter, objectMapper))
+                        .toList()
+        );
+    }
+
+    public NewsletterDetailResponse findById(long newsletterId) {
+        Newsletter newsletter = newsletterMapper.findById(newsletterId);
+        if (newsletter == null) {
+            throw new ApiException(ErrorCode.NEWSLETTER_NOT_FOUND);
+        }
+        return NewsletterDetailResponse.from(newsletter, objectMapper);
+    }
+}

--- a/src/main/resources/mappers/newsletter/NewsletterMapper.xml
+++ b/src/main/resources/mappers/newsletter/NewsletterMapper.xml
@@ -40,6 +40,13 @@
         WHERE newsletter_id = #{newsletterId}
     </select>
 
+    <select id="findByIdForUpdate" resultMap="newsletterResultMap">
+        SELECT <include refid="newsletterColumns" />
+        FROM newsletters
+        WHERE newsletter_id = #{newsletterId}
+        FOR UPDATE
+    </select>
+
     <select id="findByStatus" resultMap="newsletterResultMap">
         SELECT <include refid="newsletterColumns" />
         FROM newsletters

--- a/src/test/java/org/firstfolio/newsletter/mapper/NewsletterMapperXmlTest.java
+++ b/src/test/java/org/firstfolio/newsletter/mapper/NewsletterMapperXmlTest.java
@@ -40,6 +40,9 @@ class NewsletterMapperXmlTest {
                 NewsletterMapper.class.getName() + ".findById"
         ));
         assertTrue(configuration.hasStatement(
+                NewsletterMapper.class.getName() + ".findByIdForUpdate"
+        ));
+        assertTrue(configuration.hasStatement(
                 NewsletterMapper.class.getName() + ".findByStatus"
         ));
         assertTrue(configuration.hasStatement(

--- a/src/test/java/org/firstfolio/newsletter/service/NewsletterPublicationServiceTest.java
+++ b/src/test/java/org/firstfolio/newsletter/service/NewsletterPublicationServiceTest.java
@@ -1,0 +1,150 @@
+package org.firstfolio.newsletter.service;
+
+import org.firstfolio.curriculum.mapper.AdminAuditLogMapper;
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.newsletter.domain.Newsletter;
+import org.firstfolio.newsletter.domain.NewsletterGenerationType;
+import org.firstfolio.newsletter.domain.NewsletterStatus;
+import org.firstfolio.newsletter.mapper.NewsletterMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class NewsletterPublicationServiceTest {
+
+    private static final long ACTOR_ID = 900L;
+    private static final String REQUEST_ID = "req-newsletter-publication";
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 8, 20, 6, 0);
+
+    private NewsletterMapper newsletterMapper;
+    private AdminAuditLogMapper auditLogMapper;
+    private NewsletterPublicationService service;
+
+    @BeforeEach
+    void setUp() {
+        newsletterMapper = mock(NewsletterMapper.class);
+        auditLogMapper = mock(AdminAuditLogMapper.class);
+        service = new NewsletterPublicationService(
+                newsletterMapper,
+                auditLogMapper,
+                Clock.fixed(Instant.parse("2026-08-20T06:00:00Z"), ZoneOffset.UTC)
+        );
+
+        when(auditLogMapper.insert(
+                anyLong(), anyString(), anyString(), anyLong(),
+                anyString(), anyString(), anyString(), any()
+        )).thenReturn(1);
+    }
+
+    @Test
+    void publishesReviewNewsletter() {
+        Newsletter target = reviewNewsletter(1L);
+        when(newsletterMapper.findByIdForUpdate(1L)).thenReturn(target);
+        when(newsletterMapper.publishReview(1L, NOW)).thenReturn(1);
+
+        Newsletter published = service.publish(1L, ACTOR_ID, REQUEST_ID);
+
+        assertEquals(NewsletterStatus.PUBLISHED, published.getStatus());
+        assertEquals(NOW, published.getPublishedAt());
+        verify(auditLogMapper).insert(
+                eq(ACTOR_ID), eq("PUBLISH"), eq("NEWSLETTER"), eq(1L),
+                anyString(), anyString(), eq(REQUEST_ID), eq(NOW)
+        );
+    }
+
+    @Test
+    void rejectsPublishWhenNotFound() {
+        when(newsletterMapper.findByIdForUpdate(1L)).thenReturn(null);
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.publish(1L, ACTOR_ID, REQUEST_ID)
+        );
+        assertEquals(ErrorCode.NEWSLETTER_NOT_FOUND, exception.getErrorCode());
+        verify(newsletterMapper, never()).publishReview(anyLong(), any());
+    }
+
+    @Test
+    void rejectsPublishWhenAlreadyPublished() {
+        Newsletter target = reviewNewsletter(1L);
+        target.publish(LocalDateTime.of(2026, 8, 19, 6, 0));
+        when(newsletterMapper.findByIdForUpdate(1L)).thenReturn(target);
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.publish(1L, ACTOR_ID, REQUEST_ID)
+        );
+        assertEquals(ErrorCode.NEWSLETTER_NOT_PUBLISHABLE, exception.getErrorCode());
+    }
+
+    @Test
+    void retiresPublishedNewsletter() {
+        Newsletter target = reviewNewsletter(1L);
+        target.publish(LocalDateTime.of(2026, 8, 19, 6, 0));
+        when(newsletterMapper.findByIdForUpdate(1L)).thenReturn(target);
+        when(newsletterMapper.retirePublished(1L)).thenReturn(1);
+
+        Newsletter retired = service.retire(1L, ACTOR_ID, REQUEST_ID);
+
+        assertEquals(NewsletterStatus.RETIRED, retired.getStatus());
+        verify(auditLogMapper).insert(
+                eq(ACTOR_ID), eq("RETIRE"), eq("NEWSLETTER"), eq(1L),
+                anyString(), anyString(), eq(REQUEST_ID), eq(NOW)
+        );
+    }
+
+    @Test
+    void rejectsRetireWhenNotPublished() {
+        Newsletter target = reviewNewsletter(1L);
+        when(newsletterMapper.findByIdForUpdate(1L)).thenReturn(target);
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.retire(1L, ACTOR_ID, REQUEST_ID)
+        );
+        assertEquals(ErrorCode.NEWSLETTER_NOT_RETIRABLE, exception.getErrorCode());
+    }
+
+    @Test
+    void rejectsRetireWhenNotFound() {
+        when(newsletterMapper.findByIdForUpdate(1L)).thenReturn(null);
+
+        ApiException exception = assertThrows(
+                ApiException.class,
+                () -> service.retire(1L, ACTOR_ID, REQUEST_ID)
+        );
+        assertEquals(ErrorCode.NEWSLETTER_NOT_FOUND, exception.getErrorCode());
+    }
+
+    private Newsletter reviewNewsletter(long newsletterId) {
+        Newsletter newsletter = Newsletter.review(
+                LocalDate.of(2026, 8, 17),
+                "대제목",
+                "[]",
+                "[]",
+                "[]",
+                NewsletterGenerationType.AI,
+                1L,
+                LocalDateTime.of(2026, 8, 20, 5, 0)
+        );
+        newsletter.setNewsletterId(newsletterId);
+        return newsletter;
+    }
+}

--- a/src/test/java/org/firstfolio/newsletter/service/NewsletterQueryServiceTest.java
+++ b/src/test/java/org/firstfolio/newsletter/service/NewsletterQueryServiceTest.java
@@ -1,0 +1,95 @@
+package org.firstfolio.newsletter.service;
+
+import org.firstfolio.exception.ApiException;
+import org.firstfolio.exception.ErrorCode;
+import org.firstfolio.newsletter.domain.Newsletter;
+import org.firstfolio.newsletter.domain.NewsletterGenerationType;
+import org.firstfolio.newsletter.domain.NewsletterStatus;
+import org.firstfolio.newsletter.dto.response.NewsletterDetailResponse;
+import org.firstfolio.newsletter.dto.response.NewsletterListResponse;
+import org.firstfolio.newsletter.mapper.NewsletterMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class NewsletterQueryServiceTest {
+
+    private static final String FINANCIAL_WORDS_JSON =
+            "[{\"term\":\"요구불예금\",\"definition\":\"필요할 때 언제든 빼 쓸 수 있는 예금\"},"
+                    + "{\"term\":\"경상수지\",\"definition\":\"나라가 외국과 주고받은 돈의 성적표\"},"
+                    + "{\"term\":\"해지환급금\",\"definition\":\"보험을 중간에 깨면 돌려받는 돈\"}]";
+    private static final String ISSUES_JSON =
+            "[{\"title\":\"이슈1\",\"summary\":\"요약1\",\"related_term\":\"요구불예금\","
+                    + "\"sources\":[{\"document_id\":1,\"chunk_key\":\"1:0\","
+                    + "\"source_url\":\"https://example.com\",\"evidence_text\":\"근거\"}]}]";
+    private static final String STATS_JSON =
+            "[{\"label\":\"라벨1\",\"value\":\"값1\"}]";
+
+    private NewsletterMapper newsletterMapper;
+    private NewsletterQueryService service;
+
+    @BeforeEach
+    void setUp() {
+        newsletterMapper = mock(NewsletterMapper.class);
+        service = new NewsletterQueryService(newsletterMapper);
+    }
+
+    @Test
+    void findByStatusParsesStoredJsonIntoStructuredResponse() {
+        when(newsletterMapper.findByStatus(NewsletterStatus.REVIEW))
+                .thenReturn(List.of(sampleNewsletter(1L)));
+
+        NewsletterListResponse response = service.findByStatus(NewsletterStatus.REVIEW);
+
+        assertEquals(1, response.items().size());
+        NewsletterDetailResponse item = response.items().get(0);
+        assertEquals(1L, item.newsletterId());
+        assertEquals("REVIEW", item.status());
+        assertEquals(3, item.financialWordsJson().size());
+        assertEquals("요구불예금", item.financialWordsJson().get(0).term());
+        assertEquals(1, item.issuesJson().size());
+        assertEquals("요구불예금", item.issuesJson().get(0).relatedTerm());
+        assertEquals(1, item.issuesJson().get(0).sources().size());
+        assertEquals(1, item.statsJson().size());
+    }
+
+    @Test
+    void findByIdReturnsDetail() {
+        when(newsletterMapper.findById(1L)).thenReturn(sampleNewsletter(1L));
+
+        NewsletterDetailResponse response = service.findById(1L);
+
+        assertEquals(1L, response.newsletterId());
+    }
+
+    @Test
+    void findByIdThrowsWhenMissing() {
+        when(newsletterMapper.findById(1L)).thenReturn(null);
+
+        ApiException exception = assertThrows(ApiException.class, () -> service.findById(1L));
+        assertEquals(ErrorCode.NEWSLETTER_NOT_FOUND, exception.getErrorCode());
+    }
+
+    private Newsletter sampleNewsletter(long newsletterId) {
+        Newsletter newsletter = Newsletter.review(
+                LocalDate.of(2026, 8, 17),
+                "역대 최대 흑자 속에서도, 돈은 안전자산으로",
+                FINANCIAL_WORDS_JSON,
+                ISSUES_JSON,
+                STATS_JSON,
+                NewsletterGenerationType.AI,
+                1L,
+                LocalDateTime.of(2026, 8, 20, 9, 0)
+        );
+        newsletter.setNewsletterId(newsletterId);
+        return newsletter;
+    }
+}


### PR DESCRIPTION
## 작업 내용
- AI가 REVIEW로 저장한 뉴스레터를 관리자가 검수·게시·비공개 처리하는 API 신규 구현
- `GET /api/admin/newsletters?status=` — 상태별 목록 조회
- `GET /api/admin/newsletters/{id}` — 상세 조회 (대제목·금융단어·이슈·숫자 전체 내용, 저장된 JSON을 구조화 응답으로 파싱)
- `POST /api/admin/newsletters/{id}/publish`, `/retire` — 상태 전환
- 상태 전환 시 기존 `admin_audit_logs` 테이블에 감사 이력 기록 (퀴즈·콘텐츠버전과 동일 패턴)
- `ErrorCode`에 `NEWSLETTER_NOT_FOUND`/`NOT_PUBLISHABLE`/`NOT_RETIRABLE` 추가
- `NewsletterMapper`에 `findByIdForUpdate` 추가 (publish/retire 시 락 걸고 조회)

## 테스트
- [x] `NewsletterPublicationServiceTest` 6개 — publish/retire 정상 전환, 없음/상태 불일치 예외, 감사 로그 기록 검증
- [x] `NewsletterQueryServiceTest` 3개 — 목록·상세 조회 시 저장된 JSON이 구조화 응답으로 정확히 파싱되는지, 없음 예외
- [x] `NewsletterMapperXmlTest` — `findByIdForUpdate` 추가 검증
- [x] `./gradlew clean test` 전체 통과, 회귀 없음