### PR TITLE
feat: Slack webhook 알림 클라이언트 추가 #182

### DIFF
--- a/src/main/java/org/firstfolio/common/alert/SlackAlertClient.java
+++ b/src/main/java/org/firstfolio/common/alert/SlackAlertClient.java
@@ -1,0 +1,68 @@
+package org.firstfolio.common.alert;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+/**
+ * Slack Incoming Webhook으로 알림을 보낸다.
+ *
+ * <p>알림 전송 실패가 호출부 로직을 막으면 안 되므로 예외를 밖으로 던지지 않고
+ * 로그만 남긴다.</p>
+ */
+@Component
+public class SlackAlertClient {
+
+    private static final Logger log = LogManager.getLogger(SlackAlertClient.class);
+
+    private final HttpClient httpClient = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(5))
+        .build();
+
+    private final String webhookUrl;
+
+    public SlackAlertClient(@Value("${slack.webhook-url:}") String webhookUrl) {
+        this.webhookUrl = webhookUrl;
+    }
+
+    public void send(String message) {
+        if (webhookUrl.isBlank()) {
+            log.debug("Slack webhook 미설정, 알림 건너뜀: {}", message);
+            return;
+        }
+
+        try {
+            HttpRequest request = HttpRequest.newBuilder(URI.create(webhookUrl))
+                .timeout(Duration.ofSeconds(5))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(
+                    "{\"text\":\"" + escape(message) + "\"}",
+                    StandardCharsets.UTF_8
+                ))
+                .build();
+
+            HttpResponse<Void> response =
+                httpClient.send(request, HttpResponse.BodyHandlers.discarding());
+
+            if (response.statusCode() != 200) {
+                log.warn("Slack 알림 응답 오류 status={}", response.statusCode());
+            }
+        } catch (Exception exception) {
+            log.warn("Slack 알림 전송 실패", exception);
+        }
+    }
+
+    private static String escape(String text) {
+        return text.replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\n", "\\n");
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -62,3 +62,5 @@ cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://127.0.0
 gifticon.crypto.encryption-key=${GIFTICON_ENCRYPTION_KEY:}
 gifticon.crypto.fingerprint-key=${GIFTICON_FINGERPRINT_KEY:}
 gifticon.crypto.key-version=${GIFTICON_KEY_VERSION:v1}
+
+slack.webhook-url=${SLACK_WEBHOOK_URL:}

--- a/src/test/java/org/firstfolio/common/alert/SlackAlertClientTest.java
+++ b/src/test/java/org/firstfolio/common/alert/SlackAlertClientTest.java
@@ -1,0 +1,83 @@
+package org.firstfolio.common.alert;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SlackAlertClientTest {
+
+    private HttpServer server;
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void sendPostsMessageAsJsonToWebhook() throws IOException {
+        BlockingQueue<String> receivedBodies = new ArrayBlockingQueue<>(1);
+        BlockingQueue<String> receivedContentTypes = new ArrayBlockingQueue<>(1);
+
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/webhook", exchange -> {
+            try (InputStream body = exchange.getRequestBody()) {
+                receivedBodies.offer(new String(body.readAllBytes(), StandardCharsets.UTF_8));
+            }
+            receivedContentTypes.offer(exchange.getRequestHeaders().getFirst("Content-Type"));
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+        server.start();
+
+        String webhookUrl = "http://localhost:" + server.getAddress().getPort() + "/webhook";
+        SlackAlertClient client = new SlackAlertClient(webhookUrl);
+
+        client.send("오류 발생: \"결제 실패\"");
+
+        String body = poll(receivedBodies);
+        String contentType = poll(receivedContentTypes);
+
+        assertEquals("application/json", contentType);
+        assertEquals("{\"text\":\"오류 발생: \\\"결제 실패\\\"\"}", body);
+    }
+
+    @Test
+    void sendDoesNothingWhenWebhookUrlIsBlank() {
+        SlackAlertClient client = new SlackAlertClient("");
+
+        assertDoesNotThrow(() -> client.send("알림 대상 없음"));
+    }
+
+    @Test
+    void sendDoesNotThrowWhenWebhookIsUnreachable() {
+        // 포트 0은 실제로 열리지 않으므로 연결 실패를 강제한다.
+        SlackAlertClient client = new SlackAlertClient("http://localhost:0/webhook");
+
+        assertDoesNotThrow(() -> client.send("연결 실패 상황"));
+    }
+
+    private static String poll(BlockingQueue<String> queue) {
+        try {
+            String value = queue.poll(2, TimeUnit.SECONDS);
+            assertTrue(value != null, "webhook 서버가 요청을 받지 못했습니다.");
+            return value;
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(exception);
+        }
+    }
+}


### PR DESCRIPTION
## 작업내용
- Slack Incoming Webhook으로 알림을 보내는 `SlackAlertClient` 추가
- webhook URL을 환경변수(`SLACK_WEBHOOK_URL`)로 설정할 수 있도록 `application.properties`에 추가
- 알림 전송 실패 시 예외를 던지지 않고 로그만 남기도록 처리

## 테스트
- `SlackAlertClientTest` 작성: 로컬 HTTP 서버로 요청을 받아 전송 내용 검증, webhook 미설정 시 무시, 연결 실패 시 예외 미전파 확인
- 실제 Slack 채널로 curl 테스트해 정상 수신 확인

closes #182