### PR TITLE
ref: Docker 빌드 시 Gradle 의존성 레이어 캐시 분리 #187

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,9 @@ FROM gradle:8.8-jdk17 AS build
 WORKDIR /src
 
 COPY build.gradle settings.gradle ./
-COPY src ./src
+RUN gradle dependencies --no-daemon || true
 
+COPY src ./src
 RUN gradle war --no-daemon
 
 


### PR DESCRIPTION
## 작업내용
- Dockerfile에서 gradle dependencies 단계를 소스 복사 전으로 분리해 의존성 레이어 캐시 재사용되도록 변경

## 테스트
- 로컬 docker build 정상 동작 확인
- main 병합 후 다음 배포부터 빌드 시간 단축 여부 확인 예정